### PR TITLE
Ensure directory exists for gen_func_call_scripts

### DIFF
--- a/gen_definitions.py
+++ b/gen_definitions.py
@@ -1027,10 +1027,10 @@ def gen_func_call_scripts(definitions: LSLDefinitions, output_path: str) -> None
 
     Useful for verifying that a compiler agrees with our function definitions
     """
-    
+
     # Ensure our output directory exists first
     os.makedirs(output_path, exist_ok=True)
-    
+
     # Unfortunately, LSO scripts are the only things that actually use function IDs, which we need to test.
     # They're also limited to 16k. For that reason, we need to chunk the calls up between multiple scripts
     # so that we don't collide heap and stack when compiling.


### PR DESCRIPTION
Hoping I understood the "No API changes" policy in the contributing correctly here. (Interpretted it as "No changes to the LSL api", rather than "No changes to the script")

Script will crash when calling `gen_func_call_scripts` if the output directory doesn't exist. This ensures the output directory exists when running by calling `os.makedirs(output_path, exist_ok=True)` before attempting to write to it. If it already exists, gracefully continue.