### PR TITLE
Mark `llCollisionSprite` as deprecated

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -5191,6 +5191,7 @@ functions:
     - ImpactSprite:
         tooltip: ''
         type: string
+    deprecated: true
     energy: 10.0
     func-id: 161
     return: void


### PR DESCRIPTION
Per #8 the function has been broken for a long time