### PR TITLE
llSetGroundTexture - no return value according to implementation

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -10451,7 +10451,7 @@ functions:
         type: list
     energy: 10.0
     func-id: 558
-    return: integer
+    return: void
     sleep: 0.0
     tooltip: Changes terrain texture properties in the region.
   llSetHoverHeight:


### PR DESCRIPTION
The function `llSetGroundTexture` does not actually return anything meaningful in the implementation.

According to [@HaroldCindy](https://github.com/secondlife/lsl-definitions/issues/14#issuecomment-3137546044) and Monty Linden (per SL discord #scripting) checking the code there were no return values.

If that's the case then we could tweak the definition to match with implementation.

Alternatively, this PR could be rejected and the implementation updated to match with estate management functions e.g. `llManageEstateAccess`:
> Returns a boolean (an integer) TRUE if the call was successful; FALSE if throttled, invalid action, invalid [...] or object owner is not allowed to manage the estate.
