### PR TITLE
Fix typo in parameter name from 'Parms' to 'Params'

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -9850,7 +9850,7 @@ functions:
     - InventoryItem:
         tooltip: ''
         type: string
-    - Parms:
+    - Params:
         tooltip: ''
         type: list
     energy: 200.0


### PR DESCRIPTION
Fix a typo in the parameter name `Parms` to `Params` for `llRezObjectWithParams`