### PR TITLE
`bool-semantics` for function parameters

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -4865,6 +4865,7 @@ functions:
     - Flag:
         tooltip: Boolean, If TRUE allows anyone to drop inventory on prim, FALSE revokes.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 176
     return: void
@@ -4894,6 +4895,7 @@ functions:
         tooltip: Boolean, if TRUE, force is treated as a local directional vector
           instead of region directional vector.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 72
     return: void
@@ -4909,6 +4911,7 @@ functions:
     - Local:
         tooltip: Boolean, if TRUE, uses local axis, if FALSE, uses region axis.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 73
     return: void
@@ -5219,6 +5222,7 @@ functions:
         tooltip: If TRUE, only accept collisions with ObjectName name AND ObjectID
           (either is optional), otherwise with objects not ObjectName AND ObjectID.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 110
     return: void
@@ -5320,6 +5324,7 @@ functions:
         tooltip: If FALSE, then TargetPrim becomes the root. If TRUE, then the script's
           object becomes the root.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 141
     return: void
@@ -5959,6 +5964,7 @@ functions:
           be forced into mouse-look mode.\nFALSE is the default setting and will undo
           a previously set TRUE or do nothing.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 294
     return: void
@@ -7031,6 +7037,7 @@ functions:
           by the parcel. If TRUE then it is the combined number of prims on all parcels
           in the region owned by the specified parcel's owner.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 326
     return: integer
@@ -7061,6 +7068,7 @@ functions:
           by the parcel. If TRUE then it is the combined number of prims on all parcels
           in the region owned by the specified parcel's owner.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 325
     return: integer
@@ -7736,6 +7744,7 @@ functions:
     - Water:
         tooltip: Boolean, if TRUE then hover above water too.
         type: integer
+        bool-semantics: true
     - Tau:
         tooltip: Seconds to critically damp in.
         type: float
@@ -8093,6 +8102,7 @@ functions:
         tooltip: 'Boolean, sound queuing for the linked prim: TRUE enables, FALSE
           disables (default).'
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 537
     return: void
@@ -8663,6 +8673,7 @@ functions:
         tooltip: Boolean. TRUE = result in ascending order, FALSE = result in descending
           order.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 184
     return: list
@@ -8687,6 +8698,7 @@ functions:
         tooltip: Boolean. TRUE = result in ascending order, FALSE = result in descending
           order.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 802
     return: list
@@ -8745,6 +8757,7 @@ functions:
     - Active:
         tooltip: ''
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 26
     return: void
@@ -9357,6 +9370,7 @@ functions:
     - Pass:
         tooltip: Boolean, if TRUE, collisions are passed from children on to parents.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 166
     return: void
@@ -9370,6 +9384,7 @@ functions:
     - Pass:
         tooltip: Boolean, if TRUE, touches are passed from children on to parents.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 154
     return: void
@@ -9499,6 +9514,7 @@ functions:
     - Local:
         tooltip: ''
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 165
     return: void
@@ -9655,6 +9671,7 @@ functions:
     - Running:
         tooltip: If the script should be set running in the target prim.
         type: integer
+        bool-semantics: true
     - StartParameter:
         tooltip: Integer. Parameter passed to the script if set to be running.
         type: integer
@@ -10477,6 +10494,7 @@ functions:
         tooltip: If TRUE, the AngVel is treated as a local directional vector instead
           of a regional directional vector.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 379
     return: void
@@ -10629,6 +10647,7 @@ functions:
     - Local:
         tooltip: Boolean, if TRUE uses local axis, if FALSE uses region axis.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 64
     return: void
@@ -10646,6 +10665,7 @@ functions:
     - Local:
         tooltip: Boolean, if TRUE uses local axis, if FALSE uses region axis.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 76
     return: void
@@ -10671,6 +10691,7 @@ functions:
     - Water:
         tooltip: Boolean, if TRUE then hover above water too.
         type: integer
+        bool-semantics: true
     - Tau:
         tooltip: Seconds to critically damp in.
         type: float
@@ -11169,6 +11190,7 @@ functions:
     - Running:
         tooltip: ''
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 148
     return: void
@@ -11189,6 +11211,7 @@ functions:
     - QueueEnable:
         tooltip: 'Boolean, sound queuing: TRUE enables, FALSE disables (default).'
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 208
     return: void
@@ -11303,6 +11326,7 @@ functions:
     - Local:
         tooltip: Boolean, if TRUE uses local axis, if FALSE uses region axis.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 74
     return: void
@@ -11495,9 +11519,11 @@ functions:
     - Queue:
         tooltip: ''
         type: integer
+        bool-semantics: true
     - Loop:
         tooltip: ''
         type: integer
+        bool-semantics: true
     deprecated: true
     energy: 10.0
     func-id: 85
@@ -11691,9 +11717,11 @@ functions:
     - Accept:
         tooltip: Boolean, determines whether control events are generated.
         type: integer
+        bool-semantics: true
     - PassOn:
         tooltip: Boolean, determines whether controls are disabled.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 111
     return: void
@@ -11998,6 +12026,7 @@ functions:
     - Checked:
         tooltip: ''
         type: integer
+        bool-semantics: true
     - OriginalValue:
         tooltip: ''
         type: string
@@ -12079,6 +12108,7 @@ functions:
     - DetectEnabled:
         tooltip: TRUE enables, FALSE disables.
         type: integer
+        bool-semantics: true
     energy: 10.0
     func-id: 248
     return: void


### PR DESCRIPTION
This adds the `bool-semantics` property for function parameters if they are integer values that operate with a `0 - off` else `on` mechanic.

Resolves #32

I have added the needed yamale changes for schema validation. If #30 is completed before or after this adjustments will be needed in either feature.