### PR TITLE
NULL_KEY is a uuid

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -1513,7 +1513,7 @@ constants:
     value: 2
   NULL_KEY:
     tooltip: ''
-    type: string
+    type: uuid
     value: "00000000-0000-0000-0000-000000000000"
   OBJECT_ACCOUNT_LEVEL:
     tooltip: Retrieves the account level of an avatar.\nReturns 0 when the avatar


### PR DESCRIPTION
in lua:
```
print(typeof(NULL_KEY)) --> uuid
```
Folks on discord suggested this file might be only for lsl, not lua. In that case, I can close this PR