### PR TITLE
Deprecate LSL math constants in favor of Luau 0.711 math constants

### DIFF
--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -5095,6 +5095,8 @@ export type rotation = quaternion</string>
          </map>
          <key>PI</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>3.14159265 - The number of radians in a semi-circle.</string>
             <key>type</key>
@@ -5113,6 +5115,8 @@ export type rotation = quaternion</string>
          </map>
          <key>PI_BY_TWO</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>1.57079633 - The number of radians in a quarter circle.</string>
             <key>type</key>
@@ -8094,6 +8098,8 @@ vector position - position in local coordinates
          </map>
          <key>SQRT2</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>1.41421356 - The square root of 2.</string>
             <key>type</key>
@@ -8769,6 +8775,8 @@ vector position - position in local coordinates
          </map>
          <key>TWO_PI</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>6.28318530 - The radians of a circle.</string>
             <key>type</key>

--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -5175,6 +5175,8 @@ export type rotation = quaternion</string>
          </map>
          <key>PI</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Mathematical constant pi, representing the number of radians in a half circle (semi-circle). When used in sensor functions, it specifies a full sphere scan.</string>
             <key>type</key>
@@ -5193,6 +5195,8 @@ export type rotation = quaternion</string>
          </map>
          <key>PI_BY_TWO</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Mathematical constant pi/2, representing the number of radians in a quarter circle. When used in sensor functions, it specifies a hemisphere scan.</string>
             <key>type</key>
@@ -8173,6 +8177,8 @@ float falloff – ranges from 0.01 to 2.0
          </map>
          <key>SQRT2</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Mathematical constant representing the square root of 2.</string>
             <key>type</key>
@@ -8841,6 +8847,8 @@ float falloff – ranges from 0.01 to 2.0
          </map>
          <key>TWO_PI</key>
          <map>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>tooltip</key>
             <string>Mathematical constant pi*2, representing the number of radians in a full circle.</string>
             <key>type</key>

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -2249,6 +2249,9 @@ constants:
     tooltip: 3.14159265 - The number of radians in a semi-circle.
     type: float
     value: '3.14159265'
+    slua-deprecated:
+      use: math.pi
+      reason: Double precision.
   PING_PONG:
     tooltip: Play animation going forwards, then backwards.
     type: integer
@@ -2257,6 +2260,9 @@ constants:
     tooltip: 1.57079633 - The number of radians in a quarter circle.
     type: float
     value: '1.57079633'
+    slua-deprecated:
+      use: math.pi/2
+      reason: Double precision.
   PRIM_ALLOW_UNSIT:
     tooltip: Prim parameter for restricting manual standing for seated avatars in
       an experience.\nIgnored if the avatar was not seated via a call to llSitOnLink.
@@ -3739,6 +3745,9 @@ constants:
     tooltip: 1.41421356 - The square root of 2.
     type: float
     value: '1.41421356'
+    slua-deprecated:
+      use: math.sqrt2
+      reason: Double precision.
   STATUS_BLOCK_GRAB:
     tooltip: Controls whether the object can be grabbed.\nA grab is the default action
       when in third person, and is available as the hand tool in build mode. This
@@ -4065,6 +4074,9 @@ constants:
     tooltip: 6.28318530 - The radians of a circle.
     type: float
     value: '6.28318530'
+    slua-deprecated:
+      use: math.tau
+      reason: Double precision.
   TYPE_FLOAT:
     slua-deprecated:
       use: '"number"'

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -4032,6 +4032,9 @@ constants:
       specifies a full sphere scan.
     type: float
     value: '3.14159265'
+    slua-deprecated:
+      use: math.pi
+      reason: Double precision.
   PING_PONG:
     member-of: [TextureAnimMode]
     tooltip: Used with texture animation functions to cause the animation to play
@@ -4044,6 +4047,9 @@ constants:
       scan.
     type: float
     value: '1.57079633'
+    slua-deprecated:
+      use: math.pi/2
+      reason: Double precision.
   PRIM_ALLOW_UNSIT:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter for allowing or restricting manual standing for avatars
@@ -6932,6 +6938,9 @@ constants:
     tooltip: Mathematical constant representing the square root of 2.
     type: float
     value: '1.41421356'
+    slua-deprecated:
+      use: math.sqrt2
+      reason: Double precision.
   STATUS_BLOCK_GRAB:
     member-of: [ObjectStatusParam]
     tooltip: Status flag (default FALSE) that blocks click-and-drag grab movements
@@ -7435,6 +7444,9 @@ constants:
     tooltip: Mathematical constant pi*2, representing the number of radians in a full circle.
     type: float
     value: '6.28318530'
+    slua-deprecated:
+      use: math.tau
+      reason: Double precision.
   TYPE_FLOAT:
     member-of: [ListEntryType]
     slua-deprecated:


### PR DESCRIPTION
- https://github.com/luau-lang/luau/releases/tag/0.711
- https://github.com/luau-lang/rfcs/pull/169
- Related: #80