### PR TITLE
Deprecate `ll.Frand` for `math.random`

### DIFF
--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -19019,6 +19019,8 @@ Returns true if result is non-zero.</string>
                   </map>
                </map>
             </array>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -566,7 +566,7 @@ declare ll: {
   FleeFrom: (Source: vector, Distance: number, Options: list) -> (),
   Floor: @[deprecated {use='math.floor', reason='Fastcall.'}](Value: number) -> number,
   ForceMouselook: (Enable: boolean | number) -> (),
-  Frand: (Magnitude: number) -> number,
+  Frand: @[deprecated {use='math.random', reason='Double precision; integers.'}](Magnitude: number) -> number,
   GenerateKey: () -> uuid,
   GetAccel: () -> vector,
   GetAgentInfo: (AvatarID: uuid) -> number,

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -5902,6 +5902,10 @@ globals:
       be reset by calling this function with Enable set to FALSE in order to disable
       it.
   ll.Frand:
+    deprecated:
+      message: Use 'math.random' instead. Double precision; integers.
+      replace:
+      - math.random() * %1
     args:
     - type: number
     must_use: true

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -6193,6 +6193,10 @@ functions:
     - Magnitude:
         tooltip: ''
         type: float
+    slua-deprecated:
+      use: math.random
+      reason: Double precision; integers.
+      selene-replace: ["math.random() * %1"]
     energy: 10.0
     func-id: 8
     must-use: true


### PR DESCRIPTION
- Part of https://feedback.secondlife.com/slua-alpha/p/remove-duplicated-luau-methods-from-ll-table
- Extracted from #71 for further discussion

`math.random` has two modes: float mode (0 arguments):
```
> math.random()
0.5956555082509403
> math.random()
0.526518904998895
> math.random()
0.8429784570452903
> math.random()
0.49559577154027495
```

and integer mode (1-2 arguments):
```
> math.random(5, 10)
8
> math.random(5, 10)
9
> math.random(-5, 10)
10
> math.random(-5, 10)
-4
> math.random(10)
1
> math.random(10)
1
```

`math.random() * x` is a direct replacement for `ll.Frand(x)`, even though `math.random(x)` is not.

`math.random(x)` is a direct replacement for `math.modf(ll.Frand(x))` (`(integer)llFrand(x)` in lsl) though, which, at least in my own code, is far more common.