### PR TITLE
SLua - Deprecate `ll.GetUnixTime` in favor of os.time

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -9306,6 +9306,8 @@ functions:
       is the torque (if the script is physical).
   llGetUnixTime:
     arguments: []
+    slua-deprecated:
+      use: os.time
     energy: 10.0
     func-id: 316
     must-use: true


### PR DESCRIPTION
No reason to encourage use of lsl's method when there is a more flexible native version.