### PR TITLE
Deprecate `ll.GetUnixTime` in favor of `os.time`

### DIFF
--- a/generated/lsl_keywords_pretty.xml
+++ b/generated/lsl_keywords_pretty.xml
@@ -15221,7 +15221,7 @@ If another state is defined before the default state, the compiler will report a
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.</string>
+            <string>Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s (1 server frame), and is 6-11x faster to look up than lua's os.clock</string>
          </map>
          <key>llGetTimeOfDay</key>
          <map>

--- a/generated/lsl_keywords_pretty.xml
+++ b/generated/lsl_keywords_pretty.xml
@@ -13035,7 +13035,7 @@ If another state is defined before the default state, the compiler will report a
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD.</string>
+            <string>Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.</string>
          </map>
          <key>llGetDayLength</key>
          <map>
@@ -15249,7 +15249,7 @@ If another state is defined before the default state, the compiler will report a
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.</string>
+            <string>Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds</string>
          </map>
          <key>llGetTorque</key>
          <map>

--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -19567,7 +19567,7 @@ Returns true if result is non-zero.</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD.</string>
+            <string>Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.</string>
          </map>
          <key>ll.GetDayLength</key>
          <map>
@@ -21767,7 +21767,7 @@ Returns true if result is non-zero.</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.</string>
+            <string>Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds</string>
          </map>
          <key>ll.GetTorque</key>
          <map>
@@ -21788,6 +21788,8 @@ Returns true if result is non-zero.</string>
             <key>arguments</key>
             <array>
             </array>
+            <key>deprecated</key>
+            <boolean>true</boolean>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>

--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -14380,7 +14380,7 @@ Returns true if result is non-zero.</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns a high-precision timestamp in seconds for measuring durations.</string>
+            <string>Returns a high-precision timestamp in seconds for measuring durations. Has a resolution of 0.0001s (222 ticks per server frame, 3 ticks per script time slice). 6-11x slower to look up than ll.GetTime.</string>
          </map>
          <key>os.date</key>
          <map>
@@ -21739,7 +21739,7 @@ Returns true if result is non-zero.</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
-            <string>Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.</string>
+            <string>Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s (1 server frame), and is 6-11x faster to look up than lua's os.clock</string>
          </map>
          <key>ll.GetTimeOfDay</key>
          <map>

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -769,7 +769,7 @@ declare ll: {
   GetTimeOfDay: () -> number,
   GetTimestamp: () -> string,
   GetTorque: () -> vector,
-  GetUnixTime: () -> number,
+  GetUnixTime: @[deprecated {use='os.time', reason='Int32 will wrap on 2038-01-19'}]() -> number,
   GetUsedMemory: () -> number,
   GetUsername: (AvatarID: uuid) -> string,
   GetVel: () -> vector,

--- a/generated/secondlife.docs.json
+++ b/generated/secondlife.docs.json
@@ -466,7 +466,7 @@
         "learn_more_link": "https://luau.org/library/#os-library"
     },
     "@sl-slua/global/os.clock": {
-        "documentation": "Returns a high-precision timestamp in seconds for measuring durations.",
+        "documentation": "Returns a high-precision timestamp in seconds for measuring durations. Has a resolution of 0.0001s (222 ticks per server frame, 3 ticks per script time slice). 6-11x slower to look up than ll.GetTime.",
         "learn_more_link": "https://create.roblox.com/docs/reference/engine/libraries/os#clock"
     },
     "@sl-slua/global/os.date": {
@@ -1674,7 +1674,7 @@
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTextureScale"
     },
     "@sl-slua/global/ll.GetTime": {
-        "documentation": "Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.",
+        "documentation": "Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s (1 server frame), and is 6-11x faster to look up than lua's os.clock",
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTime"
     },
     "@sl-slua/global/ll.GetTimeOfDay": {
@@ -3741,7 +3741,7 @@
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTextureScale"
     },
     "@sl-slua/global/llcompat.GetTime": {
-        "documentation": "Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime.",
+        "documentation": "Returns the time in seconds since the last region reset, script reset, or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s (1 server frame), and is 6-11x faster to look up than lua's os.clock",
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTime"
     },
     "@sl-slua/global/llcompat.GetTimeOfDay": {

--- a/generated/secondlife.docs.json
+++ b/generated/secondlife.docs.json
@@ -1246,7 +1246,7 @@
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetCreator"
     },
     "@sl-slua/global/ll.GetDate": {
-        "documentation": "Returns the current date in the UTC time zone in the format YYYY-MM-DD.<br>Returns the current UTC date as YYYY-MM-DD.",
+        "documentation": "Returns the current date in the UTC time zone in the format YYYY-MM-DD.<br>Returns the current UTC date as YYYY-MM-DD. Equivilant to os.date(\"%Y-%m-%d\") in lua.",
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetDate"
     },
     "@sl-slua/global/ll.GetDayLength": {
@@ -1682,7 +1682,7 @@
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTimeOfDay"
     },
     "@sl-slua/global/ll.GetTimestamp": {
-        "documentation": "Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.",
+        "documentation": "Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.<br> Almost equivilant to os.date(\"%Y-%m-%dT%XZ\") in lua, except for the milliseconds",
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTimestamp"
     },
     "@sl-slua/global/ll.GetTorque": {
@@ -3313,7 +3313,7 @@
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetCreator"
     },
     "@sl-slua/global/llcompat.GetDate": {
-        "documentation": "Returns the current date in the UTC time zone in the format YYYY-MM-DD.<br>Returns the current UTC date as YYYY-MM-DD.",
+        "documentation": "Returns the current date in the UTC time zone in the format YYYY-MM-DD.<br>Returns the current UTC date as YYYY-MM-DD. Equivilant to os.date(\"%Y-%m-%d\") in lua.",
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetDate"
     },
     "@sl-slua/global/llcompat.GetDayLength": {
@@ -3749,7 +3749,7 @@
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTimeOfDay"
     },
     "@sl-slua/global/llcompat.GetTimestamp": {
-        "documentation": "Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.",
+        "documentation": "Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.<br> Almost equivilant to os.date(\"%Y-%m-%dT%XZ\") in lua, except for the milliseconds",
         "learn_more_link": "https://wiki.secondlife.com/wiki/LlGetTimestamp"
     },
     "@sl-slua/global/llcompat.GetTorque": {

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -6088,7 +6088,7 @@ globals:
     args: []
     must_use: true
     description: Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns
-      the current UTC date as YYYY-MM-DD.
+      the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.
   ll.GetDayLength:
     args: []
     must_use: true
@@ -6773,13 +6773,16 @@ globals:
   ll.GetTimestamp:
     args: []
     must_use: true
-    description: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.'
+    description: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n
+      Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds'
   ll.GetTorque:
     args: []
     must_use: true
     description: Returns the torque (if the script is physical).\nReturns a vector
       that is the torque (if the script is physical).
   ll.GetUnixTime:
+    deprecated:
+      message: Use 'os.time' instead. Int32 will wrap on 2038-01-19
     args: []
     must_use: true
     description: Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970
@@ -10399,11 +10402,11 @@ globals:
   llcompat.GetDate:
     deprecated:
       message: Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns
-        the current UTC date as YYYY-MM-DD.
+        the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.
     args: []
     must_use: true
     description: Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns
-      the current UTC date as YYYY-MM-DD.
+      the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.
   llcompat.GetDayLength:
     deprecated:
       message: Returns the number of seconds in a day on this parcel.
@@ -11443,10 +11446,12 @@ globals:
     description: Returns the time in seconds since environmental midnight on the parcel.
   llcompat.GetTimestamp:
     deprecated:
-      message: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.'
+      message: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n
+        Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds'
     args: []
     must_use: true
-    description: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.'
+    description: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n
+      Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds'
   llcompat.GetTorque:
     deprecated:
       message: Returns the torque (if the script is physical).\nReturns a vector that

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -4639,6 +4639,8 @@ globals:
     args: []
     must_use: true
     description: Returns a high-precision timestamp in seconds for measuring durations.
+      Has a resolution of 0.0001s (222 ticks per server frame, 3 ticks per script
+      time slice). 6-11x slower to look up than ll.GetTime.
   os.date:
     args:
     - type: string
@@ -6765,7 +6767,8 @@ globals:
     args: []
     must_use: true
     description: Returns the time in seconds since the last region reset, script reset,
-      or call to either llResetTime or llGetAndResetTime.
+      or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s
+      (1 server frame), and is 6-11x faster to look up than lua's os.clock
   ll.GetTimeOfDay:
     args: []
     must_use: true
@@ -11433,11 +11436,13 @@ globals:
   llcompat.GetTime:
     deprecated:
       message: Returns the time in seconds since the last region reset, script reset,
-        or call to either llResetTime or llGetAndResetTime.
+        or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s
+        (1 server frame), and is 6-11x faster to look up than lua's os.clock
     args: []
     must_use: true
     description: Returns the time in seconds since the last region reset, script reset,
-      or call to either llResetTime or llGetAndResetTime.
+      or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s
+      (1 server frame), and is 6-11x faster to look up than lua's os.clock
   llcompat.GetTimeOfDay:
     deprecated:
       message: Returns the time in seconds since environmental midnight on the parcel.

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -8300,7 +8300,7 @@ functions:
     return: string
     sleep: 0.0
     tooltip: Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns
-      the current UTC date as YYYY-MM-DD.
+      the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.
     categories:
       - time
   llGetDayLength:
@@ -9885,7 +9885,8 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.'
+    tooltip: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n
+      Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds'
     categories:
       - time
   llGetTorque:
@@ -9902,6 +9903,9 @@ functions:
       - physics
   llGetUnixTime:
     arguments: []
+    slua-deprecated:
+      use: os.time
+      reason: Int32 will wrap on 2038-01-19
     energy: 10.0
     func-id: 316
     must-use: true

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -9865,7 +9865,8 @@ functions:
     return: float
     sleep: 0.0
     tooltip: Returns the time in seconds since the last region reset, script reset,
-      or call to either llResetTime or llGetAndResetTime.
+      or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s
+      (1 server frame), and is 6-11x faster to look up than lua's os.clock
     categories:
       - script
   llGetTimeOfDay:

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -1585,6 +1585,8 @@ modules:
   functions:
   - name: clock
     comment: Returns a high-precision timestamp in seconds for measuring durations.
+      Has a resolution of 0.0001s (222 ticks per server frame, 3 ticks per script time slice).
+      6-11x slower to look up than ll.GetTime.
     parameters: []
     return-type: number
     must-use: true


### PR DESCRIPTION
- Part of https://feedback.secondlife.com/slua-alpha/p/remove-duplicated-luau-methods-from-ll-table
- Better version of #110 

Deprecate ll.GetUnixTime and document other lsl equivilencies:
- `ll.GetUnixTime`: deprecated in favor of `os.time` due to integer overflow
- `ll.GetDate`: documented the equivilancy with `os.date`
- `ll.GetTimeStamp`: documented the near-equivilancy with `os.date`
- `ll.GetTime` and `os.clock`: documented their slightly different behaviors
