### PR TITLE
Add missing constant `SIT_OK`

### DIFF
--- a/generated/builtins.txt
+++ b/generated/builtins.txt
@@ -1364,6 +1364,7 @@ const integer SIT_NOT_EXPERIENCE = -1
 const integer SIT_NO_ACCESS = -6
 const integer SIT_NO_EXPERIENCE_PERMISSION = -2
 const integer SIT_NO_SIT_TARGET = -3
+const integer SIT_OK = 1
 const integer SKY_ABSORPTION_CONFIG = 16
 const integer SKY_AMBIENT = 0
 const integer SKY_BLUE = 22

--- a/generated/cpp/lllslconstants_generated.h
+++ b/generated/cpp/lllslconstants_generated.h
@@ -841,6 +841,7 @@ constexpr int32_t LSL_GEN_SIT_NOT_EXPERIENCE = -1;
 constexpr int32_t LSL_GEN_SIT_NO_ACCESS = -6;
 constexpr int32_t LSL_GEN_SIT_NO_EXPERIENCE_PERMISSION = -2;
 constexpr int32_t LSL_GEN_SIT_NO_SIT_TARGET = -3;
+constexpr int32_t LSL_GEN_SIT_OK = 1;
 constexpr int32_t LSL_GEN_SKY_ABSORPTION_CONFIG = 16;
 constexpr int32_t LSL_GEN_SKY_AMBIENT = 0;
 constexpr int32_t LSL_GEN_SKY_BLUE = 22;

--- a/generated/cpp/lua_constant_definitions.cpp
+++ b/generated/cpp/lua_constant_definitions.cpp
@@ -2512,6 +2512,9 @@
     luaSL_pushnativeinteger(L, -3);
     lua_setglobal(L, "SIT_NO_SIT_TARGET");
 
+    luaSL_pushnativeinteger(L, 1);
+    lua_setglobal(L, "SIT_OK");
+
     luaSL_pushnativeinteger(L, 16);
     lua_setglobal(L, "SKY_ABSORPTION_CONFIG");
 

--- a/generated/experimental/enums.txt
+++ b/generated/experimental/enums.txt
@@ -1140,6 +1140,7 @@ enum SitError {
   NO_SIT_TARGET = -3
   NO_EXPERIENCE_PERMISSION = -2
   NOT_EXPERIENCE = -1
+  OK = 1
 };
 enum SitFlag {
   SIT_TARGET = 0x1

--- a/generated/lsl_keywords_pretty.xml
+++ b/generated/lsl_keywords_pretty.xml
@@ -7622,6 +7622,15 @@ vector position - position in local coordinates
             <key>value</key>
             <string>-3</string>
          </map>
+         <key>SIT_OK</key>
+         <map>
+            <key>tooltip</key>
+            <string>Avatar seated successfully.</string>
+            <key>type</key>
+            <string>integer</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
          <key>SKY_AMBIENT</key>
          <map>
             <key>tooltip</key>

--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -7911,6 +7911,15 @@ vector position - position in local coordinates
             <key>value</key>
             <string>-3</string>
          </map>
+         <key>SIT_OK</key>
+         <map>
+            <key>tooltip</key>
+            <string>Avatar seated successfully.</string>
+            <key>type</key>
+            <string>number</string>
+            <key>value</key>
+            <string>1</string>
+         </map>
          <key>SKY_AMBIENT</key>
          <map>
             <key>tooltip</key>

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -2356,6 +2356,7 @@ declare SIT_NOT_EXPERIENCE: number
 declare SIT_NO_ACCESS: number
 declare SIT_NO_EXPERIENCE_PERMISSION: number
 declare SIT_NO_SIT_TARGET: number
+declare SIT_OK: number
 declare SKY_AMBIENT: number
 declare SKY_BLUE: number
 declare SKY_CLOUDS: number

--- a/generated/secondlife.docs.json
+++ b/generated/secondlife.docs.json
@@ -7442,6 +7442,9 @@
     "@sl-slua/global/SIT_NO_SIT_TARGET": {
         "documentation": "Value: -3<br>No available sit target in linkset for forced sit."
     },
+    "@sl-slua/global/SIT_OK": {
+        "documentation": "Value: 1<br>Avatar seated successfully."
+    },
     "@sl-slua/global/SKY_AMBIENT": {
         "documentation": "Value: 0<br>The ambient color of the environment"
     },

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -3199,6 +3199,10 @@ globals:
     property: read-only
     type: number
     description: No available sit target in linkset for forced sit.
+  SIT_OK:
+    property: read-only
+    type: number
+    description: Avatar seated successfully.
   SKY_AMBIENT:
     property: read-only
     type: number

--- a/generated/templated/indra.l
+++ b/generated/templated/indra.l
@@ -842,6 +842,7 @@
 "SIT_NO_ACCESS" { count(); yylval.ival = -6; return(INTEGER_CONSTANT); }
 "SIT_NO_EXPERIENCE_PERMISSION" { count(); yylval.ival = -2; return(INTEGER_CONSTANT); }
 "SIT_NO_SIT_TARGET" { count(); yylval.ival = -3; return(INTEGER_CONSTANT); }
+"SIT_OK" { count(); yylval.ival = 1; return(INTEGER_CONSTANT); }
 "SKY_ABSORPTION_CONFIG" { count(); yylval.ival = 16; return(INTEGER_CONSTANT); }
 "SKY_AMBIENT" { count(); yylval.ival = 0; return(INTEGER_CONSTANT); }
 "SKY_BLUE" { count(); yylval.ival = 22; return(INTEGER_CONSTANT); }

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -4932,6 +4932,11 @@ constants:
     tooltip: No available sit target in linkset for forced sit.
     type: integer
     value: -3
+  SIT_OK:
+    member-of: [SitError]
+    tooltip: Avatar seated successfully.
+    type: integer
+    value: 1
   SKY_ABSORPTION_CONFIG:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]


### PR DESCRIPTION
According to [the wiki](https://wiki.secondlife.com/wiki/LlSitOnLink), `llSitOnLink` has 8 possible return values. But, only 7 of them are named constants. Add the missing one.

Discovered while auditing the `Error` enums for #113 