### PR TITLE
Move parts of PrimParamsSetterType to yaml

### DIFF
--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -222,7 +222,7 @@ export type rotation = quaternion</string>
          <key>PrimParamsSetterType</key>
          <map>
             <key>tooltip</key>
-            <string></string>
+            <string>Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast</string>
          </map>
       </map>
       <key>constants</key>
@@ -325,8 +325,10 @@ export type rotation = quaternion</string>
          <key>llprim.ParamsSetter</key>
          <map>
             <key>tooltip</key>
-            <string></string>
+            <string>Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast</string>
             <key>type</key>
+            <string>PrimParamsSetterTypeMeta</string>
+            <key>value</key>
             <string>PrimParamsSetterTypeMeta</string>
          </map>
          <key>math.huge</key>

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -171,6 +171,8 @@ end
 
 export type PrimParamsSetterTypeMeta = {
   __index: PrimParamsSetterTypeMeta,
+  new: () -> PrimParamsSetterType,
+  apply: (self: PrimParamsSetterType, link: number?) -> (),
   targetLink: <T>(self: T & PrimParamsSetterType, link_target: number) -> T,
   physicsMaterial: <T>(self: T & PrimParamsSetterType, flag: number) -> T,
   physical: <T>(self: T & PrimParamsSetterType, enabled: boolean) -> T,
@@ -221,8 +223,6 @@ export type PrimParamsSetterTypeMeta = {
   damage: <T>(self: T & PrimParamsSetterType, damage: number, damage_type: number) -> T,
   health: <T>(self: T & PrimParamsSetterType, health: number) -> T,
   collisionSound: <T>(self: T & PrimParamsSetterType, sound: (string | uuid), volume: number) -> T,
-  apply: (self: PrimParamsSetterType, link: number?) -> (),
-  new: () -> PrimParamsSetterType,
 }
 
 export type PrimParamsSetterType = typeof(

--- a/generated/secondlife.docs.json
+++ b/generated/secondlife.docs.json
@@ -299,7 +299,7 @@
         "documentation": "Utilities for working with prims / objects"
     },
     "@sl-slua/global/llprim.ParamsSetter": {
-        "documentation": ""
+        "documentation": "Value: PrimParamsSetterTypeMeta<br>Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast"
     },
     "@sl-slua/global/math": {
         "documentation": "Mathematical functions library.",

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -15961,6 +15961,5 @@ structs:
       - type: string
       - type: number
     new:
-      property: read-only
-      type: function
+      args: []
       description: Create an empty list with PrimParamsSetterTypeMeta as metatable

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -4414,6 +4414,7 @@ globals:
       an error if JSON is invalid.
   llprim.ParamsSetter:
     property: read-only
+    description: Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast
   math.pi:
     property: read-only
     type: number
@@ -15567,6 +15568,12 @@ structs:
       - type: function
       description: Unregisters a timer callback. Returns true if found and removed.
   PrimParamsSetterType:
+    apply:
+      method: true
+      args:
+      - type: number
+        required: false
+      description: Call ll.SetLinkPrimitiveParamsFast with my instance list
     targetLink:
       method: true
       args:
@@ -15953,11 +15960,7 @@ structs:
       args:
       - type: string
       - type: number
-    apply:
-      method: true
-      args:
-      - type: number
-        required: false
     new:
-      method: true
-      args: []
+      property: read-only
+      type: function
+      description: Create an empty list with PrimParamsSetterTypeMeta as metatable

--- a/lsl_definitions/generators/slua.py
+++ b/lsl_definitions/generators/slua.py
@@ -181,6 +181,8 @@ def gen_selene_yml(definitions: LSLDefinitions, slua_definitions: SLuaDefinition
         fields = {}
         for method in class_.methods:
             fields[method.name] = selene_function(method, method=True)
+        for func in class_.functions:
+            fields[func.name] = selene_function(func, method=False)
         for prop in class_.properties:
             fields[prop.name] = selene_property(prop)
         return fields

--- a/lsl_definitions/rulesets.py
+++ b/lsl_definitions/rulesets.py
@@ -60,8 +60,6 @@ class BuilderMethod:
 @dataclasses.dataclass(frozen=True)
 class BuilderSpec:
     class_name: str
-    module_entry: str
-    module_name: str
     methods: List[BuilderMethod]
 
 
@@ -123,7 +121,5 @@ def expand_spp_builder(lsl: "LSLDefinitions") -> BuilderSpec:
     return BuilderSpec(
         # The "class name" is global, so we don't want it to be ambiguous
         class_name="PrimParamsSetterType",
-        module_entry="ParamsSetter",
-        module_name="llprim",
         methods=methods,
     )

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -259,7 +259,7 @@ class SLuaModule:
     """Module declaration with constants and functions"""
 
     name: str
-    callable: Optional[SLuaFunction] = None
+    callable: Optional[SLuaFunction]
     constants: List[SLuaProperty]
     functions: List[SLuaFunction]
     comment: str = ""

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import re
-from typing import TYPE_CHECKING, Any, List, Set, TextIO
+from typing import TYPE_CHECKING, Any, List, Optional, Set, TextIO
 
 import llsd
 import yaml
@@ -54,7 +54,7 @@ class SLuaParameter:
     """
 
     name: str
-    type: str | None = None
+    type: Optional[str] = None
     selene_type: Any = None
     """a custom Selene type for this parameter, in case auto-detection fails"""
     comment: str = ""
@@ -212,7 +212,7 @@ class SLuaClassDeclaration:
     functions: List[SLuaFunction]
     methods: List[SLuaFunction]
     comment: str = ""
-    instance_type: str | None = None
+    instance_type: Optional[str] = None
     export: bool = False
     """Only meaningful when `instance_type` is set."""
 
@@ -259,7 +259,7 @@ class SLuaModule:
     """Module declaration with constants and functions"""
 
     name: str
-    callable: SLuaFunction | None
+    callable: Optional[SLuaFunction] = None
     constants: List[SLuaProperty]
     functions: List[SLuaFunction]
     comment: str = ""

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -209,6 +209,7 @@ class SLuaClassDeclaration:
 
     name: str
     properties: List[SLuaProperty]
+    functions: List[SLuaFunction]
     methods: List[SLuaFunction]
     comment: str = ""
     instance_type: str | None = None
@@ -228,6 +229,8 @@ class SLuaClassDeclaration:
         f.write(f"declare extern type {self.name} with\n")
         for prop in self.properties:
             f.write(f"  {prop.to_luau_def()}\n")
+        for func in self.functions:
+            func.write_luau_global_def(f, indent=1)
         for func in self.methods:
             func.write_luau_global_def(f, indent=1)
         f.write("end\n\n")
@@ -239,6 +242,8 @@ class SLuaClassDeclaration:
         f.write(f"  __index: {mt_name},\n")
         for prop in self.properties:
             f.write(f"  {prop.to_luau_def()},\n")
+        for func in self.functions:
+            func.write_luau_table_def(f, indent=1)
         for func in self.methods:
             func.write_luau_table_def(f, indent=1)
         f.write("}\n\n")
@@ -705,6 +710,7 @@ class SLuaDefinitionParser:
             export=data.get("export", False),
             comment=data.get("comment", ""),
             properties=[],
+            functions=[],
             methods=[],
         )
         try:
@@ -716,6 +722,9 @@ class SLuaDefinitionParser:
             class_scope: Set[str] = set()
             class_.properties = [
                 self._validate_property(prop, class_scope) for prop in data.get("properties", [])
+            ]
+            class_.functions = [
+                self._validate_function(method, class_scope) for method in data.get("functions", [])
             ]
             class_.methods = [
                 self._validate_function(method, class_scope, class_name=class_.name)

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import re
-from typing import TYPE_CHECKING, Any, List, Optional, Set, TextIO
+from typing import TYPE_CHECKING, Any, List, Set, TextIO
 
 import llsd
 import yaml
@@ -54,7 +54,7 @@ class SLuaParameter:
     """
 
     name: str
-    type: Optional[str] = None
+    type: str | None = None
     selene_type: Any = None
     """a custom Selene type for this parameter, in case auto-detection fails"""
     comment: str = ""
@@ -211,7 +211,7 @@ class SLuaClassDeclaration:
     properties: List[SLuaProperty]
     methods: List[SLuaFunction]
     comment: str = ""
-    instance_type: Optional[str] = None
+    instance_type: str | None = None
     export: bool = False
     """Only meaningful when `instance_type` is set."""
 
@@ -254,7 +254,7 @@ class SLuaModule:
     """Module declaration with constants and functions"""
 
     name: str
-    callable: Optional[SLuaFunction]
+    callable: SLuaFunction | None
     constants: List[SLuaProperty]
     functions: List[SLuaFunction]
     comment: str = ""
@@ -591,43 +591,10 @@ class SLuaDefinitions:
 
         spec = expand_spp_builder(lsl)
         methods: List[SLuaFunction] = [make_fluent_method(spec, m) for m in spec.methods]
-        methods.append(
-            SLuaFunction(
-                name="apply",
-                parameters=[
-                    SLuaParameter(name="self", type=spec.class_name),
-                    SLuaParameter(name="link", type="number?"),
-                ],
-            )
-        )
-        methods.append(
-            SLuaFunction(
-                name="new",
-                parameters=[],
-                return_type=spec.class_name,
-            )
-        )
-        self.classes.append(
-            SLuaClassDeclaration(
-                name=spec.class_name,
-                properties=[],
-                methods=methods,
-                # These generally wrap heterogeneous lists for LSL APIs,
-                # type them as such so `table.clone()` and `table.freeze()`
-                # and such still work
-                instance_type="{any}",
-                export=True,
-            )
-        )
-        self.type_names.add(spec.class_name)
 
-        builder_prop = SLuaProperty(
-            name=spec.module_entry,
-            type=f"{spec.class_name}Meta",
-        )
-        # We assume that the module we place this in is pre-existing
-        builder_module = [m for m in self.modules if m.name == spec.module_name][0]
-        builder_module.constants.append(builder_prop)
+        # We assume that the class we place this in is pre-existing
+        builder_class = [m for m in self.classes if m.name == spec.class_name][0]
+        builder_class.methods.extend(methods)
 
 
 class SLuaDefinitionParser:
@@ -734,6 +701,8 @@ class SLuaDefinitionParser:
     def _validate_class(self, data: dict) -> SLuaClassDeclaration:
         class_ = SLuaClassDeclaration(
             name=data["name"],
+            instance_type=data.get("instance-type", None),
+            export=data.get("export", False),
             comment=data.get("comment", ""),
             properties=[],
             methods=[],
@@ -741,6 +710,9 @@ class SLuaDefinitionParser:
         try:
             self._validate_identifier(class_.name)
             self._validate_scope(class_.name, self._type_names)
+            if class_.instance_type is not None:
+                self._validate_scope(f"{class_.name}Meta", self._type_names)
+                self._validate_type(class_.instance_type)
             class_scope: Set[str] = set()
             class_.properties = [
                 self._validate_property(prop, class_scope) for prop in data.get("properties", [])

--- a/slua_definitions.schema.json
+++ b/slua_definitions.schema.json
@@ -200,6 +200,12 @@
             "additionalProperties": false,
             "properties": {
                 "name": { "$ref": "#/$defs/identifier" },
+                "instance-type": { "$ref": "#/$defs/type" },
+                "export": {
+                    "const": true,
+                    "markdownDescription": "Whether this type is available to users. Only applicable if instance-type is specified.",
+                    "type": "boolean"
+                },
                 "properties": {
                     "items": { "$ref": "#/$defs/property" },
                     "type": "array"

--- a/slua_definitions.schema.json
+++ b/slua_definitions.schema.json
@@ -210,6 +210,10 @@
                     "items": { "$ref": "#/$defs/property" },
                     "type": "array"
                 },
+                "functions": {
+                    "items": { "$ref": "#/$defs/function" },
+                    "type": "array"
+                },
                 "methods": {
                     "items": { "$ref": "#/$defs/function" },
                     "type": "array"

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -322,6 +322,11 @@ classes:
   comment: Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast
   instance-type: '{any}'
   export: true
+  functions:
+  - name: new
+    comment: Create an empty list with PrimParamsSetterTypeMeta as metatable
+    parameters: []
+    return-type: PrimParamsSetterType
   methods: # This class is currently populated dynamically
   - name: apply
     comment: Call ll.SetLinkPrimitiveParamsFast with my instance list
@@ -331,10 +336,6 @@ classes:
     - name: link
       type: number?
       comment: Link number to target, or LINK_THIS if not specified
-  properties:
-  - name: new
-    comment: Create an empty list with PrimParamsSetterTypeMeta as metatable
-    type: () -> PrimParamsSetterType
 global-variables:
 - name: rotation
   comment: rotation is an alias for quaternion.

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -318,6 +318,23 @@ classes:
     - name: callback
       type: LLTimerCallback
     return-type: boolean
+- name: PrimParamsSetterType
+  comment: Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast
+  instance-type: '{any}'
+  export: true
+  methods: # This class is currently populated dynamically
+  - name: apply
+    comment: Call ll.SetLinkPrimitiveParamsFast with my instance list
+    parameters:
+    - name: self
+      type: PrimParamsSetterType
+    - name: link
+      type: number?
+      comment: Link number to target, or LINK_THIS if not specified
+  properties:
+  - name: new
+    comment: Create an empty list with PrimParamsSetterTypeMeta as metatable
+    type: () -> PrimParamsSetterType
 global-variables:
 - name: rotation
   comment: rotation is an alias for quaternion.
@@ -1179,7 +1196,11 @@ modules:
     value: 'setmetatable({}, lljson.object_mt}'
 - name: llprim
   comment: Utilities for working with prims / objects
-  # This module is currently populated dynamically
+  constants:
+  - name: ParamsSetter
+    comment: Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast
+    type: PrimParamsSetterTypeMeta
+    value: PrimParamsSetterTypeMeta
 - name: math
   comment: Mathematical functions library.
   functions:


### PR DESCRIPTION
Move the non-generated parts of `PrimParamsSetterType` to `slua_definitions.yaml` so they can be documented better.

I also added another field to classes: `functions`, for static methods and constructors and such. They are rendered almost identically to methods, with a slight difference for selene. But mostly, I figure we'll have more of those in the future and a document generator probably wants to put them in different sections. The first class function is `PrimParamsSetterType.new`

I thought about moving `LLEvents.touch_start` and such from properties to functions, as they would fit. But, I kept them as properties since it doesn't make much sense to ever call them, only set them yourself