### PR TITLE
Run `pyupgrade --py37-plus`

### DIFF
--- a/lsl_definitions/generators/lscript.py
+++ b/lsl_definitions/generators/lscript.py
@@ -579,7 +579,7 @@ def gen_mono_library_defs(definitions: LSLDefinitions, template_path: str) -> st
         return ToArrayListNoCopy(llDetectedDamageInternal(Number));
     }
     """
-    with open(template_path, "r") as f:
+    with open(template_path) as f:
         template = f.read()
 
     new_defs = ""
@@ -736,24 +736,24 @@ def gen_mono_bind_interfaces(definitions: LSLDefinitions) -> str:
 
     binding_file_code = """
 extern "C"
-{
+{{
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/object.h>
 #include <mono/jit/jit.h>
-}
+}}
 
 #include "llscriptexecutemono.h"
 #include "llmonointerfacehelpers.h"
 
 typedef void (*PtrType)();
 
-%s
+{}
 
 void mono_internal_call_init_generated()
-{
-%s
-}
-""" % (functions, binding_calls)
+{{
+{}
+}}
+""".format(functions, binding_calls)
     return binding_file_code
 
 

--- a/lsl_definitions/generators/lscript.py
+++ b/lsl_definitions/generators/lscript.py
@@ -21,7 +21,7 @@ def gen_lscript_library_defs(definitions: LSLDefinitions) -> str:
     func_defs = ""
     for func in definitions.functions.values():
         if func.arguments:
-            args_def = '"%s"' % "".join(x.type.meta.library_abbr for x in func.arguments)
+            args_def = '"{}"'.format("".join(x.type.meta.library_abbr for x in func.arguments))
         else:
             # Using `nullptr` instead of `""` saves a worthless array alloc inside `runllib_common()`.
             args_def = "nullptr"
@@ -30,7 +30,7 @@ def gen_lscript_library_defs(definitions: LSLDefinitions) -> str:
             # Using `nullptr` instead of `""` saves a worthless alloc inside `runllib_common()`.
             ret_def = "nullptr"
         else:
-            ret_def = '"%s"' % func.ret_type.meta.library_abbr
+            ret_def = f'"{func.ret_type.meta.library_abbr}"'
 
         func_defs += (
             f'dangerousAddFunction({func.func_id}, "{func.name}", {ret_def}, {args_def}, '
@@ -734,7 +734,7 @@ def gen_mono_bind_interfaces(definitions: LSLDefinitions) -> str:
             f" fnPtrToObjPtr(reinterpret_cast<PtrType>(_mono_binding_{impl_name})));\n"
         )
 
-    binding_file_code = """
+    binding_file_code = f"""
 extern "C"
 {{
 #include <mono/metadata/metadata.h>
@@ -747,13 +747,13 @@ extern "C"
 
 typedef void (*PtrType)();
 
-{}
+{functions}
 
 void mono_internal_call_init_generated()
 {{
-{}
+{binding_calls}
 }}
-""".format(functions, binding_calls)
+"""
     return binding_file_code
 
 
@@ -777,15 +777,12 @@ def gen_lscript_interface(definitions: LSLDefinitions) -> str:
         # Bind to LSO VM
         assign_execs += f'    gScriptLibrary.assignExec("{func.name}", {impl_name});\n'
 
-    function_code = (
-        """
+    function_code = f"""
 void task_lscript_init_generated()
-{
-%s
-}
+{{
+{assign_execs}
+}}
 """
-        % assign_execs
-    )
     return function_code
 
 
@@ -826,24 +823,24 @@ def gen_lua_registrations(definitions: LSLDefinitions, *, compat_mode: int = 0) 
             prelude += "    }\n"
 
         binding = """
-{"%(func_name)s", [](lua_State *L) {
-    LLScriptLibData args[%(num_args)d];
-    const LSCRIPTType types[] = {%(arg_types)s};
+{{"{func_name}", [](lua_State *L) {{
+    LLScriptLibData args[{num_args:d}];
+    const LSCRIPTType types[] = {{{arg_types}}};
     // Convert the arguments to LLScriptLibData, throwing if not possible.
-    extract_lua_args(L, %(num_args)d, types, args);
-%(prelude)s
-    return call_lib_func_lua(L, %(func_id)d, %(num_args)d, args, %(ret_type)s, %(bool_semantics)s, %(index_semantics)s);
-}}
-        """ % {
-            "num_args": len(func.arguments),
-            "ret_type": func.ret_type.meta.lst_name,
-            "arg_types": ", ".join(a.type.meta.lst_name for a in func.arguments),
-            "func_id": func.func_id,
-            "func_name": func_name,
-            "prelude": prelude if prelude.strip() else "    // no prelude",
-            "index_semantics": "false" if not func.index_semantics else "!compat_mode",
-            "bool_semantics": "false" if not func.bool_semantics else "!compat_mode",
-        }
+    extract_lua_args(L, {num_args:d}, types, args);
+{prelude}
+    return call_lib_func_lua(L, {func_id:d}, {num_args:d}, args, {ret_type}, {bool_semantics}, {index_semantics});
+}}}}
+        """.format(
+            num_args=len(func.arguments),
+            ret_type=func.ret_type.meta.lst_name,
+            arg_types=", ".join(a.type.meta.lst_name for a in func.arguments),
+            func_id=func.func_id,
+            func_name=func_name,
+            prelude=prelude if prelude.strip() else "    // no prelude",
+            index_semantics="false" if not func.index_semantics else "!compat_mode",
+            bool_semantics="false" if not func.bool_semantics else "!compat_mode",
+        )
         bindings.append(binding)
 
     return ",".join(bindings)

--- a/lsl_definitions/generators/lscript.py
+++ b/lsl_definitions/generators/lscript.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+# ruff: noqa: UP031  # Allow % formatting
 import re
 
 from lsl_definitions.generators.base import register
@@ -21,7 +22,7 @@ def gen_lscript_library_defs(definitions: LSLDefinitions) -> str:
     func_defs = ""
     for func in definitions.functions.values():
         if func.arguments:
-            args_def = '"{}"'.format("".join(x.type.meta.library_abbr for x in func.arguments))
+            args_def = f'"{"".join(x.type.meta.library_abbr for x in func.arguments)}"'
         else:
             # Using `nullptr` instead of `""` saves a worthless array alloc inside `runllib_common()`.
             args_def = "nullptr"
@@ -734,26 +735,26 @@ def gen_mono_bind_interfaces(definitions: LSLDefinitions) -> str:
             f" fnPtrToObjPtr(reinterpret_cast<PtrType>(_mono_binding_{impl_name})));\n"
         )
 
-    binding_file_code = f"""
+    binding_file_code = """
 extern "C"
-{{
+{
 #include <mono/metadata/metadata.h>
 #include <mono/metadata/object.h>
 #include <mono/jit/jit.h>
-}}
+}
 
 #include "llscriptexecutemono.h"
 #include "llmonointerfacehelpers.h"
 
 typedef void (*PtrType)();
 
-{functions}
+%s
 
 void mono_internal_call_init_generated()
-{{
-{binding_calls}
-}}
-"""
+{
+%s
+}
+""" % (functions, binding_calls)
     return binding_file_code
 
 
@@ -777,12 +778,15 @@ def gen_lscript_interface(definitions: LSLDefinitions) -> str:
         # Bind to LSO VM
         assign_execs += f'    gScriptLibrary.assignExec("{func.name}", {impl_name});\n'
 
-    function_code = f"""
+    function_code = (
+        """
 void task_lscript_init_generated()
-{{
-{assign_execs}
-}}
+{
+%s
+}
 """
+        % assign_execs
+    )
     return function_code
 
 
@@ -823,24 +827,24 @@ def gen_lua_registrations(definitions: LSLDefinitions, *, compat_mode: int = 0) 
             prelude += "    }\n"
 
         binding = """
-{{"{func_name}", [](lua_State *L) {{
-    LLScriptLibData args[{num_args:d}];
-    const LSCRIPTType types[] = {{{arg_types}}};
+{"%(func_name)s", [](lua_State *L) {
+    LLScriptLibData args[%(num_args)d];
+    const LSCRIPTType types[] = {%(arg_types)s};
     // Convert the arguments to LLScriptLibData, throwing if not possible.
-    extract_lua_args(L, {num_args:d}, types, args);
-{prelude}
-    return call_lib_func_lua(L, {func_id:d}, {num_args:d}, args, {ret_type}, {bool_semantics}, {index_semantics});
-}}}}
-        """.format(
-            num_args=len(func.arguments),
-            ret_type=func.ret_type.meta.lst_name,
-            arg_types=", ".join(a.type.meta.lst_name for a in func.arguments),
-            func_id=func.func_id,
-            func_name=func_name,
-            prelude=prelude if prelude.strip() else "    // no prelude",
-            index_semantics="false" if not func.index_semantics else "!compat_mode",
-            bool_semantics="false" if not func.bool_semantics else "!compat_mode",
-        )
+    extract_lua_args(L, %(num_args)d, types, args);
+%(prelude)s
+    return call_lib_func_lua(L, %(func_id)d, %(num_args)d, args, %(ret_type)s, %(bool_semantics)s, %(index_semantics)s);
+}}
+        """ % {
+            "num_args": len(func.arguments),
+            "ret_type": func.ret_type.meta.lst_name,
+            "arg_types": ", ".join(a.type.meta.lst_name for a in func.arguments),
+            "func_id": func.func_id,
+            "func_name": func_name,
+            "prelude": prelude if prelude.strip() else "    // no prelude",
+            "index_semantics": "false" if not func.index_semantics else "!compat_mode",
+            "bool_semantics": "false" if not func.bool_semantics else "!compat_mode",
+        }
         bindings.append(binding)
 
     return ",".join(bindings)

--- a/lsl_definitions/generators/lscript_compiler.py
+++ b/lsl_definitions/generators/lscript_compiler.py
@@ -35,9 +35,7 @@ def gen_lexer_file(definitions: LSLDefinitions, template_path: str) -> str:
     for event in definitions.events.values():
         if event.name in _LEXER_BLACKLIST:
             continue
-        generated_events += '"{}" {{ count(); return({}); }}\n'.format(
-            event.name, event.name.upper()
-        )
+        generated_events += f'"{event.name}" {{ count(); return({event.name.upper()}); }}\n'
     lexer_template = splice_str(lexer_template, _LEXER_EVENT_COMMENT, generated_events)
 
     generated_constants = ""
@@ -123,15 +121,12 @@ def gen_parser_file(definitions: LSLDefinitions, template_path: str) -> str:
         if event.name not in _PARSER_TYPES_BLACKLIST:
             generated_event_tokens += f"%token    {event.name.upper()}\n"
             generated_event_types += f"%type<event>    {event.name}\n"
-            generated_event_switch += (
-                """
-    | %s compound_statement {
+            generated_event_switch += f"""
+    | {event.name} compound_statement {{
         $$ = new LLScriptEventHandler(gLine, gColumn, $1, $2);
         gAllocationManager->addAllocation($$);
-    }
+    }}
 """
-                % event.name
-            )
         if event.name not in _PARSER_DEFINITIONS_BLACKLIST:
             generated_event_definitions += f"{event.name}\n"
             generated_event_definitions += f"    : {event.name.upper()} '(' "
@@ -160,7 +155,7 @@ def gen_parser_file(definitions: LSLDefinitions, template_path: str) -> str:
                 arg_idx += 3
 
             event_class = _event_to_class_name(event)
-            arg_str = ", ".join("id%d" % x for x in range(0, len(event.arguments)))
+            arg_str = ", ".join(f"id{x}" for x in range(0, len(event.arguments)))
             if arg_str:
                 arg_str = ", " + arg_str
             generated_event_definitions += (

--- a/lsl_definitions/generators/lscript_compiler.py
+++ b/lsl_definitions/generators/lscript_compiler.py
@@ -28,14 +28,16 @@ _LEXER_BLACKLIST = {
 @register("gen_lexer_file")
 def gen_lexer_file(definitions: LSLDefinitions, template_path: str) -> str:
     """Generate lexer bits for indra.in.l"""
-    with open(template_path, "r") as f:
+    with open(template_path) as f:
         lexer_template = f.read()
 
     generated_events = ""
     for event in definitions.events.values():
         if event.name in _LEXER_BLACKLIST:
             continue
-        generated_events += '"%s" { count(); return(%s); }\n' % (event.name, event.name.upper())
+        generated_events += '"{}" {{ count(); return({}); }}\n'.format(
+            event.name, event.name.upper()
+        )
     lexer_template = splice_str(lexer_template, _LEXER_EVENT_COMMENT, generated_events)
 
     generated_constants = ""
@@ -109,7 +111,7 @@ def _event_to_class_name(event: LSLEvent) -> str:
 @register("gen_parser_file")
 def gen_parser_file(definitions: LSLDefinitions, template_path: str) -> str:
     """Generate parser bits for indra.in.y"""
-    with open(template_path, "r") as f:
+    with open(template_path) as f:
         parser_template: str = f.read()
 
     generated_event_tokens = ""

--- a/lsl_definitions/generators/lsl.py
+++ b/lsl_definitions/generators/lsl.py
@@ -26,7 +26,7 @@ def gen_constant_lsl_script(definitions: LSLDefinitions) -> str:
         event_handlers += f"{event.name}("
         event_handlers += ", ".join(f"{str(x.type)} _{i}" for i, x in enumerate(event.arguments))
         event_handlers += "){}\n"
-    return "list l = [%s];\ndefault{\n%s\n}" % (joined_names, event_handlers)
+    return f"list l = [{joined_names}];\ndefault{{\n{event_handlers}\n}}"
 
 
 @register("gen_func_call_scripts")

--- a/lsl_definitions/generators/lsl.py
+++ b/lsl_definitions/generators/lsl.py
@@ -17,7 +17,7 @@ def gen_constant_lsl_script(definitions: LSLDefinitions) -> str:
 
     This can be done by looking at the bytecode of the compiled script.
     """
-    keys = ['"%s"' % x for x in definitions.constants.keys()]
+    keys = [f'"{x}"' for x in definitions.constants.keys()]
     joined_names = ", \n".join(itertools.chain(*zip(keys, definitions.constants.keys())))
 
     # Generate some stub event handlers as well

--- a/lsl_definitions/generators/textmate.py
+++ b/lsl_definitions/generators/textmate.py
@@ -205,7 +205,7 @@ def gen_textmate_slua(
 
     _base, ext = os.path.splitext(template_path)
 
-    with open(template_path, "r") as f:
+    with open(template_path) as f:
         template = Template(f.read())
         if ext == ".tmLanguage":
             return template.safe_substitute(inserts)
@@ -256,7 +256,7 @@ def gen_textmate_lsl(definitions: LSLDefinitions, template_path: str) -> str:
 
     _base, ext = os.path.splitext(template_path)
 
-    with open(template_path, "r") as f:
+    with open(template_path) as f:
         template = Template(f.read())
         if ext == ".tmLanguage":
             return template.safe_substitute(inserts)

--- a/lsl_definitions/lsl.py
+++ b/lsl_definitions/lsl.py
@@ -6,7 +6,7 @@ import ast
 import dataclasses
 import re
 from enum import IntEnum
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Set, Union
+from typing import TYPE_CHECKING, NamedTuple
 
 import llsd
 import yaml
@@ -33,7 +33,7 @@ class LSLType(StringEnum):
     LIST = "list"
 
     @property
-    def meta(self) -> "LSLTypeMeta":
+    def meta(self) -> LSLTypeMeta:
         return _TYPE_META_MAP[self]
 
 
@@ -51,7 +51,7 @@ class LSLTypeMeta(NamedTuple):
 _CS_TYPE_MODULE = "[ScriptTypes]LindenLab.SecondLife"
 
 
-_TYPE_META_MAP: Dict[LSLType, LSLTypeMeta] = {
+_TYPE_META_MAP: dict[LSLType, LSLTypeMeta] = {
     LSLType.VOID: LSLTypeMeta(
         cil_name="void",
         lso_size=0,
@@ -139,7 +139,7 @@ _TYPE_META_MAP: Dict[LSLType, LSLTypeMeta] = {
 class LSLConstant:
     name: str
     type: LSLType
-    slua_type: Optional[str]
+    slua_type: str | None
     slua_removed: bool
     value: str
     """A LSL literal, except:
@@ -202,7 +202,7 @@ class LSLConstant:
         )
 
     # TODO: This is a bit smelly, move it to `SLuaDefinitions`.
-    def to_slua_dict(self, slua: "SLuaDefinitions") -> dict:
+    def to_slua_dict(self, slua: SLuaDefinitions) -> dict:
         try:
             return remove_worthless(
                 {
@@ -249,7 +249,7 @@ class LSLEnum:
 class LSLArgument:
     name: str
     type: LSLType
-    slua_type: Optional[str]
+    slua_type: str | None
     tooltip: str
     index_semantics: bool
     asset_semantics: bool
@@ -273,7 +273,7 @@ class LSLArgument:
 @dataclasses.dataclass
 class LSLEvent:
     name: str
-    arguments: List[LSLArgument]
+    arguments: list[LSLArgument]
     tooltip: str
     private: bool
     deprecated: Deprecated | None
@@ -298,7 +298,7 @@ class LSLEvent:
             }
         )
 
-    def to_slua_dict(self, slua: "SLuaDefinitions") -> dict:
+    def to_slua_dict(self, slua: SLuaDefinitions) -> dict:
         try:
             if self.detected_semantics:
                 arguments = [
@@ -336,13 +336,13 @@ class LSLFunction:
     energy: float
     sleep: float
     ret_type: LSLType
-    slua_type: Optional[str]
+    slua_type: str | None
     god_mode: bool
     index_semantics: bool
     bool_semantics: bool
     detected_semantics: bool
-    type_arguments: List[str]
-    arguments: List[LSLArgument]
+    type_arguments: list[str]
+    arguments: list[LSLArgument]
     tooltip: str
     private: bool
     """
@@ -451,7 +451,7 @@ class LSLFunction:
             tooltip = tooltip.replace("-1", "nil")
         return tooltip
 
-    def to_slua_dict(self, slua: "SLuaDefinitions") -> dict:
+    def to_slua_dict(self, slua: SLuaDefinitions) -> dict:
         try:
             known_types = slua.validate_type_params(self.type_arguments)
             return remove_worthless(
@@ -482,16 +482,16 @@ class LSLFunction:
 
 
 class LSLDefinitions(NamedTuple):
-    events: Dict[str, LSLEvent]
-    functions: Dict[str, LSLFunction]
-    enums: Dict[str, LSLEnum]
-    constants: Dict[str, LSLConstant]
+    events: dict[str, LSLEvent]
+    functions: dict[str, LSLFunction]
+    enums: dict[str, LSLEnum]
+    constants: dict[str, LSLConstant]
     controls: dict
     types: dict
     builder_rulesets: dict
 
     @property
-    def reserved_words(self) -> Set[str]:
+    def reserved_words(self) -> set[str]:
         """Words that may not be used as identifiers (case-sensitive)"""
         return (
             set(self.controls.keys())
@@ -694,8 +694,8 @@ class LSLDefinitionParser:
             )
         return arg
 
-    def _validate_args(self, obj: Union[LSLEvent, LSLFunction]) -> None:
-        unique_arg_names = set(a.name for a in obj.arguments)
+    def _validate_args(self, obj: LSLEvent | LSLFunction) -> None:
+        unique_arg_names = {a.name for a in obj.arguments}
         if len(unique_arg_names) != len(obj.arguments):
             raise KeyError(f"Duplicate argument names in {obj.name}")
         for name in unique_arg_names:
@@ -739,7 +739,7 @@ class LSLDefinitionParser:
                 f"{variant_enum_name!r}"
             )
         variant_enum = self._definitions.enums[variant_enum_name]
-        seen: Set[str] = set()
+        seen: set[str] = set()
         for variant in variants:
             for tag in variant["applies-to"]:
                 if tag not in variant_enum.by_name:

--- a/lsl_definitions/lsl.py
+++ b/lsl_definitions/lsl.py
@@ -6,7 +6,7 @@ import ast
 import dataclasses
 import re
 from enum import IntEnum
-from typing import TYPE_CHECKING, Dict, List, NamedTuple, Optional, Set, Union
+from typing import TYPE_CHECKING, NamedTuple
 
 import llsd
 import yaml
@@ -33,7 +33,7 @@ class LSLType(StringEnum):
     LIST = "list"
 
     @property
-    def meta(self) -> "LSLTypeMeta":
+    def meta(self) -> LSLTypeMeta:
         return _TYPE_META_MAP[self]
 
 
@@ -51,7 +51,7 @@ class LSLTypeMeta(NamedTuple):
 _CS_TYPE_MODULE = "[ScriptTypes]LindenLab.SecondLife"
 
 
-_TYPE_META_MAP: Dict[LSLType, LSLTypeMeta] = {
+_TYPE_META_MAP: dict[LSLType, LSLTypeMeta] = {
     LSLType.VOID: LSLTypeMeta(
         cil_name="void",
         lso_size=0,
@@ -139,7 +139,7 @@ _TYPE_META_MAP: Dict[LSLType, LSLTypeMeta] = {
 class LSLConstant:
     name: str
     type: LSLType
-    slua_type: Optional[str]
+    slua_type: str | None
     slua_removed: bool
     value: str
     """A LSL literal, except:
@@ -202,7 +202,7 @@ class LSLConstant:
         )
 
     # TODO: This is a bit smelly, move it to `SLuaDefinitions`.
-    def to_slua_dict(self, slua: "SLuaDefinitions") -> dict:
+    def to_slua_dict(self, slua: SLuaDefinitions) -> dict:
         try:
             return remove_worthless(
                 {
@@ -249,7 +249,7 @@ class LSLEnum:
 class LSLArgument:
     name: str
     type: LSLType
-    slua_type: Optional[str]
+    slua_type: str | None
     tooltip: str
     index_semantics: bool
     asset_semantics: bool
@@ -273,7 +273,7 @@ class LSLArgument:
 @dataclasses.dataclass
 class LSLEvent:
     name: str
-    arguments: List[LSLArgument]
+    arguments: list[LSLArgument]
     tooltip: str
     private: bool
     deprecated: Deprecated | None
@@ -298,7 +298,7 @@ class LSLEvent:
             }
         )
 
-    def to_slua_dict(self, slua: "SLuaDefinitions") -> dict:
+    def to_slua_dict(self, slua: SLuaDefinitions) -> dict:
         try:
             if self.detected_semantics:
                 arguments = [
@@ -336,14 +336,14 @@ class LSLFunction:
     energy: float
     sleep: float
     ret_type: LSLType
-    slua_type: Optional[str]
+    slua_type: str | None
     god_mode: bool
     index_semantics: bool
     bool_semantics: bool
     asset_semantics: bool
     detected_semantics: bool
-    type_arguments: List[str]
-    arguments: List[LSLArgument]
+    type_arguments: list[str]
+    arguments: list[LSLArgument]
     tooltip: str
     private: bool
     """
@@ -452,7 +452,7 @@ class LSLFunction:
             tooltip = tooltip.replace("-1", "nil")
         return tooltip
 
-    def to_slua_dict(self, slua: "SLuaDefinitions") -> dict:
+    def to_slua_dict(self, slua: SLuaDefinitions) -> dict:
         try:
             known_types = slua.validate_type_params(self.type_arguments)
             return remove_worthless(
@@ -483,16 +483,16 @@ class LSLFunction:
 
 
 class LSLDefinitions(NamedTuple):
-    events: Dict[str, LSLEvent]
-    functions: Dict[str, LSLFunction]
-    enums: Dict[str, LSLEnum]
-    constants: Dict[str, LSLConstant]
+    events: dict[str, LSLEvent]
+    functions: dict[str, LSLFunction]
+    enums: dict[str, LSLEnum]
+    constants: dict[str, LSLConstant]
     controls: dict
     types: dict
     builder_rulesets: dict
 
     @property
-    def reserved_words(self) -> Set[str]:
+    def reserved_words(self) -> set[str]:
         """Words that may not be used as identifiers (case-sensitive)"""
         return (
             set(self.controls.keys())
@@ -700,8 +700,8 @@ class LSLDefinitionParser:
             )
         return arg
 
-    def _validate_args(self, obj: Union[LSLEvent, LSLFunction]) -> None:
-        unique_arg_names = set(a.name for a in obj.arguments)
+    def _validate_args(self, obj: LSLEvent | LSLFunction) -> None:
+        unique_arg_names = {a.name for a in obj.arguments}
         if len(unique_arg_names) != len(obj.arguments):
             raise KeyError(f"Duplicate argument names in {obj.name}")
         for name in unique_arg_names:
@@ -745,7 +745,7 @@ class LSLDefinitionParser:
                 f"{variant_enum_name!r}"
             )
         variant_enum = self._definitions.enums[variant_enum_name]
-        seen: Set[str] = set()
+        seen: set[str] = set()
         for variant in variants:
             for tag in variant["applies-to"]:
                 if tag not in variant_enum.by_name:

--- a/lsl_definitions/rulesets.py
+++ b/lsl_definitions/rulesets.py
@@ -6,7 +6,7 @@ expanded into the fluent SPP builder.
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from lsl_definitions.lsl import LSLDefinitions
@@ -20,7 +20,7 @@ class BuilderParamType:
     luau_type: str
 
 
-_RULESET_TYPES: Dict[str, BuilderParamType] = {
+_RULESET_TYPES: dict[str, BuilderParamType] = {
     t.name: t
     for t in [
         BuilderParamType("integer", "number"),
@@ -50,17 +50,17 @@ class BuilderMethod:
     """Owning ruleset rule, prefix stripped (e.g. `COLOR` or `TYPE`)"""
     rule_tag: int
     """Int value of `rule_name`"""
-    variant_tag: Optional[int]
+    variant_tag: int | None
     """`None` for non-variant rules, int value of the variant constant otherwise"""
     face_target: bool
     nullable: bool
-    params: List[BuilderMethodParam]
+    params: list[BuilderMethodParam]
 
 
 @dataclasses.dataclass(frozen=True)
 class BuilderSpec:
     class_name: str
-    methods: List[BuilderMethod]
+    methods: list[BuilderMethod]
 
 
 def _method_name(*parts: str) -> str:
@@ -70,7 +70,7 @@ def _method_name(*parts: str) -> str:
     return words[0].lower() + "".join(w.capitalize() for w in words[1:])
 
 
-def _build_params(raw_params: List[Tuple[str, str]]) -> List[BuilderMethodParam]:
+def _build_params(raw_params: list[tuple[str, str]]) -> list[BuilderMethodParam]:
     """`raw_params` comes from YAML as a list of `[type_name, arg_name]` pairs."""
     return [
         BuilderMethodParam(name=arg_name, type=_RULESET_TYPES[type_name])
@@ -78,14 +78,14 @@ def _build_params(raw_params: List[Tuple[str, str]]) -> List[BuilderMethodParam]
     ]
 
 
-def expand_spp_builder(lsl: "LSLDefinitions") -> BuilderSpec:
+def expand_spp_builder(lsl: LSLDefinitions) -> BuilderSpec:
     # Translates the `prim-params` ruleset into SLua builder methods. The
     # LSL-side semantic validation already ran in
     # `LSLDefinitionParser._validate_builder_rule_variants`.
     ruleset = lsl.builder_rulesets["prim-params"]
     rule_enum = lsl.enums[ruleset["enum"]]
 
-    methods: List[BuilderMethod] = []
+    methods: list[BuilderMethod] = []
     for rule_name, rule in ruleset["rules"].items():
         face_target = bool(rule.get("face-target"))
         nullable = bool(rule.get("nullable"))

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import re
-from typing import TYPE_CHECKING, Any, List, Optional, Set, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 import llsd
 import yaml
@@ -54,7 +54,7 @@ class SLuaParameter:
     """
 
     name: str
-    type: Optional[str] = None
+    type: str | None = None
     selene_type: Any = None
     """a custom Selene type for this parameter, in case auto-detection fails"""
     comment: str = ""
@@ -74,8 +74,8 @@ class SLuaParameter:
 @dataclasses.dataclass
 class SLuaFunctionBase(abc.ABC):
     name: str = ""
-    type_parameters: List[str] = dataclasses.field(default_factory=list)
-    parameters: List[SLuaParameter] = dataclasses.field(default_factory=list)
+    type_parameters: list[str] = dataclasses.field(default_factory=list)
+    parameters: list[SLuaParameter] = dataclasses.field(default_factory=list)
     return_type: str = "()"
     comment: str = ""
 
@@ -111,7 +111,7 @@ class SLuaFunction(SLuaFunctionBase):
     must_use: bool = False
     """Emit a warning if the return value is not used.
     See https://kampfkarren.github.io/selene/usage/std.html#must_use."""
-    overloads: List[SLuaFunctionOverload] = dataclasses.field(default_factory=list)
+    overloads: list[SLuaFunctionOverload] = dataclasses.field(default_factory=list)
 
     @property
     def deprecated_string(self) -> str:
@@ -208,11 +208,11 @@ class SLuaClassDeclaration:
     """Class declaration with properties and methods"""
 
     name: str
-    properties: List[SLuaProperty]
-    functions: List[SLuaFunction]
-    methods: List[SLuaFunction]
+    properties: list[SLuaProperty]
+    functions: list[SLuaFunction]
+    methods: list[SLuaFunction]
     comment: str = ""
-    instance_type: Optional[str] = None
+    instance_type: str | None = None
     export: bool = False
     """Only meaningful when `instance_type` is set."""
 
@@ -259,9 +259,9 @@ class SLuaModule:
     """Module declaration with constants and functions"""
 
     name: str
-    callable: Optional[SLuaFunction]
-    constants: List[SLuaProperty]
-    functions: List[SLuaFunction]
+    callable: SLuaFunction | None
+    constants: list[SLuaProperty]
+    functions: list[SLuaFunction]
     comment: str = ""
 
     def to_keywords_functions_dict(self) -> dict:
@@ -313,28 +313,28 @@ class SLuaDefinitions:
     # 1. Luau builtins. Typecheckers already know about these
     controls: dict  # same structure as LSLDefinitions.controls
     builtin_types: dict  # same structure as LSLDefinitions.types
-    builtin_constants: List[SLuaProperty]
-    builtin_functions: List[SLuaFunction]
+    builtin_constants: list[SLuaProperty]
+    builtin_functions: list[SLuaFunction]
 
     # 2. SLua base classes. These only depend on Luau builtins
-    base_classes: List[SLuaClassDeclaration]
-    type_aliases: List[SLuaTypeAlias]
+    base_classes: list[SLuaClassDeclaration]
+    type_aliases: list[SLuaTypeAlias]
 
     # 3. SLua standard library. Depends on base classes
-    classes: List[SLuaClassDeclaration]
-    global_functions: List[SLuaFunction]
-    modules: List[SLuaModule]
-    global_variables: List[SLuaProperty]
-    global_constants: List[SLuaProperty]
+    classes: list[SLuaClassDeclaration]
+    global_functions: list[SLuaFunction]
+    modules: list[SLuaModule]
+    global_variables: list[SLuaProperty]
+    global_constants: list[SLuaProperty]
 
     # All known type names, populated by parser
-    type_names: Set[str] = dataclasses.field(default_factory=set)
+    type_names: set[str] = dataclasses.field(default_factory=set)
 
     _TYPE_SEPERATORS_RE = re.compile(
         r"[ \n?&|,{}\[\]()]|\.\.\.|typeof|->|[a-zA-Z0-9_]*:|\"[a-zA-Z0-9_]*\""
     )
 
-    def validate_type(self, type_str: str, known_type_names: Set[str] | None = None) -> str:
+    def validate_type(self, type_str: str, known_type_names: set[str] | None = None) -> str:
         """Validate that a type string only references known types."""
         if not type_str:
             raise ValueError("Type may not be empty")
@@ -348,7 +348,7 @@ class SLuaDefinitions:
             return type_str
         raise ValueError(f"Unknown types {unknown_subtypes} in definition {type_str!r}")
 
-    def validate_type_params(self, type_params: List[str]) -> Set[str]:
+    def validate_type_params(self, type_params: list[str]) -> set[str]:
         """Validate type parameters and return the set of known types including them."""
         known_types = set(self.type_names)
         for type_param in type_params:
@@ -360,7 +360,7 @@ class SLuaDefinitions:
             known_types.add(type_param)
         return known_types
 
-    def finalize(self, lsl: "LSLDefinitions") -> None:
+    def finalize(self, lsl: LSLDefinitions) -> None:
         """Enrich this SLuaDefinitions with content derived from the LSL definitions.
 
         Call exactly once after parsing, before handing off to any generator.
@@ -368,7 +368,7 @@ class SLuaDefinitions:
         self.generate_ll_modules(lsl)
         self._generate_spp_builder_class(lsl)
 
-    def generate_ll_modules(self, lsl: "LSLDefinitions", solverV2: bool = True) -> None:
+    def generate_ll_modules(self, lsl: LSLDefinitions, solverV2: bool = True) -> None:
         """
         Generate ll and llcompat module content from LSL definitions.
 
@@ -570,7 +570,7 @@ class SLuaDefinitions:
             )
             self.global_constants.append(prop)
 
-    def _generate_spp_builder_class(self, lsl: "LSLDefinitions") -> None:
+    def _generate_spp_builder_class(self, lsl: LSLDefinitions) -> None:
         """Expand the `prim-params` ruleset into the fluent SPP builder class and attach it to self."""
 
         # TODO: Eh. Maybe this is too builder-specific and shouldn't be here?
@@ -595,7 +595,7 @@ class SLuaDefinitions:
             )
 
         spec = expand_spp_builder(lsl)
-        methods: List[SLuaFunction] = [make_fluent_method(spec, m) for m in spec.methods]
+        methods: list[SLuaFunction] = [make_fluent_method(spec, m) for m in spec.methods]
 
         # We assume that the class we place this in is pre-existing
         builder_class = [m for m in self.classes if m.name == spec.class_name][0]
@@ -604,8 +604,8 @@ class SLuaDefinitions:
 
 class SLuaDefinitionParser:
     def __init__(self):
-        self._type_names: Set[str] = set()
-        self._global_scope: Set[str] = set()
+        self._type_names: set[str] = set()
+        self._global_scope: set[str] = set()
 
     def parse_file(self, name: str) -> SLuaDefinitions:
         if name.endswith(".llsd"):
@@ -684,7 +684,7 @@ class SLuaDefinitionParser:
         try:
             self._validate_identifier(module.name)
             self._validate_scope(module.name, self._global_scope)
-            module_scope: Set[str] = set()
+            module_scope: set[str] = set()
             callable = data.get("callable")
             if callable is not None:
                 module.callable = self._validate_function(callable, module_scope)
@@ -719,7 +719,7 @@ class SLuaDefinitionParser:
             if class_.instance_type is not None:
                 self._validate_scope(f"{class_.name}Meta", self._type_names)
                 self._validate_type(class_.instance_type)
-            class_scope: Set[str] = set()
+            class_scope: set[str] = set()
             class_.properties = [
                 self._validate_property(prop, class_scope) for prop in data.get("properties", [])
             ]
@@ -735,7 +735,7 @@ class SLuaDefinitionParser:
         return class_
 
     def _validate_function(
-        self, data: dict, scope: Set[str], class_name: str | None = None
+        self, data: dict, scope: set[str], class_name: str | None = None
     ) -> SLuaFunction:
         try:
             func = SLuaFunction(
@@ -785,7 +785,7 @@ class SLuaDefinitionParser:
             raise ValueError(f"In type alias {alias.name}: {e}") from e
         return alias
 
-    def _validate_property(self, data: dict, scope: Set[str], const: bool = False) -> SLuaProperty:
+    def _validate_property(self, data: dict, scope: set[str], const: bool = False) -> SLuaProperty:
         prop = SLuaProperty(
             name=data["name"],
             type=data["type"],
@@ -806,7 +806,7 @@ class SLuaDefinitionParser:
         known_types = self._validate_type_params(func.type_parameters)
         self._validate_type(func.return_type, known_types)
         params = func.parameters
-        params_scope: Set[str] = set()
+        params_scope: set[str] = set()
         if class_name is not None:
             if not (
                 params
@@ -824,7 +824,7 @@ class SLuaDefinitionParser:
             self._validate_scope(param.name, params_scope)
             self._validate_type(param.type, known_types)
 
-    def _validate_type_params(self, type_params: List[str]) -> Set[str]:
+    def _validate_type_params(self, type_params: list[str]) -> set[str]:
         known_types = set(self._type_names)
         for type_param in type_params:
             type_param = type_param.replace("...", "", 1)
@@ -836,7 +836,7 @@ class SLuaDefinitionParser:
         r"[ \n?&|,{}\[\]()]|\.\.\.|typeof|->|[a-zA-Z0-9_]*:|\"[^\"]*\""
     )
 
-    def _validate_type(self, type_str: str, known_type_names: Set[str] | None = None) -> str:
+    def _validate_type(self, type_str: str, known_type_names: set[str] | None = None) -> str:
         if not type_str:
             raise ValueError("Type may not be empty")
         if known_type_names is None:
@@ -849,7 +849,7 @@ class SLuaDefinitionParser:
             return type_str
         raise ValueError(f"Unknown types {unknown_subtypes} in definition {type_str!r}")
 
-    def _validate_scope(self, name: str, scope: Set[str]) -> None:
+    def _validate_scope(self, name: str, scope: set[str]) -> None:
         if name in scope:
             raise ValueError(f"{name!r} is already defined in this scope")
         scope.add(name)

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 import dataclasses
 import re
-from typing import TYPE_CHECKING, Any, List, Optional, Set, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 import llsd
 import yaml
@@ -54,7 +54,7 @@ class SLuaParameter:
     """
 
     name: str
-    type: Optional[str] = None
+    type: str | None = None
     selene_type: Any = None
     """a custom Selene type for this parameter, in case auto-detection fails"""
     comment: str = ""
@@ -107,8 +107,8 @@ class SLuaTypecheckerFlags:
 @dataclasses.dataclass
 class SLuaFunctionBase(abc.ABC):
     name: str = ""
-    type_parameters: List[str] = dataclasses.field(default_factory=list)
-    parameters: List[SLuaParameter] = dataclasses.field(default_factory=list)
+    type_parameters: list[str] = dataclasses.field(default_factory=list)
+    parameters: list[SLuaParameter] = dataclasses.field(default_factory=list)
     return_type: str = "()"
     comment: str = ""
 
@@ -147,7 +147,7 @@ class SLuaFunction(SLuaFunctionBase):
         default_factory=SLuaTypecheckerFlags
     )
     """Flags specific to the internals of luau-analyze and luau-lsp."""
-    overloads: List[SLuaFunctionOverload] = dataclasses.field(default_factory=list)
+    overloads: list[SLuaFunctionOverload] = dataclasses.field(default_factory=list)
 
     @property
     def deprecated_string(self) -> str:
@@ -247,11 +247,11 @@ class SLuaClassDeclaration:
     """Class declaration with properties and methods"""
 
     name: str
-    properties: List[SLuaProperty]
-    functions: List[SLuaFunction]
-    methods: List[SLuaFunction]
+    properties: list[SLuaProperty]
+    functions: list[SLuaFunction]
+    methods: list[SLuaFunction]
     comment: str = ""
-    instance_type: Optional[str] = None
+    instance_type: str | None = None
     export: bool = False
     """Only meaningful when `instance_type` is set."""
 
@@ -298,9 +298,9 @@ class SLuaModule:
     """Module declaration with constants and functions"""
 
     name: str
-    callable: Optional[SLuaFunction]
-    constants: List[SLuaProperty]
-    functions: List[SLuaFunction]
+    callable: SLuaFunction | None
+    constants: list[SLuaProperty]
+    functions: list[SLuaFunction]
     comment: str = ""
 
     def to_keywords_functions_dict(self) -> dict:
@@ -352,22 +352,22 @@ class SLuaDefinitions:
     # 1. Luau builtins. Typecheckers already know about these
     controls: dict  # same structure as LSLDefinitions.controls
     builtin_types: dict  # same structure as LSLDefinitions.types
-    metamethods: dict  # name: {tooltip: str}
-    builtin_constants: List[SLuaProperty]
+    metamethods: dict[str, str]
+    builtin_constants: list[SLuaProperty]
 
     # 2. SLua base classes. These only depend on Luau builtins
-    base_classes: List[SLuaClassDeclaration]
-    type_aliases: List[SLuaTypeAlias]
+    base_classes: list[SLuaClassDeclaration]
+    type_aliases: list[SLuaTypeAlias]
 
     # 3. SLua standard library. Depends on base classes
-    classes: List[SLuaClassDeclaration]
-    functions: List[SLuaFunction]
-    modules: List[SLuaModule]
-    global_variables: List[SLuaProperty]
-    global_constants: List[SLuaProperty]
+    classes: list[SLuaClassDeclaration]
+    functions: list[SLuaFunction]
+    modules: list[SLuaModule]
+    global_variables: list[SLuaProperty]
+    global_constants: list[SLuaProperty]
 
     # All known type names, populated by parser
-    type_names: Set[str] = dataclasses.field(default_factory=set)
+    type_names: set[str] = dataclasses.field(default_factory=set)
 
     _TYPE_SEPERATORS_RE = re.compile(
         r"[ \n?&|,{}\[\]()]|\.\.\.|typeof|->|[a-zA-Z0-9_]*:|\"[a-zA-Z0-9_]*\""
@@ -379,13 +379,13 @@ class SLuaDefinitions:
                 return m
         return None
 
-    def get_class(self, name: str) -> Optional[SLuaClassDeclaration]:
+    def get_class(self, name: str) -> SLuaClassDeclaration | None:
         for c in self.classes:
             if c.name == name:
                 return c
         return None
 
-    def validate_type(self, type_str: str, known_type_names: Set[str] | None = None) -> str:
+    def validate_type(self, type_str: str, known_type_names: set[str] | None = None) -> str:
         """Validate that a type string only references known types."""
         if not type_str:
             raise ValueError("Type may not be empty")
@@ -399,7 +399,7 @@ class SLuaDefinitions:
             return type_str
         raise ValueError(f"Unknown types {unknown_subtypes} in definition {type_str!r}")
 
-    def validate_type_params(self, type_params: List[str]) -> Set[str]:
+    def validate_type_params(self, type_params: list[str]) -> set[str]:
         """Validate type parameters and return the set of known types including them."""
         known_types = set(self.type_names)
         for type_param in type_params:
@@ -411,7 +411,7 @@ class SLuaDefinitions:
             known_types.add(type_param)
         return known_types
 
-    def finalize(self, lsl: "LSLDefinitions") -> None:
+    def finalize(self, lsl: LSLDefinitions) -> None:
         """Enrich this SLuaDefinitions with content derived from the LSL definitions.
 
         Call exactly once after parsing, before handing off to any generator.
@@ -419,7 +419,7 @@ class SLuaDefinitions:
         self.generate_ll_modules(lsl)
         self._generate_spp_builder_class(lsl)
 
-    def generate_ll_modules(self, lsl: "LSLDefinitions", solverV2: bool = True) -> None:
+    def generate_ll_modules(self, lsl: LSLDefinitions, solverV2: bool = True) -> None:
         """
         Generate ll and llcompat module content from LSL definitions.
 
@@ -621,7 +621,7 @@ class SLuaDefinitions:
             )
             self.global_constants.append(prop)
 
-    def _generate_spp_builder_class(self, lsl: "LSLDefinitions") -> None:
+    def _generate_spp_builder_class(self, lsl: LSLDefinitions) -> None:
         """Expand the `prim-params` ruleset into the fluent SPP builder class and attach it to self."""
 
         # TODO: Eh. Maybe this is too builder-specific and shouldn't be here?
@@ -646,7 +646,7 @@ class SLuaDefinitions:
             )
 
         spec = expand_spp_builder(lsl)
-        methods: List[SLuaFunction] = [make_fluent_method(spec, m) for m in spec.methods]
+        methods: list[SLuaFunction] = [make_fluent_method(spec, m) for m in spec.methods]
 
         # We assume that the class we place this in is pre-existing
         builder_class = [m for m in self.classes if m.name == spec.class_name][0]
@@ -655,9 +655,9 @@ class SLuaDefinitions:
 
 class SLuaDefinitionParser:
     def __init__(self):
-        self._type_names: Set[str] = set()
-        self._metamethods: Set[str] = set()
-        self._global_scope: Set[str] = set()
+        self._type_names: set[str] = set()
+        self._metamethods: set[str] = set()
+        self._global_scope: set[str] = set()
 
     def parse_file(self, name: str) -> SLuaDefinitions:
         if name.endswith(".llsd"):
@@ -738,7 +738,7 @@ class SLuaDefinitionParser:
         try:
             self._validate_identifier(module.name)
             self._validate_scope(module.name, self._global_scope)
-            module_scope: Set[str] = set()
+            module_scope: set[str] = set()
             callable = data.get("callable")
             if callable is not None:
                 module.callable = self._validate_function(callable, module_scope)
@@ -773,7 +773,7 @@ class SLuaDefinitionParser:
             if class_.instance_type is not None:
                 self._validate_scope(f"{class_.name}Meta", self._type_names)
                 self._validate_type(class_.instance_type)
-            class_scope: Set[str] = set()
+            class_scope: set[str] = set()
             class_.properties = [
                 self._validate_property(prop, class_scope) for prop in data.get("properties", [])
             ]
@@ -789,7 +789,7 @@ class SLuaDefinitionParser:
         return class_
 
     def _validate_function(
-        self, data: dict, scope: Set[str], class_name: str | None = None
+        self, data: dict, scope: set[str], class_name: str | None = None
     ) -> SLuaFunction:
         try:
             func = SLuaFunction(
@@ -840,7 +840,7 @@ class SLuaDefinitionParser:
             raise ValueError(f"In type alias {alias.name}: {e}") from e
         return alias
 
-    def _validate_property(self, data: dict, scope: Set[str], const: bool = False) -> SLuaProperty:
+    def _validate_property(self, data: dict, scope: set[str], const: bool = False) -> SLuaProperty:
         prop = SLuaProperty(
             name=data["name"],
             type=data["type"],
@@ -861,7 +861,7 @@ class SLuaDefinitionParser:
         known_types = self._validate_type_params(func.type_parameters)
         self._validate_type(func.return_type, known_types)
         params = func.parameters
-        params_scope: Set[str] = set()
+        params_scope: set[str] = set()
         if class_name is not None:
             if not (
                 params
@@ -879,7 +879,7 @@ class SLuaDefinitionParser:
             self._validate_scope(param.name, params_scope)
             self._validate_type(param.type, known_types)
 
-    def _validate_type_params(self, type_params: List[str]) -> Set[str]:
+    def _validate_type_params(self, type_params: list[str]) -> set[str]:
         known_types = set(self._type_names)
         for type_param in type_params:
             type_param = type_param.replace("...", "", 1)
@@ -891,7 +891,7 @@ class SLuaDefinitionParser:
         r"[ \n?&|,{}\[\]()<>]|\.\.\.|typeof|setmetatable|getmetatable|->|[a-zA-Z0-9_]*:|\"[^\"]*\""
     )
 
-    def _validate_type(self, type_str: str, known_type_names: Set[str] | None = None) -> str:
+    def _validate_type(self, type_str: str, known_type_names: set[str] | None = None) -> str:
         if not type_str:
             raise ValueError("Type may not be empty")
         if known_type_names is None:
@@ -904,7 +904,7 @@ class SLuaDefinitionParser:
             return type_str
         raise ValueError(f"Unknown types {unknown_subtypes} in definition {type_str!r}")
 
-    def _validate_scope(self, name: str, scope: Set[str]) -> None:
+    def _validate_scope(self, name: str, scope: set[str]) -> None:
         if name in scope:
             raise ValueError(f"{name!r} is already defined in this scope")
         scope.add(name)

--- a/lsl_definitions/utils.py
+++ b/lsl_definitions/utils.py
@@ -7,7 +7,7 @@ import enum
 import os
 import os.path
 import stat
-from typing import Iterable, Sequence, TypeVar, Union
+from typing import Iterable, Sequence, TypeVar
 
 
 @dataclasses.dataclass
@@ -19,7 +19,7 @@ class Deprecated:
     selene_replace: list[str] | None = None
 
     @classmethod
-    def from_definition(cls, definition: dict | bool) -> "Deprecated | None":
+    def from_definition(cls, definition: dict | bool) -> Deprecated | None:
         if definition is False:
             return None
         if definition is True:
@@ -118,7 +118,7 @@ def is_uuid(val: str) -> bool:
     return bool(re.match(r"\A[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\Z", val))
 
 
-def write_if_different(filename: str, data: Union[bytes, str]):
+def write_if_different(filename: str, data: bytes | str):
     """
     Write, but not if it would change mtime needlessly
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,4 +55,4 @@ line-length = 100
 target-version = "py37"
 
 [tool.ruff.lint]
-extend-select = ["I"]
+extend-select = ["I", "UP"]

--- a/validate.py
+++ b/validate.py
@@ -1,5 +1,4 @@
 #!/bin/env python3
-# coding: utf-8
 
 
 import json
@@ -10,9 +9,9 @@ import yaml
 
 
 def validate_definitions_via_jsonschema(schema_filename, yaml_filename) -> None:
-    with open(schema_filename, "r", encoding="utf-8") as schema_file:
+    with open(schema_filename, encoding="utf-8") as schema_file:
         schemadata = json.load(schema_file)
-    with open(yaml_filename, "r", encoding="utf-8") as yaml_file:
+    with open(yaml_filename, encoding="utf-8") as yaml_file:
         yamldata = yaml.safe_load(yaml_file)
 
     try:


### PR DESCRIPTION
run pyupgrade so that the code is consistently using the typing recommendations of python 3.7, and not earlier