### PR TITLE
Fix Luau global function type syntax errors

### DIFF
--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -10592,7 +10592,7 @@ vector position - position in local coordinates
                   </map>
                </map>
                <map>
-                  <key>message</key>
+                  <key>errorMessage</key>
                   <map>
                      <key>tooltip</key>
                      <string>Optional error message to display if the value is not truthy.</string>
@@ -10635,15 +10635,19 @@ vector position - position in local coordinates
          </map>
          <key>error</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
-                  <key>obj</key>
+                  <key>message</key>
                   <map>
                      <key>tooltip</key>
-                     <string>The error object to raise.</string>
+                     <string>The error message to raise.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T</string>
                   </map>
                </map>
                <map>
@@ -10711,7 +10715,7 @@ vector position - position in local coordinates
             <key>arguments</key>
             <array>
                <map>
-                  <key>t</key>
+                  <key>tab</key>
                   <map>
                      <key>tooltip</key>
                      <string>The table to iterate over.</string>
@@ -10783,7 +10787,7 @@ vector position - position in local coordinates
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
-            <string>(K, V)?</string>
+            <string>(K?, V)</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
@@ -10811,7 +10815,7 @@ vector position - position in local coordinates
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
-            <string>(({[K], V}, K) -&gt; (K?, V), {[K], V}, K)</string>
+            <string>(({[K]: V}, K?) -&gt; (K?, V), {[K]: V}, K)</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
@@ -10856,6 +10860,10 @@ vector position - position in local coordinates
          </map>
          <key>print</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T...</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -10864,7 +10872,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>Arguments to print to standard output.</string>
                      <key>type</key>
-                     <string>...any</string>
+                     <string>T...</string>
                   </map>
                </map>
             </array>
@@ -10879,6 +10887,11 @@ vector position - position in local coordinates
          </map>
          <key>rawequal</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T1</string>
+               <string>T2</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -10887,7 +10900,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>First object to compare.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T1</string>
                   </map>
                </map>
                <map>
@@ -10896,7 +10909,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>Second object to compare.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T2</string>
                   </map>
                </map>
             </array>
@@ -11030,7 +11043,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The name of the external module.</string>
                      <key>type</key>
-                     <string>string</string>
+                     <string>any</string>
                   </map>
                </map>
             </array>
@@ -11045,6 +11058,10 @@ vector position - position in local coordinates
          </map>
          <key>select</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>A...</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -11062,14 +11079,14 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The arguments to select from.</string>
                      <key>type</key>
-                     <string>...any</string>
+                     <string>A...</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
-            <string>any</string>
+            <string>...any</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
@@ -11112,7 +11129,7 @@ vector position - position in local coordinates
             <key>arguments</key>
             <array>
                <map>
-                  <key>s</key>
+                  <key>value</key>
                   <map>
                      <key>tooltip</key>
                      <string>The string to convert to a number.</string>
@@ -11144,7 +11161,7 @@ vector position - position in local coordinates
             <key>arguments</key>
             <array>
                <map>
-                  <key>val</key>
+                  <key>value</key>
                   <map>
                      <key>tooltip</key>
                      <string></string>
@@ -11167,7 +11184,7 @@ vector position - position in local coordinates
             <key>arguments</key>
             <array>
                <map>
-                  <key>val</key>
+                  <key>value</key>
                   <map>
                      <key>tooltip</key>
                      <string></string>
@@ -11187,15 +11204,19 @@ vector position - position in local coordinates
          </map>
          <key>tostring</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
-                  <key>obj</key>
+                  <key>value</key>
                   <map>
                      <key>tooltip</key>
                      <string>The object to convert to a string.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T</string>
                   </map>
                </map>
             </array>
@@ -11256,6 +11277,10 @@ vector position - position in local coordinates
          </map>
          <key>type</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -11264,7 +11289,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The object to get the type of.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T</string>
                   </map>
                </map>
             </array>
@@ -11279,6 +11304,10 @@ vector position - position in local coordinates
          </map>
          <key>typeof</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -11287,7 +11316,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The object to get the type of.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T</string>
                   </map>
                </map>
             </array>
@@ -11309,7 +11338,7 @@ vector position - position in local coordinates
             <key>arguments</key>
             <array>
                <map>
-                  <key>a</key>
+                  <key>tab</key>
                   <map>
                      <key>tooltip</key>
                      <string>Array from which to extract values.</string>
@@ -11318,7 +11347,7 @@ vector position - position in local coordinates
                   </map>
                </map>
                <map>
-                  <key>f</key>
+                  <key>i</key>
                   <map>
                      <key>tooltip</key>
                      <string>Starting index (optional, defaults to 1).</string>
@@ -11327,7 +11356,7 @@ vector position - position in local coordinates
                   </map>
                </map>
                <map>
-                  <key>t</key>
+                  <key>j</key>
                   <map>
                      <key>tooltip</key>
                      <string>Ending index (optional, defaults to #a).</string>
@@ -11366,7 +11395,7 @@ vector position - position in local coordinates
                   </map>
                </map>
                <map>
-                  <key>e</key>
+                  <key>err</key>
                   <map>
                      <key>tooltip</key>
                      <string>Error handler function.</string>

--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -10685,6 +10685,10 @@ vector position - position in local coordinates
          </map>
          <key>getmetatable</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -10693,14 +10697,14 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The object to get the metatable for.</string>
                      <key>type</key>
-                     <string>any</string>
+                     <string>T</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
-            <string>{[any]: any}?</string>
+            <string>getmetatable&lt;T&gt;</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>
@@ -11094,6 +11098,11 @@ vector position - position in local coordinates
          </map>
          <key>setmetatable</key>
          <map>
+            <key>type-arguments</key>
+            <array>
+               <string>T</string>
+               <string>MT</string>
+            </array>
             <key>arguments</key>
             <array>
                <map>
@@ -11102,7 +11111,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The table to set the metatable for.</string>
                      <key>type</key>
-                     <string>{ [any]: any }</string>
+                     <string>T</string>
                   </map>
                </map>
                <map>
@@ -11111,14 +11120,14 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The metatable to set.</string>
                      <key>type</key>
-                     <string>{ [any]: any }?</string>
+                     <string>MT</string>
                   </map>
                </map>
             </array>
             <key>energy</key>
             <real>10.0</real>
             <key>return</key>
-            <string>()</string>
+            <string>setmetatable&lt;T, MT&gt;</string>
             <key>sleep</key>
             <real>0.0</real>
             <key>tooltip</key>

--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -11143,7 +11143,7 @@ vector position - position in local coordinates
                      <key>tooltip</key>
                      <string>The string to convert to a number.</string>
                      <key>type</key>
-                     <string>string</string>
+                     <string>string? | number</string>
                   </map>
                </map>
                <map>

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -251,7 +251,7 @@ declare function require(target: any): any
 declare function select<A...>(i: string | number, ...: A...): ...any
 declare setfenv: nil
 declare function setmetatable<T, MT>(t: T, mt: MT): setmetatable<T, MT>
-declare function tonumber(value: string, base: number?): number?
+declare function tonumber(value: string? | number, base: number?): number?
 declare function toquaternion(value: string? | quaternion): quaternion?
 declare function torotation(value: string? | quaternion): quaternion?
 declare function tostring<T>(value: T): string

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -230,37 +230,37 @@ export type PrimParamsSetterType = typeof(
 )
 
 
-declare function assert<T>(value: T?, message: string?): T
+declare function assert<T>(value: T?, errorMessage: string?): T
 declare function dangerouslyexecuterequiredmodule(f: (...any) -> ...any): ...any
-declare function error(obj: any, level: number?): never
+declare function error<T>(message: T, level: number?): never
 declare function gcinfo(): number
 declare getfenv: nil
 declare function getmetatable(obj: any): {[any]: any}?
-declare function ipairs<V>(t: {V}): (({V}, number) -> (number?, V), {V}, number)
+declare function ipairs<V>(tab: {V}): (({V}, number) -> (number?, V), {V}, number)
 declare loadstring: nil
 declare function newproxy(mt: boolean?): any
-declare function next<K, V>(t: {[K]: V}, i: K?): (K, V)?
-declare function pairs<K, V>(t: {[K]: V}): (({[K], V}, K) -> (K?, V), {[K], V}, K)
-declare function pcall<A..., R...>(f: (A...) -> R..., A...): (boolean, R...)
-declare function print(...any): ()
-declare function rawequal(a: any, b: any): boolean
+declare function next<K, V>(t: {[K]: V}, i: K?): (K?, V)
+declare function pairs<K, V>(t: {[K]: V}): (({[K]: V}, K?) -> (K?, V), {[K]: V}, K)
+declare function pcall<A..., R...>(f: (A...) -> R..., ...: A...): (boolean, R...)
+declare function print<T...>(...: T...): ()
+declare function rawequal<T1, T2>(a: T1, b: T2): boolean
 declare function rawget<K, V>(t: {[K]: V}, k: K): V?
 declare function rawlen<K, V>(t: {[K]: V} | string): number
 declare function rawset<K, V>(t: {[K]: V}, k: K, v: V): {[K]: V}
-declare function require(target: string): any
-declare function select(i: string | number, ...any): any
+declare function require(target: any): any
+declare function select<A...>(i: string | number, ...: A...): ...any
 declare setfenv: nil
 declare function setmetatable(t: { [any]: any }, mt: { [any]: any }?): ()
-declare function tonumber(s: string, base: number?): number?
-declare function toquaternion(val: string? | quaternion): quaternion?
-declare function torotation(val: string? | quaternion): quaternion?
-declare function tostring(obj: any): string
+declare function tonumber(value: string, base: number?): number?
+declare function toquaternion(value: string? | quaternion): quaternion?
+declare function torotation(value: string? | quaternion): quaternion?
+declare function tostring<T>(value: T): string
 declare function touuid(val: string? | buffer | uuid): uuid?
 declare function tovector(val: string? | vector): vector?
-declare function type(obj: any): string
-declare function typeof(obj: any): string
-declare function unpack<V>(a: {V}, f: number?, t: number?): ...V
-declare function xpcall<E, A..., R1..., R2...>(f: (A...) -> R1..., e: (E) -> R2..., A...): (boolean, R1...)
+declare function type<T>(obj: T): string
+declare function typeof<T>(obj: T): string
+declare function unpack<V>(tab: {V}, i: number?, j: number?): ...V
+declare function xpcall<E, A..., R1..., R2...>(f: (A...) -> R1..., err: (E) -> R2..., ...: A...): (boolean, R1...)
 
 ---------------------------
 -- Global Table: bit32

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -235,7 +235,7 @@ declare function dangerouslyexecuterequiredmodule(f: (...any) -> ...any): ...any
 declare function error<T>(message: T, level: number?): never
 declare function gcinfo(): number
 declare getfenv: nil
-declare function getmetatable(obj: any): {[any]: any}?
+declare function getmetatable<T>(obj: T): getmetatable<T>
 declare function ipairs<V>(tab: {V}): (({V}, number) -> (number?, V), {V}, number)
 declare loadstring: nil
 declare function newproxy(mt: boolean?): any
@@ -250,7 +250,7 @@ declare function rawset<K, V>(t: {[K]: V}, k: K, v: V): {[K]: V}
 declare function require(target: any): any
 declare function select<A...>(i: string | number, ...: A...): ...any
 declare setfenv: nil
-declare function setmetatable(t: { [any]: any }, mt: { [any]: any }?): ()
+declare function setmetatable<T, MT>(t: T, mt: MT): setmetatable<T, MT>
 declare function tonumber(value: string, base: number?): number?
 declare function toquaternion(value: string? | quaternion): quaternion?
 declare function torotation(value: string? | quaternion): quaternion?

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -3983,7 +3983,7 @@ globals:
   pcall:
     args:
     - type: function
-    - type: any
+    - type: '...'
     description: Calls function f with parameters args, returning success and function
       results or an error.
   print:
@@ -4012,7 +4012,7 @@ globals:
     description: Assigns a value to a table field bypassing metatables.
   require:
     args:
-    - type: string
+    - type: any
     description: Execute the named external module.
   select:
     args:
@@ -4083,7 +4083,7 @@ globals:
     args:
     - type: function
     - type: function
-    - type: any
+    - type: '...'
     description: Calls function f with parameters args, handling errors with e if
       they occur.
   bit32.arshift:

--- a/generated/secondlife_selene.yml
+++ b/generated/secondlife_selene.yml
@@ -3956,7 +3956,7 @@ globals:
     description: getfenv is removed in SLua.
   getmetatable:
     args:
-    - type: any
+    - type: table
     description: Returns the metatable for the specified object.
   ipairs:
     args:
@@ -4026,7 +4026,6 @@ globals:
     args:
     - type: table
     - type: table
-      required: false
     description: Changes the metatable for the given table.
   tonumber:
     args:

--- a/lsl_definitions/generators/slua.py
+++ b/lsl_definitions/generators/slua.py
@@ -125,14 +125,14 @@ def gen_selene_yml(definitions: LSLDefinitions, slua_definitions: SLuaDefinition
             return type_map[type_str]
         if type_str in type_aliases:
             return type_aliases[type_str].selene_type
-        if type_str.startswith("..."):
-            return "..."
         if type_str.startswith("{") and type_str.endswith("}"):
             return "table"
         if "|" in type_str:
             return default
         if "->" in type_str:
             return "function"
+        if "..." in type_str:
+            return "..."
         return default
 
     def selene_property(prop: SLuaProperty) -> dict:

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -62,11 +62,16 @@ class SLuaParameter:
     observes: Literal["read-write", "read", "write"] | None = None
     """See https://kampfkarren.github.io/selene/usage/std.html#observes."""
 
-    def to_luau_def(self) -> str:
+    def to_luau_def(self, declaration: bool = False) -> str:
         if self.type is None:
             return self.name
         elif self.name == "...":
-            return self.type
+            if not declaration:
+                return self.type
+            elif self.type.startswith("..."):
+                return f"...: {self.type[3:]}"
+            else:
+                return f"...: {self.type}"
         else:
             return f"{self.name}: {self.type}"
 
@@ -85,13 +90,12 @@ class SLuaFunctionBase(abc.ABC):
             return ""
         return "<" + ", ".join(self.type_parameters) + ">"
 
-    @property
-    def parameters_string(self) -> str:
-        return "(" + ", ".join(p.to_luau_def() for p in self.parameters) + ")"
+    def parameters_string(self, declaration: bool = False) -> str:
+        return "(" + ", ".join(p.to_luau_def(declaration) for p in self.parameters) + ")"
 
     @property
     def type_def_string(self) -> str:
-        return self.type_parameters_string + self.parameters_string + " -> " + self.return_type
+        return self.type_parameters_string + self.parameters_string() + " -> " + self.return_type
 
 
 @dataclasses.dataclass
@@ -159,7 +163,7 @@ class SLuaFunction(SLuaFunctionBase):
             f.write(self.deprecated_string)
             f.write(f"function {self.name}")
             f.write(self.type_parameters_string)
-            f.write(self.parameters_string)
+            f.write(self.parameters_string(declaration=True))
             f.write(f": {self.return_type}\n")
 
     def write_luau_table_def(self, f: TextIO, indent: int = 0, suffix=",") -> None:

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -848,7 +848,7 @@ class SLuaDefinitionParser:
         return known_types
 
     _TYPE_SEPERATORS_RE = re.compile(
-        r"[ \n?&|,{}\[\]()]|\.\.\.|typeof|->|[a-zA-Z0-9_]*:|\"[^\"]*\""
+        r"[ \n?&|,{}\[\]()<>]|\.\.\.|typeof|setmetatable|getmetatable|->|[a-zA-Z0-9_]*:|\"[^\"]*\""
     )
 
     def _validate_type(self, type_str: str, known_type_names: Set[str] | None = None) -> str:

--- a/slua_definitions.schema.json
+++ b/slua_definitions.schema.json
@@ -9,7 +9,7 @@
         },
         "type": {
             "markdownDescription": "A luau-format type definition.",
-            "pattern": "^([ \n?&|,{}\\[\\]():a-zA-Z0-9_]|\"[^\"]*\"|\\.\\.\\.|->)*$",
+            "pattern": "^([ \n?&|,{}\\[\\]()<>:a-zA-Z0-9_]|\"[^\"]*\"|\\.\\.\\.|->)*$",
             "type": "string"
         },
         "selene-type": {

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -354,7 +354,7 @@ functions:
   - name: value
     comment: The value to check for truthiness.
     type: T?
-  - name: message
+  - name: errorMessage
     comment: Optional error message to display if the value is not truthy.
     type: string?
   return-type: T
@@ -381,10 +381,11 @@ functions:
   return-type: '...any'
 - name: error
   comment: Raises an error with the specified object and optional call stack level.
+  type-parameters: [T]
   parameters:
-  - name: obj
-    comment: The error object to raise.
-    type: any
+  - name: message
+    comment: The error message to raise.
+    type: T
   - name: level
     comment: Optional level to attribute the error to in the call stack.
     type: number?
@@ -426,7 +427,7 @@ functions:
   comment: Returns an iterator for numeric key-value pairs in the table.
   type-parameters: [V]
   parameters:
-  - name: t
+  - name: tab
     comment: The table to iterate over.
     type: "{V}"
   return-type: "(({V}, number) -> (number?, V), {V}, number)"
@@ -457,7 +458,7 @@ functions:
   - name: i
     comment: Optional key to start traversal after.
     type: K?
-  return-type: (K, V)?
+  return-type: (K?, V)
 - name: pairs
   comment: Returns an iterator for all key-value pairs in the table.
   type-parameters: [K, V]
@@ -465,7 +466,7 @@ functions:
   - name: t
     comment: The table to iterate over.
     type: "{[K]: V}"
-  return-type: "(({[K], V}, K) -> (K?, V), {[K], V}, K)"
+  return-type: "(({[K]: V}, K?) -> (K?, V), {[K]: V}, K)"
 - name: pcall
   comment: Calls function f with parameters args, returning success and function results or an error.
   type-parameters: [A..., R...]
@@ -479,20 +480,22 @@ functions:
   return-type: (boolean, R...)
 - name: print
   comment: Prints all arguments to standard output using Tab as a separator.
+  type-parameters: [T...]
   parameters:
   - name: ...
     comment: Arguments to print to standard output.
-    type: ...any
+    type: T...
   return-type: ()
 - name: rawequal
   comment: Returns true if a and b have the same type and value.
+  type-parameters: [T1, T2]
   parameters:
   - name: a
     comment: First object to compare.
-    type: any
+    type: T1
   - name: b
     comment: Second object to compare.
-    type: any
+    type: T2
   return-type: boolean
   fastcall: true
 - name: rawget
@@ -536,27 +539,30 @@ functions:
   parameters:
   - name: target
     comment: The name of the external module.
-    type: string
+    type: any
   return-type: any
 - name: select
   comment: Returns a subset of arguments or the number of arguments.
+  type-parameters: [A...]
   parameters:
   - name: i
     comment: The index or '#' to count arguments.
     type: string | number
   - name: ...
     comment: The arguments to select from.
-    type: ...any
-  return-type: any
+    type: A...
+  return-type: ...any
   fastcall: true
 - name: setfenv
   comment: Set the scoped environment for the given function.
+  type-parameters: [T..., R...]
   parameters:
   - name: target
-    type: '((...any) -> ...any) | number'
+    type: 'number | (T...) -> R...'
     selene-type: function
   - name: env
     type: '{[string]: any}'
+  return-type: ((T...) -> R...)?
   slua-removed: true
 - name: setmetatable
   comment: Changes the metatable for the given table.
@@ -572,7 +578,7 @@ functions:
 - name: tonumber
   comment: Converts the input string to a number in the specified base.
   parameters:
-  - name: s
+  - name: value
     comment: The string to convert to a number.
     type: string
   - name: base
@@ -584,7 +590,7 @@ functions:
 - name: toquaternion
   comment: Converts a string to a quaternion, returns nil if invalid
   parameters:
-  - name: val
+  - name: value
     type: string? | quaternion
     selene-type: string
   return-type: quaternion?
@@ -592,17 +598,18 @@ functions:
 - name: torotation
   comment: Converts a string to a rotation (quaternion), returns nil if invalid
   parameters:
-  - name: val
+  - name: value
     type: string? | quaternion
     selene-type: string
   return-type: quaternion?
   must-use: true
 - name: tostring
   comment: Converts the input object to a string.
+  type-parameters: [T]
   parameters:
-  - name: obj
+  - name: value
     comment: The object to convert to a string.
-    type: any
+    type: T
   return-type: string
   fastcall: true
 - name: touuid
@@ -625,19 +632,21 @@ functions:
   must-use: true
 - name: type
   comment: Returns the type of the object as a string.
+  type-parameters: [T]
   parameters:
   - name: obj
     comment: The object to get the type of.
-    type: any
+    type: T
   return-type: string
   must-use: true
   fastcall: true
 - name: typeof
   comment: Returns the type of the object, including custom userdata types.
+  type-parameters: [T]
   parameters:
   - name: obj
     comment: The object to get the type of.
-    type: any
+    type: T
   return-type: string
   must-use: true
   fastcall: true
@@ -645,13 +654,13 @@ functions:
   comment: Returns values from an array in the specified index range.
   type-parameters: [V]
   parameters:
-  - name: a
+  - name: tab
     comment: Array from which to extract values.
     type: "{V}"
-  - name: f
+  - name: i
     comment: Starting index (optional, defaults to 1).
     type: number?
-  - name: t
+  - name: j
     comment: "Ending index (optional, defaults to #a)."
     type: number?
   return-type: ...V
@@ -663,7 +672,7 @@ functions:
   - name: f
     comment: A function to be called.
     type: (A...) -> R1...
-  - name: e
+  - name: err
     comment: Error handler function.
     type: (E) -> R2...
   - name: ...

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -403,11 +403,13 @@ functions:
   slua-removed: true
 - name: getmetatable
   comment: Returns the metatable for the specified object.
+  type-parameters: [T]
   parameters:
   - name: obj
     comment: The object to get the metatable for.
-    type: any
-  return-type: "{[any]: any}?"
+    type: T
+    selene-type: table
+  return-type: getmetatable<T>
   fastcall: true
 - name: graphheap
   comment: Writes the contents of heap to the given file in JSON format.
@@ -566,14 +568,17 @@ functions:
   slua-removed: true
 - name: setmetatable
   comment: Changes the metatable for the given table.
+  type-parameters: [T, MT]
   parameters:
   - name: t
     comment: The table to set the metatable for.
-    type: "{ [any]: any }"
+    type: T
+    selene-type: table
   - name: mt
     comment: The metatable to set.
-    type: "{ [any]: any }?"
-  return-type: ()
+    type: MT
+    selene-type: table
+  return-type: setmetatable<T, MT>
   fastcall: true
 - name: tonumber
   comment: Converts the input string to a number in the specified base.

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -585,7 +585,8 @@ functions:
   parameters:
   - name: value
     comment: The string to convert to a number.
-    type: string
+    type: string? | number
+    selene-type: string
   - name: base
     comment: Optional base for the conversion.
     type: number?


### PR DESCRIPTION
- Follows #133 
- Part of #122 

Fix a number of issues with the global funcion types that were added to `secondlife.d.luau` in #133:
- They had syntax errors, especially with type packs
- They did not match `EmbeddedBuiltinDefinitions.cpp`