### PR TITLE
Changing arguments names and improving tooltips

### DIFF
--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -21,10 +21,10 @@
 # retain the "llsd-" prefix for compatibility...
 llsd-lsl-syntax-version: 2
 enums:
-# This section documents the relationship between LSL's functions and constants.
-# Neither LSL nor Lua have real enums, nor is this a proposal to add them.
-# This is purely for the purpose of documentation generation, and to
-# document these relationships somewhere other than the LSL wiki.
+  # This section documents the relationship between LSL's functions and constants.
+  # Neither LSL nor Lua have real enums, nor is this a proposal to add them.
+  # This is purely for the purpose of documentation generation, and to
+  # document these relationships somewhere other than the LSL wiki.
   AgentData:
     type: enum
     prefix: DATA_
@@ -510,72 +510,90 @@ enums:
 constants:
   ACTIVE:
     member-of: [DetectType]
-    tooltip: Objects in world that are running a script or currently physically moving.
+    tooltip: Objects running a script or physically moving (using server resources).
+      In llDetectedType(), it identifies physical objects and agents. In
+      llSensor() or llSensorRepeat(), it searches for moving physical objects or
+      scripted objects.
     type: integer
     value: '0x2'
   AGENT:
     member-of: [DetectType]
-    tooltip: Objects in world that are agents.
+    tooltip: Agents (avatars). In llDetectedType, it indicates an avatar. In
+      llSensor or llSensorRepeat, it searches for avatars by legacy name
+      (functionally identical to AGENT_BY_LEGACY_NAME, though using
+      AGENT_BY_LEGACY_NAME is recommended instead).
     type: integer
     value: '0x1'
   AGENT_ALWAYS_RUN:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the queried avatar has 'Always
+      Run' enabled or is using tap-tap-hold.
     type: integer
     value: '0x1000'
   AGENT_ATTACHMENTS:
     member-of: [AgentInfo]
-    tooltip: The agent has attachments.
+    tooltip: Used with llGetAgentInfo to determine if the queried avatar has
+      attachments.
     type: integer
     value: '0x2'
   AGENT_AUTOMATED:
     member-of: [AgentInfo]
-    tooltip: The agent has been identified as a scripted agent
+    tooltip: Used with llGetAgentInfo to identify if the avatar is registered with
+      Linden Lab as an automated/scripted agent (bot).
     type: integer
     value: '0x4000'
   AGENT_AUTOPILOT:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is in autopilot
+      mode, which is enabled when the user selects 'Go Here' on the ground or
+      uses double-click autopilot.
     type: integer
     value: '0x2000'
   AGENT_AWAY:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is in 'away' mode,
+      which indicates they toggled away or have been inactive for too long.
     type: integer
     value: '0x40'
   AGENT_BUSY:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is in 'busy' mode.
     type: integer
     value: '0x800'
   AGENT_BY_LEGACY_NAME:
     member-of: [DetectType]
-    tooltip: ''
+    tooltip: Used to find agents by legacy name. In llDetectedType, it indicates an
+      avatar. In llSensor or llSensorRepeat, it searches for avatars by legacy
+      name.
     type: integer
     value: '0x1'
   AGENT_BY_USERNAME:
     member-of: [DetectType]
-    tooltip: ''
+    tooltip: Used to find agents by username (see Avatar Names).
     type: integer
     value: '0x10'
   AGENT_CROUCHING:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is crouching.
     type: integer
     value: '0x400'
   AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT:
     member-of: [AgentInfo]
-    tooltip: The agent is floating via scripted attachment.
+    tooltip: Used with llGetAgentInfo to determine if the avatar is floating or
+      hovering because of a scripted attachment using either llSetHoverHeight or
+      llGroundRepel.
     type: integer
     value: '0x8000'
   AGENT_FLYING:
     member-of: [AgentInfo]
-    tooltip: The agent is flying.
+    tooltip: Used with llGetAgentInfo to determine if the queried avatar is flying
+      or hovering.
     type: integer
     value: '0x1'
   AGENT_IN_AIR:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is in the air
+      (jumping, flying, or falling).
     type: integer
     value: '0x100'
   AGENT_LIST_PARCEL:
@@ -591,526 +609,552 @@ constants:
     value: 2
   AGENT_LIST_REGION:
     member-of: [AgentListScope]
-    tooltip: All agents in the region.
+    tooltip: Returns any or all agents in the region.
     type: integer
     value: 4
   AGENT_MOUSELOOK:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is in mouselook.
     type: integer
     value: '0x8'
   AGENT_ON_OBJECT:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is sitting on an
+      object and linked to it.
     type: integer
     value: '0x20'
   AGENT_SCRIPTED:
     member-of: [AgentInfo]
-    tooltip: The agent has scripted attachments.
+    tooltip: Used with llGetAgentInfo to determine if the avatar is carrying
+      scripted objects or has scripted attachments.
     type: integer
     value: '0x4'
   AGENT_SITTING:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is sitting.
     type: integer
     value: '0x10'
   AGENT_TYPING:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the avatar is typing.
     type: integer
     value: '0x200'
   AGENT_WALKING:
     member-of: [AgentInfo]
-    tooltip: ''
+    tooltip: Used with llGetAgentInfo to determine if the queried avatar is walking,
+      running, or crouch walking.
     type: integer
     value: '0x80'
   ALL_SIDES:
     member-of: [Faces]
-    tooltip: ''
+    tooltip: Selects all sides of an object in an applicable function.
     type: integer
     value: -1
   ANIM_ON:
     member-of: [TextureAnimMode]
-    tooltip: Texture animation is on.
+    tooltip: Enables texture animation. This must be set to start the animation and
+      cleared to stop it.
     type: integer
     value: '0x1'
   ATTACH_ANY_HUD:
     member-of: [AttachPoint]
-    tooltip: Filtering for any HUD attachment.
+    tooltip: A special constant representing all HUD attachment points when
+      filtering for any HUD attachment.
     type: integer
     value: -1
   ATTACH_AVATAR_CENTER:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's geometric centre.
+    tooltip: Attachment point for the avatar's geometric center or root.
     type: integer
     value: 40
   ATTACH_BACK:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's back.
+    tooltip: Attachment point for the avatar's back.
     type: integer
     value: 9
   ATTACH_BELLY:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's belly.
+    tooltip: Attachment point for the avatar's belly, stomach, or tummy.
     type: integer
     value: 28
   ATTACH_CHEST:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's chest.
+    tooltip: Attachment point for the avatar's chest or sternum.
     type: integer
     value: 1
   ATTACH_CHIN:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's chin.
+    tooltip: Attachment point for the avatar's chin.
     type: integer
     value: 12
   ATTACH_FACE_JAW:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's jaw.
+    tooltip: Attachment point for the avatar's jaw.
     type: integer
     value: 47
   ATTACH_FACE_LEAR:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left ear (extended).
+    tooltip: Attachment point for the avatar's left ear (extended).
     type: integer
     value: 48
   ATTACH_FACE_LEYE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left eye (extended).
+    tooltip: Attachment point for the avatar's left eye (extended).
     type: integer
     value: 50
   ATTACH_FACE_REAR:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right ear (extended).
+    tooltip: Attachment point for the avatar's right ear (extended).
     type: integer
     value: 49
   ATTACH_FACE_REYE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right eye (extended).
+    tooltip: Attachment point for the avatar's right eye (extended).
     type: integer
     value: 51
   ATTACH_FACE_TONGUE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's tongue.
+    tooltip: Attachment point for the avatar's tongue.
     type: integer
     value: 52
   ATTACH_GROIN:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's groin.
+    tooltip: Attachment point for the avatar's groin.
     type: integer
     value: 53
   ATTACH_HEAD:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's head.
+    tooltip: Attachment point for the avatar's head.
     type: integer
     value: 2
   ATTACH_HIND_LFOOT:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left hind foot.
+    tooltip: Attachment point for the avatar's left hind foot.
     type: integer
     value: 54
   ATTACH_HIND_RFOOT:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right hind foot.
+    tooltip: Attachment point for the avatar's right hind foot.
     type: integer
     value: 55
   ATTACH_HUD_BOTTOM:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Bottom.
     type: integer
     value: 37
   ATTACH_HUD_BOTTOM_LEFT:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Bottom Left.
     type: integer
     value: 36
   ATTACH_HUD_BOTTOM_RIGHT:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Bottom Right.
     type: integer
     value: 38
   ATTACH_HUD_CENTER_1:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Center.
     type: integer
     value: 35
   ATTACH_HUD_CENTER_2:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Center 2.
     type: integer
     value: 31
   ATTACH_HUD_TOP_CENTER:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Top Center.
     type: integer
     value: 33
   ATTACH_HUD_TOP_LEFT:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Top Left.
     type: integer
     value: 34
   ATTACH_HUD_TOP_RIGHT:
     member-of: [AttachPoint]
-    tooltip: ''
+    tooltip: Attachment point for HUD Top Right.
     type: integer
     value: 32
   ATTACH_LEAR:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left ear.
+    tooltip: Attachment point for the avatar's left ear.
     type: integer
     value: 13
   ATTACH_LEFT_PEC:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left pectoral.
+    tooltip: Attachment point for the avatar's left pectoral.
     type: integer
     value: 29
   ATTACH_LEYE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left eye.
+    tooltip: Attachment point for the avatar's left eye.
     type: integer
     value: 15
   ATTACH_LFOOT:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left foot.
+    tooltip: Attachment point for the avatar's left foot.
     type: integer
     value: 7
   ATTACH_LHAND:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left hand.
+    tooltip: Attachment point for the avatar's left hand.
     type: integer
     value: 5
   ATTACH_LHAND_RING1:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left ring finger.
+    tooltip: Attachment point for the avatar's left ring finger.
     type: integer
     value: 41
   ATTACH_LHIP:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left hip.
+    tooltip: Attachment point for the avatar's left hip.
     type: integer
     value: 25
   ATTACH_LLARM:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left lower arm.
+    tooltip: Attachment point for the avatar's left lower arm.
     type: integer
     value: 21
   ATTACH_LLLEG:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's lower left leg.
+    tooltip: Attachment point for the avatar's left lower leg.
     type: integer
     value: 27
   ATTACH_LPEC:
     deprecated:
       use: ATTACH_RIGHT_PEC
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right pectoral. (Deprecated, use ATTACH_RIGHT_PEC)
+    tooltip: Attachment point for the avatar's right pectoral (deprecated, use
+      ATTACH_RIGHT_PEC).
     type: integer
     value: 30
   ATTACH_LSHOULDER:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left shoulder.
+    tooltip: Attachment point for the avatar's left shoulder.
     type: integer
     value: 3
   ATTACH_LUARM:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left upper arm.
+    tooltip: Attachment point for the avatar's left upper arm.
     type: integer
     value: 20
   ATTACH_LULEG:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's lower upper leg.
+    tooltip: Attachment point for the avatar's left upper leg.
     type: integer
     value: 26
   ATTACH_LWING:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left wing.
+    tooltip: Attachment point for the avatar's left wing.
     type: integer
     value: 45
   ATTACH_MOUTH:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's mouth.
+    tooltip: Attachment point for the avatar's mouth.
     type: integer
     value: 11
   ATTACH_NECK:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's neck.
+    tooltip: Attachment point for the avatar's neck.
     type: integer
     value: 39
   ATTACH_NOSE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's nose.
+    tooltip: Attachment point for the avatar's nose.
     type: integer
     value: 17
   ATTACH_PELVIS:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's pelvis.
+    tooltip: Attachment point for the avatar's pelvis.
     type: integer
     value: 10
   ATTACH_REAR:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right ear.
+    tooltip: Attachment point for the avatar's right ear.
     type: integer
     value: 14
   ATTACH_REYE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right eye.
+    tooltip: Attachment point for the avatar's right eye.
     type: integer
     value: 16
   ATTACH_RFOOT:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right foot.
+    tooltip: Attachment point for the avatar's right foot.
     type: integer
     value: 8
   ATTACH_RHAND:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right hand.
+    tooltip: Attachment point for the avatar's right hand (the default attachment
+      point).
     type: integer
     value: 6
   ATTACH_RHAND_RING1:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right ring finger.
+    tooltip: Attachment point for the avatar's right ring finger.
     type: integer
     value: 42
   ATTACH_RHIP:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right hip.
+    tooltip: Attachment point for the avatar's right hip.
     type: integer
     value: 22
   ATTACH_RIGHT_PEC:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right pectoral.
+    tooltip: Attachment point for the avatar's right pectoral.
     type: integer
     value: 30
   ATTACH_RLARM:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right lower arm.
+    tooltip: Attachment point for the avatar's right lower arm.
     type: integer
     value: 19
   ATTACH_RLLEG:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right lower leg.
+    tooltip: Attachment point for the avatar's right lower leg.
     type: integer
     value: 24
   ATTACH_RPEC:
     deprecated:
       use: ATTACH_LEFT_PEC
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's left pectoral. (deprecated, use ATTACH_LEFT_PEC)
+    tooltip: Attachment point for the avatar's left pectoral (deprecated, use
+      ATTACH_LEFT_PEC).
     type: integer
     value: 29
   ATTACH_RSHOULDER:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right shoulder.
+    tooltip: Attachment point for the avatar's right shoulder.
     type: integer
     value: 4
   ATTACH_RUARM:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right upper arm.
+    tooltip: Attachment point for the avatar's right upper arm.
     type: integer
     value: 18
   ATTACH_RULEG:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right upper leg.
+    tooltip: Attachment point for the avatar's right upper leg.
     type: integer
     value: 23
   ATTACH_RWING:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's right wing.
+    tooltip: Attachment point for the avatar's right wing.
     type: integer
     value: 46
   ATTACH_TAIL_BASE:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's tail base.
+    tooltip: Attachment point for the avatar's tail base.
     type: integer
     value: 43
   ATTACH_TAIL_TIP:
     member-of: [AttachPoint]
-    tooltip: Attach to the avatar's tail tip.
+    tooltip: Attachment point for the avatar's tail tip.
     type: integer
     value: 44
   AVOID_CHARACTERS:
     member-of: [CharacterAvoidanceMode]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   AVOID_DYNAMIC_OBSTACLES:
     member-of: [CharacterAvoidanceMode]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   AVOID_NONE:
     member-of: [CharacterAvoidanceMode]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 0
   BEACON_MAP:
     member-of: [MapBeaconParam]
-    tooltip: Cause llMapBeacon to optionally display and focus the world map on the
+    tooltip: Causes llMapBeacon to optionally display and focus the world map on the
       avatar's viewer.
     type: integer
     value: 1
   CAMERA_ACTIVE:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 12
   CAMERA_BEHINDNESS_ANGLE:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets the angle in degrees within which the camera is not constrained by
+      changes in target rotation.
     type: integer
     value: 8
   CAMERA_BEHINDNESS_LAG:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets how strongly the camera is forced to stay behind the target if
+      outside of the behindness angle.
     type: integer
     value: 9
   CAMERA_DISTANCE:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets how far away the camera wants to be from its target.
     type: integer
     value: 7
   CAMERA_FOCUS:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets camera focus (target position) in region coordinates.
     type: integer
     value: 17
   CAMERA_FOCUS_LAG:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets how much the camera lags as it aims toward the target.
     type: integer
     value: 6
   CAMERA_FOCUS_LOCKED:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 22
   CAMERA_FOCUS_OFFSET:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Adjusts the camera focus position relative to the target.
     type: integer
     value: 1
   CAMERA_FOCUS_THRESHOLD:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets the radius of a sphere around the camera's target position within
+      which its focus is not affected by target motion.
     type: integer
     value: 11
   CAMERA_PITCH:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Adjusts the angular amount that the camera aims straight ahead versus
+      straight down, maintaining the same distance (analogous to 'incidence').
     type: integer
     value: 0
   CAMERA_POSITION:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets camera position in region coordinates.
     type: integer
     value: 13
   CAMERA_POSITION_LAG:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets how much the camera lags as it moves toward its ideal position.
     type: integer
     value: 5
   CAMERA_POSITION_LOCKED:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 21
   CAMERA_POSITION_THRESHOLD:
     member-of: [CameraParam]
-    tooltip: ''
+    tooltip: Sets the radius of a sphere around the camera's ideal position within
+      which it is not affected by target motion.
     type: integer
     value: 10
   CHANGED_ALLOWED_DROP:
     member-of: [ChangeType]
-    tooltip: The object inventory has changed because an item was added through the
+    tooltip: The prim inventory has changed because a user other than the owner (or
+      the owner if the object is no-mod) added an item through the
       llAllowInventoryDrop interface.
     type: integer
     value: '0x40'
   CHANGED_COLOR:
     member-of: [ChangeType]
-    tooltip: The object color has changed.
+    tooltip: The object's Blinn-Phong color or alpha parameters have changed.
     type: integer
     value: '0x2'
   CHANGED_INVENTORY:
     member-of: [ChangeType]
-    tooltip: The object inventory has changed.
+    tooltip: The prim inventory has changed by someone who has modification rights
+      to it.
     type: integer
     value: '0x1'
   CHANGED_LINK:
     member-of: [ChangeType]
-    tooltip: The object has linked or its links were broken.
+    tooltip: The number of prims making up the object or avatars seated on it has
+      changed. Also occurs when duplicating a linked object or when a prim
+      changes type or shape. Does not trigger on attach/detach, sit/unsit in
+      attachments, or single prim duplication.
     type: integer
     value: '0x20'
   CHANGED_MEDIA:
     member-of: [ChangeType]
-    tooltip: ''
+    tooltip: Prim Media on the prim has changed.
     type: integer
     value: '0x800'
   CHANGED_OWNER:
     member-of: [ChangeType]
-    tooltip: The object has changed ownership.
+    tooltip: The object has changed owners. Triggers in the original object when a
+      user takes it, copies it, or deeds it to a group, and in the new object
+      when it is first rezzed.
     type: integer
     value: '0x80'
   CHANGED_REGION:
     member-of: [ChangeType]
-    tooltip: The object has changed region.
+    tooltip: The object has changed regions by crossing a boundary or teleporting
+      (if attached). Triggers only in the root prim of a linkset.
     type: integer
     value: '0x100'
   CHANGED_REGION_START:
     member-of: [ChangeType]
-    tooltip: The region this object is in has just come online.
+    tooltip: The region containing this object has just come online.
     type: integer
     value: '0x400'
   CHANGED_RENDER_MATERIAL:
     member-of: [ChangeType]
-    tooltip: The render material has changed.
+    tooltip: The render material (prim material ID or material overrides) has
+      changed on one or more faces.
     type: integer
     value: '0x1000'
   CHANGED_SCALE:
     member-of: [ChangeType]
-    tooltip: The object scale (size) has changed.
+    tooltip: The prim scale of at least one prim in the linked object has changed.
+      Only the root prim receives this event.
     type: integer
     value: '0x8'
   CHANGED_SHAPE:
     member-of: [ChangeType]
-    tooltip: The object base shape has changed, e.g., a box to a cylinder.
+    tooltip: The prim base shape (PRIM_TYPE, such as box, prism, torus, taper,
+      twist, or cut) has changed.
     type: integer
     value: '0x4'
   CHANGED_TELEPORT:
     member-of: [ChangeType]
-    tooltip: The avatar to whom this object is attached has teleported.
+    tooltip: The avatar this object is attached to has teleported. Triggers only in
+      the root prim of an attachment. Does not occur for child prims or 'sit
+      teleports'. If scripts are disabled at the destination, the event queues
+      and triggers after moving to a script-enabled parcel.
     type: integer
     value: '0x200'
   CHANGED_TEXTURE:
     member-of: [ChangeType]
-    tooltip: The texture offset, scale rotation, or simply the object texture has
-      changed.
+    tooltip: The prim texture parameters (shine/bump settings, repeats, flip,
+      rotation, offset, or texture) have changed.
     type: integer
     value: '0x10'
   CHARACTER_ACCOUNT_FOR_SKIPPED_FRAMES:
     member-of: [CharacterParam]
-    tooltip: If set to false, character will not attempt to catch up on lost time
-      when pathfinding performance is low, potentially providing more reliable movement
-      (albeit while potentially appearing to be more stuttery). Default is true to
-      match pre-existing behavior.
+    tooltip: If set to FALSE, the pathfinding character will not attempt to catch up
+      on lost time when performance is low, potentially providing more reliable
+      (though potentially more stuttery) movement. Default is TRUE.
     type: integer
     value: 14
   CHARACTER_AVOIDANCE_MODE:
     member-of: [CharacterParam]
-    tooltip: Allows you to specify that a character should not try to avoid other
-      characters, should not try to avoid dynamic obstacles (relatively fast moving
-      objects and avatars), or both.
+    tooltip: Specifies which objects a pathfinding character avoids (other
+      characters, dynamic obstacles like fast-moving objects and avatars, or
+      both). Combined using bit flags; setting to AVOID_NONE disables avoidance
+      for both categories.
     type: integer
     value: 5
   CHARACTER_CMD_JUMP:
     member-of: [CharacterCommand]
-    tooltip: Makes the character jump. Requires an additional parameter, the height
-      to jump, between 0.1m and 2.0m. This must be provided as the first element of
-      the llExecCharacterCmd option list.
+    tooltip: Makes the character jump. Requires a height parameter between 0.1m and
+      2.0m as the first element of the llExecCharacterCmd option list.
     type: integer
     value: '0x01'
   CHARACTER_CMD_SMOOTH_STOP:
     member-of: [CharacterCommand]
-    tooltip: ''
+    tooltip: Stops any current pathfinding operation in a smooth fashion.
     type: integer
     value: 2
   CHARACTER_CMD_STOP:
@@ -1120,259 +1164,296 @@ constants:
     value: '0x00'
   CHARACTER_DESIRED_SPEED:
     member-of: [CharacterParam]
-    tooltip: Speed of pursuit in meters per second.
+    tooltip: Constant used to indicate that the following argument is the desired
+      speed (or speed of pursuit in meters per second) for a pathfinding
+      character.
     type: integer
     value: 1
   CHARACTER_DESIRED_TURN_SPEED:
     member-of: [CharacterParam]
-    tooltip: The character's maximum speed while turning about the Z axis. - Note
-      that this is only loosely enforced.
+    tooltip: Specifies the character's maximum speed while turning about the Z-axis
+      (default is 6 meters/second). Note that this is only loosely enforced, and
+      a character may turn at higher speeds under certain conditions.
     type: integer
     value: 12
   CHARACTER_LENGTH:
     member-of: [CharacterParam]
-    tooltip: Set collision capsule length - cannot be less than two times the radius.
+    tooltip: Sets the collision capsule length for a pathfinding character. If the
+      value is less than twice the radius plus 0.1m, it automatically adjusts to
+      twice the radius plus 0.1m.
     type: integer
     value: 3
   CHARACTER_MAX_ACCEL:
     member-of: [CharacterParam]
-    tooltip: The character's maximum acceleration rate.
+    tooltip: Specifies the character's maximum acceleration rate (default is 20 m/s²).
     type: integer
     value: 8
   CHARACTER_MAX_DECEL:
     member-of: [CharacterParam]
-    tooltip: The character's maximum deceleration rate.
+    tooltip: Specifies the character's maximum deceleration rate (default is 30 m/s²).
     type: integer
     value: 9
   CHARACTER_MAX_SPEED:
     member-of: [CharacterParam]
-    tooltip: The character's maximum speed.
+    tooltip: Specifies the character's maximum speed (must be between 0.2 and 50
+      meters/second; default is 20 m/s). Affects speed when avoiding dynamic
+      obstacles and when traversing low-walkability objects in
+      TRAVERSAL_TYPE_FAST mode.
     type: integer
     value: 13
   CHARACTER_MAX_TURN_RADIUS:
     member-of: [CharacterParam]
-    tooltip: The character's turn radius when travelling at CHARACTER_MAX_TURN_SPEED.
+    tooltip: Specifies the character's turn radius when traveling at
+      CHARACTER_DESIRED_TURN_SPEED (default is 1.25 meters).
     type: integer
     value: 10
   CHARACTER_ORIENTATION:
     member-of: [CharacterParam]
-    tooltip: 'Valid options are: VERTICAL, HORIZONTAL.'
+    tooltip: Specifies the orientation of the collision capsule for a pathfinding
+      character to denote how to interpret its size. Valid options are VERTICAL
+      and HORIZONTAL.
     type: integer
     value: 4
   CHARACTER_RADIUS:
     member-of: [CharacterParam]
-    tooltip: Set collision capsule radius.
+    tooltip: Sets the collision capsule radius used to define the size of a
+      pathfinding character.
     type: integer
     value: 2
   CHARACTER_STAY_WITHIN_PARCEL:
     member-of: [CharacterParam]
-    tooltip: Determines whether a character can leave its starting parcel.\nTakes
-      a boolean parameter. If TRUE, the character cannot voluntarilly leave the parcel,
-      but can return to it.
+    tooltip: Determines whether a character is restricted to its starting parcel
+      (default is FALSE). If TRUE, parcel boundaries act as one-way obstacles;
+      the character cannot voluntarily leave and pathfinding behaviors (wander,
+      flee, evade, pursue) will only choose goal points within the parcel. If
+      pushed out, it can re-enter but cannot voluntarily leave again.
     type: integer
     value: 15
   CHARACTER_TYPE:
     member-of: [CharacterParam, GetClosestNavPointParam]
-    tooltip: Specifies which walk-ability coefficient will be used by this character.
+    tooltip: Specifies the preferred surface and terrain terrain-type for the
+      character (default is CHARACTER_TYPE_NONE). Used to describe preferred
+      surfaces rather than behavior (e.g., cows prefer type B, sheep herded
+      along a road prefer type C).
     type: integer
     value: 6
   CHARACTER_TYPE_A:
     member-of: [CharacterType]
-    tooltip: ''
+    tooltip: Used for pathfinding character types that prefer movement consistent
+      with humanoids.
     type: integer
     value: 0
   CHARACTER_TYPE_B:
     member-of: [CharacterType]
-    tooltip: ''
+    tooltip: Used for pathfinding character types that prefer movement consistent
+      with wild animals or off-road vehicles.
     type: integer
     value: 1
   CHARACTER_TYPE_C:
     member-of: [CharacterType]
-    tooltip: ''
+    tooltip: Used for mechanical pathfinding character types or road-going vehicles.
     type: integer
     value: 2
   CHARACTER_TYPE_D:
     member-of: [CharacterType]
-    tooltip: ''
+    tooltip: Used for pathfinding character types that are inconsistent with types
+      A, B, or C.
     type: integer
     value: 3
   CHARACTER_TYPE_NONE:
     member-of: [CharacterType]
-    tooltip: ''
+    tooltip: Used to set no specific pathfinding character type.
     type: integer
     value: 4
   CLICK_ACTION_BUY:
     member-of: [ClickAction]
-    tooltip: When the prim is clicked, the buy dialog is opened.
+    tooltip: Opens the buy dialog when the prim is clicked or touched.
     type: integer
     value: 2
   CLICK_ACTION_DISABLED:
     member-of: [ClickAction]
-    tooltip: No click action. No touches detected or passed.
+    tooltip: Disables click actions. No touches are detected or passed.
     type: integer
     value: 8
   CLICK_ACTION_IGNORE:
     member-of: [ClickAction]
-    tooltip: No click action. Object is invisible to the mouse.
+    tooltip: Disables click actions. Clicks pass through the object to whatever is
+      behind it, and no touches are detected.
     type: integer
     value: 9
   CLICK_ACTION_NONE:
     member-of: [ClickAction]
-    tooltip: 'Performs the default action: when the prim is clicked, touch events
-      are triggered.'
+    tooltip: "Performs the default action: triggers touch events when the prim is
+      clicked or touched."
     type: integer
     value: 0
   CLICK_ACTION_OPEN:
     member-of: [ClickAction]
-    tooltip: When the prim is clicked, the object inventory dialog is opened.
+    tooltip: Opens the object inventory dialog when the prim is clicked or touched.
     type: integer
     value: 4
   CLICK_ACTION_OPEN_MEDIA:
     member-of: [ClickAction]
-    tooltip: When the prim is touched, the web media dialog is opened.
+    tooltip: Opens the web media dialog or plays parcel media (without pausing) when
+      the prim is touched.
     type: integer
     value: 6
   CLICK_ACTION_PAY:
     member-of: [ClickAction]
-    tooltip: When the prim is clicked, the pay dialog is opened.
+    tooltip: Opens the pay dialog when the prim is clicked or touched.
     type: integer
     value: 3
   CLICK_ACTION_PLAY:
     member-of: [ClickAction]
-    tooltip: When the prim is clicked, html-on-a-prim is enabled?
+    tooltip: Enables HTML-on-a-prim or plays/pauses parcel media when the prim is
+      clicked or touched.
     type: integer
     value: 5
   CLICK_ACTION_SIT:
     member-of: [ClickAction]
-    tooltip: When the prim is clicked, the avatar sits upon it.
+    tooltip: Causes the avatar to sit on the prim when it is clicked or touched.
     type: integer
     value: 1
   CLICK_ACTION_TOUCH:
     member-of: [ClickAction]
-    tooltip: When the prim is clicked, touch events are triggered.
+    tooltip: Triggers touch events when the prim is clicked or touched.
     type: integer
     value: 0
   CLICK_ACTION_ZOOM:
     member-of: [ClickAction]
-    tooltip: Zoom in on object when clicked.
+    tooltip: Zooms the avatar camera in on the object (Viewer 2) when clicked or
+      touched.
     type: integer
     value: 7
   COMBAT_CHANNEL:
-    tooltip: COMBAT_CHANNEL is an integer constant that, when passed to llRegionSay
-      will add the message to the combat log. A script with a chat listen active on
-      COMBAT_CHANNEL may also monitor the combat log.
+    tooltip: A region-wide channel reserved for combat-related log events. Passing
+      this to llRegionSay adds the message to the combat log, and scripts
+      listening on this channel can monitor the combat log.
     type: integer
     value: 2147483646
   COMBAT_LOG_ID:
-    tooltip: Messages from the region to the COMBAT_CHANNEL will all be from this ID.\n
-      Scripts may filter llListen calls on this ID to receive only system generated combat log messages.
+    tooltip: The ID used by all combat log messages sent from the region to the
+      COMBAT_CHANNEL. Scripts can filter llListen calls with this ID to receive
+      only system-generated combat log messages.
     type: string
     slua-type: uuid
     value: "45e0fcfa-2268-4490-a51c-3e51bdfe80d1"
   CONTENT_TYPE_ATOM:
     member-of: [HTTPContentType]
-    tooltip: '"application/atom+xml"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/atom+xml'.
     type: integer
     value: 4
   CONTENT_TYPE_FORM:
     member-of: [HTTPContentType]
-    tooltip: '"application/x-www-form-urlencoded"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/x-www-form-urlencoded'.
     type: integer
     value: 7
   CONTENT_TYPE_HTML:
     member-of: [HTTPContentType]
-    tooltip: '"text/html", only valid for embedded browsers on content owned by the
-      person viewing. Falls back to "text/plain" otherwise.'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'text/html'. Only valid for embedded browsers on
+      content owned by the viewer; falls back to 'text/plain' otherwise.
     type: integer
     value: 1
   CONTENT_TYPE_JSON:
     member-of: [HTTPContentType]
-    tooltip: '"application/json"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/json'.
     type: integer
     value: 5
   CONTENT_TYPE_LLSD:
     member-of: [HTTPContentType]
-    tooltip: '"application/llsd+xml"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/llsd+xml' (Linden Lab Structured Data).
     type: integer
     value: 6
   CONTENT_TYPE_RSS:
     member-of: [HTTPContentType]
-    tooltip: '"application/rss+xml"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/rss+xml'.
     type: integer
     value: 8
   CONTENT_TYPE_TEXT:
     member-of: [HTTPContentType]
-    tooltip: '"text/plain"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'text/plain'.
     type: integer
     value: 0
   CONTENT_TYPE_XHTML:
     member-of: [HTTPContentType]
-    tooltip: '"application/xhtml+xml"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/xhtml+xml'.
     type: integer
     value: 3
   CONTENT_TYPE_XML:
     member-of: [HTTPContentType]
-    tooltip: '"application/xml"'
+    tooltip: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+      via llHTTPResponse to 'application/xml'.
     type: integer
     value: 2
   CONTROL_BACK:
     member-of: [ControlButton]
-    tooltip: Test for the avatar move back control.
+    tooltip: Tests for the avatar move back control (↓ or S).
     type: integer
     value: '0x2'
   CONTROL_DOWN:
     member-of: [ControlButton]
-    tooltip: Test for the avatar move down control.
+    tooltip: Tests for the avatar move down control (PgDn or C).
     type: integer
     value: '0x20'
   CONTROL_FWD:
     member-of: [ControlButton]
-    tooltip: Test for the avatar move forward control.
+    tooltip: Tests for the avatar move forward control (↑ or W).
     type: integer
     value: '0x1'
   CONTROL_LBUTTON:
     member-of: [ControlButton]
-    tooltip: Test for the avatar left button control.
+    tooltip: Tests for the avatar left mouse button control.
     type: integer
     value: '0x10000000'
   CONTROL_LEFT:
     member-of: [ControlButton]
-    tooltip: Test for the avatar move left control.
+    tooltip: Tests for the avatar move left control (Shift + ← or Shift + A).
     type: integer
     value: '0x4'
   CONTROL_ML_LBUTTON:
     member-of: [ControlButton]
-    tooltip: Test for the avatar left button control while in mouse look.
+    tooltip: Tests for the avatar left mouse button control while in mouselook.
     type: integer
     value: '0x40000000'
   CONTROL_RIGHT:
     member-of: [ControlButton]
-    tooltip: Test for the avatar move right control.
+    tooltip: Tests for the avatar move right control (Shift + → or Shift + D).
     type: integer
     value: '0x8'
   CONTROL_ROT_LEFT:
     member-of: [ControlButton]
-    tooltip: Test for the avatar rotate left control.
+    tooltip: Tests for the avatar rotate left control (← or A).
     type: integer
     value: '0x100'
   CONTROL_ROT_RIGHT:
     member-of: [ControlButton]
-    tooltip: Test for the avatar rotate right control.
+    tooltip: Tests for the avatar rotate right control (→ or D).
     type: integer
     value: '0x200'
   CONTROL_UP:
     member-of: [ControlButton]
-    tooltip: Test for the avatar move up control.
+    tooltip: Tests for the avatar move up control (PgUp or E).
     type: integer
     value: '0x10'
   DAMAGEABLE:
     member-of: [DetectType]
-    tooltip: Objects in world that are able to process damage.
+    tooltip: Identifies objects in the world that can process damage. In
+      llDetectedType, it indicates a damageable agent, or an object containing a
+      script with on_damage or final_damage events. Can also filter
+      llSensor/llSensorRepeat calls.
     type: integer
     value: '0x20'
   DAMAGE_TYPE_ACID:
     member-of: [DamageType]
-    tooltip: Damage caused by a caustic substance, such as acid
+    tooltip: Damage caused by a caustic substance, such as acid.
     type: integer
     value: 1
   DAMAGE_TYPE_BLUDGEONING:
@@ -1382,7 +1463,7 @@ constants:
     value: '2'
   DAMAGE_TYPE_COLD:
     member-of: [DamageType]
-    tooltip: Damage inflicted by exposure to extreme cold
+    tooltip: Damage inflicted by exposure to extreme cold.
     type: integer
     value: 3
   DAMAGE_TYPE_ELECTRIC:
@@ -1392,7 +1473,7 @@ constants:
     value: 4
   DAMAGE_TYPE_EMOTIONAL:
     member-of: [DamageType]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 14
   DAMAGE_TYPE_FIRE:
@@ -1402,7 +1483,7 @@ constants:
     value: 5
   DAMAGE_TYPE_FORCE:
     member-of: [DamageType]
-    tooltip: Damage inflicted by a great force or impact.
+    tooltip: Damage inflicted by a great force or impact (Vertical Sim / SLMC).
     type: integer
     value: 6
   DAMAGE_TYPE_GENERIC:
@@ -1412,17 +1493,18 @@ constants:
     value: 0
   DAMAGE_TYPE_IMPACT:
     member-of: [DamageType]
-    tooltip: System damage generated by impact with land or a prim.
+    tooltip: System damage generated by impact with land, terrain, or a prim.
     type: integer
     value: -1
   DAMAGE_TYPE_NECROTIC:
     member-of: [DamageType]
-    tooltip: Damage caused by a direct assault on life-force
+    tooltip: Damage caused by a direct assault on the life-force.
     type: integer
     value: 7
   DAMAGE_TYPE_PIERCING:
     member-of: [DamageType]
-    tooltip: Damage caused by a piercing object such as a bullet, spear, or arrow.
+    tooltip: Damage caused by a piercing object such as a bullet, spear, or arrow
+      (Vertical Sim / SLMC).
     type: integer
     value: 8
   DAMAGE_TYPE_POISON:
@@ -1452,122 +1534,141 @@ constants:
     value: 13
   DATA_BORN:
     member-of: [AgentData]
-    tooltip: The date the agent was born, returned in ISO 8601 format of YYYY-MM-DD.
+    tooltip: Used with llRequestAgentData to return the agent's account creation
+      ('born on') date as a string in ISO 8601 format (YYYY-MM-DD), based on
+      Pacific Time (not UTC).
     type: integer
     value: 3
   DATA_NAME:
     member-of: [AgentData]
-    tooltip: The name of the agent.
+    tooltip: Used with llRequestAgentData to return the requested agent's legacy name.
     type: integer
     value: 2
   DATA_ONLINE:
     member-of: [AgentData]
-    tooltip: TRUE for online, FALSE for offline.
+    tooltip: "Used with llRequestAgentData to return whether the requested agent is
+      online (returns an integer boolean string: TRUE if online, FALSE if
+      offline)."
     type: integer
     value: 1
   DATA_PAYINFO:
     member-of: [AgentData]
-    tooltip: ''
+    tooltip: Used with llRequestAgentData to return a string containing the integer
+      mask flag for payment status (contains PAYMENT_INFO_ON_FILE,
+      PAYMENT_INFO_USED, or both).
     type: integer
     value: 8
   DATA_RATING:
     member-of: [AgentData]
-    tooltip: "Returns the agent ratings as a comma separated string of six integers.\
-      \ They are:\n\t\t\t1) Positive rated behaviour\n\t\t\t2) Negative rated behaviour\n\
-      \t\t\t3) Positive rated appearance\n\t\t\t4) Negative rated appearance\n\t\t\
-      \t5) Positive rated building\n\t\t\t6) Negative rated building"
+    tooltip: Deprecated. Used with llRequestAgentData to return the string '0, 0, 0,
+      0, 0, 0'. It formerly returned a comma-separated list of positive and
+      negative ratings (behavior, appearance, and building) before ratings were
+      removed from SL.
     type: integer
     value: 4
   DATA_RESERVED_0:
     member-of: [AgentData]
-    tooltip: "Reserved for Linden use."
+    tooltip: Reserved for Linden use.
     type: integer
     value: 9
   DATA_SIM_POS:
     member-of: [SimulatorData]
-    tooltip: ''
+    tooltip: Used with llRequestSimulatorData to return the region's global position
+      as a vector.
     type: integer
     value: 5
   DATA_SIM_RATING:
     member-of: [SimulatorData]
-    tooltip: ''
+    tooltip: Used with llRequestSimulatorData to return the simulator rating string
+      ('PG', 'MATURE', 'ADULT', or 'UNKNOWN').
     type: integer
     value: 7
   DATA_SIM_STATUS:
     member-of: [SimulatorData]
-    tooltip: ''
+    tooltip: Used with llRequestSimulatorData to return the simulator status as a
+      string.
     type: integer
     value: 6
   DEBUG_CHANNEL:
-    tooltip: DEBUG_CHANNEL is an integer constant that, when passed to llSay, llWhisper,
-      or llShout as a channel parameter, will print text to the Script Warning/Error
-      Window.
+    tooltip: A chat channel reserved for script debugging and error messages.
+      Passing this to llSay, llWhisper, or llShout prints text to the Script
+      Warning/Error Window and broadcasts it to nearby avatars' script consoles.
     type: integer
     value: 2147483647
   DEG_TO_RAD:
-    tooltip: "0.017453293 - Number of radians per degree.\n\t\t\tYou can use this\
-      \ to convert degrees to radians by multiplying the degrees by this number."
+    tooltip: The constant 0.017453293 (precise value is PI/180). Multiply a value in
+      degrees by this number to convert it to radians.
     type: float
     value: '0.017453293'
   DENSITY:
     member-of: [PhysicsMaterialParam]
-    tooltip: Used with llSetPhysicsMaterial to enable the density value. Must be between
-      1.0 and 22587.0 (in Kg/m^3 -- see if you can figure out what 22587 represents)
+    tooltip: Used with llSetPhysicsMaterial to indicate that the density parameter
+      is enabled (which overrides the previous value). Must be between 1.0 and
+      22587.0 kg/m³.
     type: integer
     value: 1
   DEREZ_DIE:
     member-of: [DerezMode]
-    tooltip: Causes the object to immediately die.
+    tooltip: Used with llDerezObject to immediately delete (kill) the object.
     type: integer
     value: 0
   DEREZ_MAKE_TEMP:
     member-of: [DerezMode]
-    tooltip: The object is made temporary and will be cleaned up at some later timer.
+    tooltip: Used with llDerezObject to mark the object as temporary, allowing the
+      simulator to clean it up at a later time.
     type: integer
     value: 1
   DEREZ_TO_INVENTORY:
     member-of: [DerezMode]
-    tooltip: The object is returned to the inventory of the rezzer.
+    tooltip: Used with llDerezObject to return the targeted object to the rezzer's
+      (derezzer's) inventory, saving its current state.
     type: integer
     value: 2
   ENVIRONMENT_DAYINFO:
     member-of: [EnvironmentParamReadOnly]
-    tooltip: Day length, offset and progression.
+    tooltip: "Day cycle and time information: day_length (seconds in the
+      environment's day cycle), day_offset (seconds offset from GMT), and
+      secs_since_midnight (seconds elapsed since the last day cycle midnight)."
     type: integer
     value: 200
   ENV_INVALID_AGENT:
     member-of: [EnvironmentError]
-    tooltip: Could not find agent with the specified ID
+    tooltip: Unable to find the specified agent, or could not find an agent with the
+      specified ID.
     type: integer
     value: -4
   ENV_INVALID_RULE:
     member-of: [EnvironmentError]
-    tooltip: Attempted to change an unknown property.
+    tooltip: There was an issue with one of the rules, or an attempt was made to
+      change an unknown property.
     type: integer
     value: -5
   ENV_NOT_EXPERIENCE:
     member-of: [EnvironmentError]
-    tooltip: Attempt to change environments outside an experience.
+    tooltip: Attempted to change environments outside an experience, or the script
+      is not running as part of an experience with a valid experience key.
     type: integer
     value: -1
   ENV_NO_ENVIRONMENT:
     member-of: [EnvironmentError]
-    tooltip: Could not find environmental settings in object inventory.
+    tooltip: The environmental settings inventory object could not be found, or
+      there is no environment on this parcel to modify.
     type: integer
     value: -3
   ENV_NO_EXPERIENCE_LAND:
     member-of: [EnvironmentError]
-    tooltip: The experience has not been enabled on this land.
+    tooltip: The experience has not been enabled or cannot run on the land.
     type: integer
     value: -7
   ENV_NO_EXPERIENCE_PERMISSION:
     member-of: [EnvironmentError]
-    tooltip: Agent has not granted permission to change environments.
+    tooltip: The agent has not granted permission to change environments.
     type: integer
     value: -2
   ENV_NO_PERMISSIONS:
     member-of: [EnvironmentError]
-    tooltip: Script does not have permission to modify environment.
+    tooltip: The script lacks permissions to modify the environment at this
+      location, or an attempt was made to remove altitude track 0 or 1.
     type: integer
     value: -9
   ENV_OK:
@@ -1577,574 +1678,635 @@ constants:
     value: 1
   ENV_THROTTLE:
     member-of: [EnvironmentError]
-    tooltip: Could not validate values for environment.
+    tooltip: The scripts have exceeded the throttle limit. Wait and retry the request.
     type: integer
     value: -8
   ENV_VALIDATION_FAIL:
     member-of: [EnvironmentError]
-    tooltip: Could not validate values for environment.
+    tooltip: Could not validate the environmental settings or values passed.
     type: integer
     value: -6
   EOF:
-    tooltip: Indicates the last line of a notecard was read.
+    tooltip: A value equal to three newline characters ("\n\n\n") returned by the
+      dataserver event, indicating that the requested line is past the end of
+      the notecard.
     type: string
     value: '\n\n\n'
   ERR_GENERIC:
     member-of: [ReturnObjectsError]
-    tooltip: ''
+    tooltip: An inexplicable and generic error where nothing is known about the cause.
     type: integer
     value: -1
   ERR_MALFORMED_PARAMS:
     member-of: [ReturnObjectsError]
-    tooltip: ''
+    tooltip: Return value for llReturnObject* functions indicating that the
+      parameters passed are malformed.
     type: integer
     value: -3
   ERR_PARCEL_PERMISSIONS:
     member-of: [ReturnObjectsError]
-    tooltip: ''
+    tooltip: Return value for llReturnObject* functions indicating a lack of
+      permissions to perform the task on the specified parcel.
     type: integer
     value: -2
   ERR_RUNTIME_PERMISSIONS:
     member-of: [ReturnObjectsError]
-    tooltip: ''
+    tooltip: Return value for llReturnObject* functions indicating the script lacks
+      the runtime permissions required to perform the requested task.
     type: integer
     value: -4
   ERR_THROTTLED:
     member-of: [ReturnObjectsError]
-    tooltip: ''
+    tooltip: Return value for llReturnObject* functions indicating that the task has
+      been throttled and should be retried later.
     type: integer
     value: -5
   ESTATE_ACCESS_ALLOWED_AGENT_ADD:
     member-of: [EstateAccessParam]
-    tooltip: Add the agent to this estate's Allowed Residents list.
+    tooltip: Used as an input parameter for llManageEstateAccess to add an agent to
+      the estate's Allowed Residents list.
     type: integer
     value: 4
   ESTATE_ACCESS_ALLOWED_AGENT_REMOVE:
     member-of: [EstateAccessParam]
-    tooltip: Remove the agent from this estate's Allowed Residents list.
+    tooltip: Used as an input parameter for llManageEstateAccess to remove an agent
+      from the estate's Allowed Residents list.
     type: integer
     value: 8
   ESTATE_ACCESS_ALLOWED_GROUP_ADD:
     member-of: [EstateAccessParam]
-    tooltip: Add the group to this estate's Allowed groups list.
+    tooltip: Used as an input parameter for llManageEstateAccess to add a group to
+      the estate's Allowed Groups list.
     type: integer
     value: 16
   ESTATE_ACCESS_ALLOWED_GROUP_REMOVE:
     member-of: [EstateAccessParam]
-    tooltip: Remove the group from this estate's Allowed groups list.
+    tooltip: Used as an input parameter for llManageEstateAccess to remove a group
+      from the estate's Allowed Groups list.
     type: integer
     value: 32
   ESTATE_ACCESS_BANNED_AGENT_ADD:
     member-of: [EstateAccessParam]
-    tooltip: Add the agent to this estate's Banned residents list.
+    tooltip: Used as an input parameter for llManageEstateAccess to add an agent to
+      the estate's Banned Residents list.
     type: integer
     value: 64
   ESTATE_ACCESS_BANNED_AGENT_REMOVE:
     member-of: [EstateAccessParam]
-    tooltip: Remove the agent from this estate's Banned residents list.
+    tooltip: Used as an input parameter for llManageEstateAccess to remove an agent
+      from the estate's Banned Residents list.
     type: integer
     value: 128
   'FALSE':
-    tooltip: An integer constant for boolean comparisons. Has the value '0'.
+    tooltip: Constant representing a boolean FALSE value. Used in conditional
+      structures or variables to improve readability over the integer value (0).
     type: integer
     slua-removed: true
     value: 0
   FILTER_FLAGS:
     member-of: [AttachedListFilterParam]
-    tooltip: Flags to control returned attachments.
+    tooltip: Flags used to control which attachments are returned.
     type: integer
     value: 2
   FILTER_FLAG_HUDS:
     member-of: [AttachedListFilterFlag]
-    tooltip: Include HUDs with matching experience.
+    tooltip: Filter flag used with llGetAttachedListFiltered to include HUDs with
+      matching experiences in the returned result.
     type: integer
     value: '0x0001'
   FILTER_INCLUDE:
     member-of: [AttachedListFilterParam]
-    tooltip: Include attachment point.
+    tooltip: Filter parameter used to include a specific attachment point.
     type: integer
     value: 1
   FORCE_DIRECT_PATH:
     member-of: [CharacterNavigateParam]
-    tooltip: Makes character navigate in a straight line toward position. May be set
-      to TRUE or FALSE.
+    tooltip: Forces the pathfinding character to navigate in a straight line toward
+      its target position (can be set to TRUE or FALSE).
     type: integer
     value: 1
   FRICTION:
     member-of: [PhysicsMaterialParam]
-    tooltip: Used with llSetPhysicsMaterial to enable the friction value. Must be
-      between 0.0 and 255.0
+    tooltip: Used with llSetPhysicsMaterial to enable the friction override. The
+      value must be between 0.0 and 255.0.
     type: integer
     value: 2
   GAME_CONTROL_AXIS_LEFTX:
     member-of: [GameControlAxis]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 0
   GAME_CONTROL_AXIS_LEFTY:
     member-of: [GameControlAxis]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   GAME_CONTROL_AXIS_RIGHTX:
     member-of: [GameControlAxis]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   GAME_CONTROL_AXIS_RIGHTY:
     member-of: [GameControlAxis]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 3
   GAME_CONTROL_AXIS_TRIGGERLEFT:
     member-of: [GameControlAxis]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 4
   GAME_CONTROL_AXIS_TRIGGERRIGHT:
     member-of: [GameControlAxis]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 5
   GAME_CONTROL_BUTTON_A:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x1'
   GAME_CONTROL_BUTTON_B:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x2'
   GAME_CONTROL_BUTTON_BACK:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x10'
   GAME_CONTROL_BUTTON_DPAD_DOWN:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x1000'
   GAME_CONTROL_BUTTON_DPAD_LEFT:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x2000'
   GAME_CONTROL_BUTTON_DPAD_RIGHT:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x4000'
   GAME_CONTROL_BUTTON_DPAD_UP:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x800'
   GAME_CONTROL_BUTTON_GUIDE:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x20'
   GAME_CONTROL_BUTTON_LEFTSHOULDER:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x200'
   GAME_CONTROL_BUTTON_LEFTSTICK:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x80'
   GAME_CONTROL_BUTTON_MISC1:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x8000'
   GAME_CONTROL_BUTTON_PADDLE1:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x10000'
   GAME_CONTROL_BUTTON_PADDLE2:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x20000'
   GAME_CONTROL_BUTTON_PADDLE3:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x40000'
   GAME_CONTROL_BUTTON_PADDLE4:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x80000'
   GAME_CONTROL_BUTTON_RIGHTSHOULDER:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x400'
   GAME_CONTROL_BUTTON_RIGHTSTICK:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x100'
   GAME_CONTROL_BUTTON_START:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x40'
   GAME_CONTROL_BUTTON_TOUCHPAD:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x100000'
   GAME_CONTROL_BUTTON_X:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x4'
   GAME_CONTROL_BUTTON_Y:
     member-of: [GameControlButton]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x8'
   GCNP_GET_WALKABILITY:
     member-of: [GetClosestNavPointParam]
     private: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '2'
   GCNP_RADIUS:
     member-of: [GetClosestNavPointParam]
-    tooltip: ''
+    tooltip: Used with llGetClosestNavPoint to limit how far out to search for a
+      navigation point.
     type: integer
     value: 0
   GCNP_STATIC:
     member-of: [GetClosestNavPointParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   GRAVITY_MULTIPLIER:
     member-of: [PhysicsMaterialParam]
-    tooltip: Used with llSetPhysicsMaterial to enable the gravity multiplier value.
-      Must be between -1.0 and +28.0
+    tooltip: Used with llSetPhysicsMaterial to enable the gravity multiplier
+      override. The value must be between -1.0 and +28.0.
     type: integer
     value: 8
   HORIZONTAL:
     member-of: [CharacterOrientation]
-    tooltip: ''
+    tooltip: Constant indicating that the collision capsule orientation for a
+      pathfinding character is horizontal.
     type: integer
     value: 1
   HTTP_ACCEPT:
     member-of: [HTTPRequestParam]
-    tooltip: "Provide a string value to be included in the HTTP\n            accepts\
-      \ header value. This replaces the default Second Life HTTP accepts header."
+    tooltip: Used with llHTTPRequest to override the default Accept header with
+      custom MIME types (such as application/json, text/html, etc.). Responses
+      with unlisted content types will return status 415.
     type: integer
     value: 8
   HTTP_BODY_MAXLENGTH:
     member-of: [HTTPRequestParam]
-    tooltip: ''
+    tooltip: "Sets the maximum (UTF-8 encoded) byte length of the HTTP response
+      body. The maximum limit depends on the VM being used (Mono Max: 16384
+      bytes, LSO Max: 4096 bytes)."
     type: integer
     value: 2
   HTTP_BODY_TRUNCATED:
     member-of: [HTTPResponseError]
-    tooltip: ''
+    tooltip: Indicates the response body truncation point in bytes.
     type: integer
     value: 0
   HTTP_CUSTOM_HEADER:
     member-of: [HTTPRequestParam]
-    tooltip: Add an extra custom HTTP header to the request. The first string is the
-      name of the parameter to change, e.g. "Pragma", and the second string is the
-      value, e.g. "no-cache". Up to 8 custom headers may be configured per request.
-      Note that certain headers, such as the default headers, are blocked for security
-      reasons.
+    tooltip: Adds a custom HTTP header (name and value pair) to the request. Up to 8
+      custom headers can be configured per request. Some default or sensitive
+      headers are blocked for security reasons.
     type: integer
     value: 5
   HTTP_EXTENDED_ERROR:
     member-of: [HTTPRequestParam]
-    tooltip: Report extended error information through http_response event.
+    tooltip: Enables the reporting of extended error information through the
+      http_response event.
     type: integer
     value: 9
   HTTP_METHOD:
     member-of: [HTTPRequestParam]
-    tooltip: ''
+    tooltip: Specifies the HTTP method ('GET', 'POST', 'PUT', or 'DELETE') for the
+      request.
     type: integer
     value: 0
   HTTP_MIMETYPE:
     member-of: [HTTPRequestParam]
-    tooltip: ''
+    tooltip: Specifies the request Content-Type MIME type. Text types should define
+      a charset (e.g., 'text/plain;charset=utf-8'). Use
+      'application/x-www-form-urlencoded' to emulate HTML forms.
     type: integer
     value: 1
   HTTP_PRAGMA_NO_CACHE:
     member-of: [HTTPRequestParam]
-    tooltip: 'Allows enabling/disabling of the "Pragma: no-cache" header.\nUsage: [HTTP_PRAGMA_NO_CACHE,
-      integer SendHeader]. When SendHeader is TRUE, the "Pragma: no-cache" header
-      is sent by the script. This matches the default behavior. When SendHeader is
-      FALSE, no "Pragma" header is sent by the script.'
+    tooltip: "Controls whether the 'Pragma: no-cache' header is sent with the
+      request. When SendHeader is TRUE (default), the header is sent; when
+      FALSE, it is omitted."
     type: integer
     value: 6
   HTTP_USER_AGENT:
     member-of: [HTTPRequestParam]
-    tooltip: "Provide a string value to be included in the HTTP\n            User-Agent\
-      \ header value. This is appended to the default value."
+    tooltip: Appends a custom string to the default LSL User-Agent header value.
+      Must follow HTTP standard syntax (e.g., 'My-Script-Name/1.0'). Spaces are
+      not allowed and will cause a script error; use hyphens instead.
     type: integer
     value: 7
   HTTP_VERBOSE_THROTTLE:
     member-of: [HTTPRequestParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 4
   HTTP_VERIFY_CERT:
     member-of: [HTTPRequestParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 3
   IMG_USE_BAKED_AUX1:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "9742065b-19b5-297c-858a-29711d539043"
   IMG_USE_BAKED_AUX2:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "03642e83-2bd1-4eb9-34b4-4c47ed586d2d"
   IMG_USE_BAKED_AUX3:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "edd51b77-fc10-ce7a-4b3d-011dfc349e4f"
   IMG_USE_BAKED_EYES:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "52cc6bb6-2ee5-e632-d3ad-50197b1dcb8a"
   IMG_USE_BAKED_HAIR:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "09aac1fb-6bce-0bee-7d44-caac6dbb6c63"
   IMG_USE_BAKED_HEAD:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "5a9f4a74-30f2-821c-b88d-70499d3e7183"
   IMG_USE_BAKED_LEFTARM:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "ff62763f-d60a-9855-890b-0c96f8f8cd98"
   IMG_USE_BAKED_LEFTLEG:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "8e915e25-31d1-cc95-ae08-d58a47488251"
   IMG_USE_BAKED_LOWER:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "24daea5f-0539-cfcf-047f-fbc40b2786ba"
   IMG_USE_BAKED_SKIRT:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "43529ce8-7faa-ad92-165a-bc4078371687"
   IMG_USE_BAKED_UPPER:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "ae2de45c-d252-50b8-5c6e-19f39ce79317"
   INVENTORY_ALL:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to specify that all types of inventory
+      items should be retrieved.
     type: integer
     value: -1
   INVENTORY_ANIMATION:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      ANIMATION type.
     type: integer
     value: 20
   INVENTORY_BODYPART:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      BODYPART type.
     type: integer
     value: 13
   INVENTORY_CLOTHING:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      CLOTHING type.
     type: integer
     value: 5
   INVENTORY_GESTURE:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      GESTURE type.
     type: integer
     value: 21
   INVENTORY_LANDMARK:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      LANDMARK type.
     type: integer
     value: 3
   INVENTORY_MATERIAL:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      MATERIAL type.
     type: integer
     value: 57
   INVENTORY_NONE:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Value returned by inventory functions indicating that the specified
+      inventory item does not exist.
     type: integer
     value: -1
   INVENTORY_NOTECARD:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      NOTECARD type.
     type: integer
     value: 7
   INVENTORY_OBJECT:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the OBJECT
+      type.
     type: integer
     value: 6
   INVENTORY_SCRIPT:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the SCRIPT
+      type.
     type: integer
     value: 10
   INVENTORY_SETTING:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      SETTING type.
     type: integer
     value: 56
   INVENTORY_SOUND:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the SOUND
+      type.
     type: integer
     value: 1
   INVENTORY_TEXTURE:
     member-of: [InventoryType]
-    tooltip: ''
+    tooltip: Used with inventory functions to filter or retrieve items of the
+      TEXTURE type.
     type: integer
     value: 0
   JSON_APPEND:
     slua-deprecated:
       reason: Use 'lljson.decode' and 'table.insert' instead.
-    tooltip: ''
+    tooltip: A specifier for llJsonSetValue indicating the given value should be
+      appended to the array at the specified level. If the target value is not
+      an array, the existing data will be overwritten and replaced by the new
+      array.
     type: integer
     value: -1
   JSON_ARRAY:
     slua-deprecated:
       use: lljson.array_mt
-    tooltip: ''
+    tooltip: Used with llList2Json to indicate that the provided list should be
+      encoded and returned as a string-serialized JSON array.
     type: string
     value: '\u{FDD2}'
   JSON_DELETE:
     slua-deprecated:
       use: nil
-    tooltip: ''
+    tooltip: A constant used to delete a value within a JSON text string.
     type: string
     value: '\u{FDD8}'
   JSON_FALSE:
     slua-deprecated:
       use: "false"
-    tooltip: ''
+    tooltip: Return value for llJsonValueType indicating that the value at the
+      specified address in a JSON string is a boolean FALSE.
     type: string
     value: '\u{FDD7}'
   JSON_INVALID:
     slua-deprecated:
       use: pcall
-    tooltip: ''
+    tooltip: Indicates an invalid state or parameter. Returned by llList2Json when
+      inputs are not well-formed, by llJsonValueType for an invalid JSON type,
+      or by llJsonGetValue when attempting to access a nonexistent location.
     type: string
     value: '\u{FDD0}'
   JSON_NULL:
     slua-deprecated:
       use: lljson.null
-    tooltip: ''
+    tooltip: Return value for llJsonValueType indicating that the value at the
+      specified address in a JSON string is a JSON null.
     type: string
     value: '\u{FDD5}'
   JSON_NUMBER:
     slua-deprecated:
       use: typeof
-    tooltip: ''
+    tooltip: Return value for llJsonValueType indicating that the value at the
+      specified address in a JSON string is a number.
     type: string
     value: '\u{FDD3}'
   JSON_OBJECT:
     slua-deprecated:
       use: lljson.object_mt
-    tooltip: ''
+    tooltip: Used with llList2Json to indicate that the provided list is a strided
+      list of key-value pairs to be encoded and returned as a JSON object.
     type: string
     value: '\u{FDD1}'
   JSON_STRING:
     slua-deprecated:
       use: typeof
-    tooltip: ''
+    tooltip: Return value for llJsonValueType indicating that the value at the
+      specified address in a JSON string is a string.
     type: string
     value: '\u{FDD4}'
   JSON_TRUE:
     slua-deprecated:
       use: "true"
-    tooltip: ''
+    tooltip: Return value for llJsonValueType indicating that the value at the
+      specified address in a JSON string is a boolean TRUE.
     type: string
     value: '\u{FDD6}'
   KFM_CMD_PAUSE:
     member-of: [KeyframedMotionCommand]
-    tooltip: For use with KFM_COMMAND.
+    tooltip: Command used with KFM_COMMAND in llSetKeyframedMotion to pause the
+      keyframed motion without resetting it to the start.
     type: integer
     value: 2
   KFM_CMD_PLAY:
     member-of: [KeyframedMotionCommand]
-    tooltip: For use with KFM_COMMAND.
+    tooltip: Command used with KFM_COMMAND in llSetKeyframedMotion to resume a
+      motion previously stopped by KFM_CMD_STOP or paused by KFM_CMD_PAUSE.
     type: integer
     value: 0
   KFM_CMD_STOP:
     member-of: [KeyframedMotionCommand]
-    tooltip: For use with KFM_COMMAND.
+    tooltip: Command used with KFM_COMMAND in llSetKeyframedMotion to stop the
+      keyframed motion and reset it to the start.
     type: integer
     value: 1
   KFM_COMMAND:
     member-of: [KeyframedMotionParam]
-    tooltip: ''
+    tooltip: Option flag in llSetKeyframedMotion followed by KFM_CMD_STOP,
+      KFM_CMD_PLAY, or KFM_CMD_PAUSE to play, stop, or pause the motion.
     type: integer
     value: 0
   KFM_DATA:
     member-of: [KeyframedMotionParam]
-    tooltip: ''
+    tooltip: Option flag in llSetKeyframedMotion followed by a bitwise combination
+      of KFM_TRANSLATION and KFM_ROTATION to specify keyframe data. If absent,
+      both rotation and translation data must be provided.
     type: integer
     value: 2
   KFM_FORWARD:
     member-of: [KeyframedMotionMode]
-    tooltip: For use with KFM_MODE.
+    tooltip: Playback mode used with KFM_MODE in llSetKeyframedMotion (default). It
+      plays the frames sequentially from 1 to N and then stops.
     type: integer
     value: 0
   KFM_LOOP:
     member-of: [KeyframedMotionMode]
-    tooltip: For use with KFM_MODE.
+    tooltip: Playback mode used with KFM_MODE in llSetKeyframedMotion. It plays the
+      frames sequentially from 1 to N, returns to the initial position, and
+      repeats indefinitely.
     type: integer
     value: 1
   KFM_MODE:
     member-of: [KeyframedMotionParam]
-    tooltip: ''
+    tooltip: Option flag in llSetKeyframedMotion followed by KFM_LOOP, KFM_REVERSE,
+      KFM_FORWARD, or KFM_PING_PONG to set the playback mode (defaults to
+      KFM_FORWARD). Must be specified when the keyframe list is provided.
     type: integer
     value: 1
   KFM_PING_PONG:
     member-of: [KeyframedMotionMode]
-    tooltip: For use with KFM_MODE.
+    tooltip: Playback mode used with KFM_MODE in llSetKeyframedMotion.
     type: integer
     value: 2
   KFM_REVERSE:
     member-of: [KeyframedMotionMode]
-    tooltip: For use with KFM_MODE.
+    tooltip: Playback mode used with KFM_MODE in llSetKeyframedMotion. It plays the
+      frames in reverse order (from N down to 1) and then stops.
     type: integer
     value: 3
   KFM_ROTATION:
     member-of: [KeyframedMotionData]
-    tooltip: For use with KFM_DATA.
+    tooltip: Specifies that rotation data is included in the moves list for
+      llSetKeyframedMotion.
     type: integer
     value: 1
   KFM_TRANSLATION:
     member-of: [KeyframedMotionData]
-    tooltip: For use with KFM_DATA.
+    tooltip: Specifies that translation data is included in the moves list for
+      llSetKeyframedMotion.
     type: integer
     value: 2
   LAND_BRUSH_LARGE:
@@ -2159,560 +2321,638 @@ constants:
     value: 1
   LAND_BRUSH_SMALL:
     member-of: [ModifyLandBrush]
-    tooltip: Use a small brush size
+    tooltip: Use a small brush size.
     type: integer
     value: 0
   LAND_LARGE_BRUSH:
     member-of: [ModifyLandBrush]
     deprecated:
       use: LAND_BRUSH_LARGE
-    tooltip: 'Use a large brush size.\nNOTE: This value is incorrect, a large brush
-      should be 2. Use LAND_BRUSH_LARGE instead'
+    tooltip: "Legacy large brush size (8m x 8m). Note: This constant value is
+      incorrect; use LAND_BRUSH_LARGE instead."
     type: integer
     value: 3
   LAND_LEVEL:
     member-of: [ModifyLandAction]
-    tooltip: Action to level the land.
+    tooltip: Action used with llModifyLand to level the land at the prim's center.
     type: integer
     value: 0
   LAND_LOWER:
     member-of: [ModifyLandAction]
-    tooltip: Action to lower the land.
+    tooltip: Action used with llModifyLand to lower the land.
     type: integer
     value: 2
   LAND_MEDIUM_BRUSH:
     member-of: [ModifyLandBrush]
     deprecated:
       use: LAND_BRUSH_MEDIUM
-    tooltip: 'Use a medium brush size.\nNOTE: This value is incorrect, a medium brush
-      should be 1. Use LAND_BRUSH_MEDIUM instead'
+    tooltip: "Legacy medium brush size (4m x 4m). Note: This constant value is
+      incorrect; use LAND_BRUSH_MEDIUM instead."
     type: integer
     value: 2
   LAND_NOISE:
     member-of: [ModifyLandAction]
-    tooltip: ''
+    tooltip: Action used with llModifyLand to randomize the terrain and make it rough.
     type: integer
     value: 4
   LAND_RAISE:
     member-of: [ModifyLandAction]
-    tooltip: Action to raise the land.
+    tooltip: Action used with llModifyLand to raise the land.
     type: integer
     value: 1
   LAND_REVERT:
     member-of: [ModifyLandAction]
-    tooltip: ''
+    tooltip: Action used with llModifyLand to restore the land to its baked value.
     type: integer
     value: 5
   LAND_SMALL_BRUSH:
     member-of: [ModifyLandBrush]
     deprecated:
       use: LAND_BRUSH_SMALL
-    tooltip: 'Use a small brush size.\nNOTE: This value is incorrect, a small brush
-      should be 0. Use LAND_BRUSH_SMALL instead'
+    tooltip: "Legacy small brush size (2m x 2m). Note: This constant value is
+      incorrect; use LAND_BRUSH_SMALL instead."
     type: integer
     value: 1
   LAND_SMOOTH:
     member-of: [ModifyLandAction]
-    tooltip: ''
+    tooltip: Action used with llModifyLand to smooth the land.
     type: integer
     value: 3
   LEGACY_MASS_FACTOR:
     private: true
-    tooltip: ''
+    tooltip: ""
     type: float
     value: '0.01'
   LINKSETDATA_DELETE:
     member-of: [LinksetDataAction]
-    tooltip: A name:value pair has been removed from the linkset datastore.
+    tooltip: Event or flag indicating a key-value pair has been removed from the
+      linkset datastore, either via llLinksetDataDelete or by writing an empty
+      value.
     type: integer
     value: 2
   LINKSETDATA_EMEMORY:
     member-of: [LinksetDataError]
-    tooltip: A name:value pair was too large to write to the linkset datastore.
+    tooltip: Error code indicating a key-value pair was too large to write to the
+      linkset datastore.
     type: integer
     value: 1
   LINKSETDATA_ENOKEY:
     member-of: [LinksetDataError]
-    tooltip: The key supplied was empty.
+    tooltip: Error code indicating the key name supplied to a linkset datastore
+      operation was empty.
     type: integer
     value: 2
   LINKSETDATA_EPROTECTED:
     member-of: [LinksetDataError]
-    tooltip: The name:value pair has been protected from overwrite in the linkset
-      datastore.
+    tooltip: Error code indicating the key-value pair is protected from being
+      deleted or overwritten in the linkset datastore.
     type: integer
     value: 3
   LINKSETDATA_MULTIDELETE:
     member-of: [LinksetDataAction]
-    tooltip: A CSV list of names removed from the linkset datastore.
+    tooltip: Flag or value indicating a comma-separated list of keys has been
+      deleted from the linkset datastore via llLinksetDataDeleteFound.
     type: integer
     value: 3
   LINKSETDATA_NOTFOUND:
     member-of: [LinksetDataError]
-    tooltip: The named key was not found in the datastore.
+    tooltip: Error code indicating the specified key could not be found in the
+      linkset datastore.
     type: integer
     value: 4
   LINKSETDATA_NOUPDATE:
     member-of: [LinksetDataError]
-    tooltip: The value written to a name in the keystore is the same as the value
-      already there.
+    tooltip: Status code indicating that the linkset datastore was not updated
+      because the written value matched the existing stored value.
     type: integer
     value: 5
   LINKSETDATA_OK:
     member-of: [LinksetDataError]
-    tooltip: The name:value pair was written to the datastore.
+    tooltip: Status code indicating the linkset datastore operation completed
+      successfully.
     type: integer
     value: 0
   LINKSETDATA_RESET:
     member-of: [LinksetDataAction]
-    tooltip: The linkset datastore has been reset.
+    tooltip: Event or flag indicating the linkset datastore has been cleared/reset
+      via llLinksetDataReset.
     type: integer
     value: 0
   LINKSETDATA_UPDATE:
     member-of: [LinksetDataAction]
-    tooltip: A name:value pair in the linkset datastore has been changed or created.
+    tooltip: Event or flag indicating a key in the linkset datastore has been
+      created or updated with a new value via llLinksetDataWrite.
     type: integer
     value: 1
   LINK_ALL_CHILDREN:
     member-of: [Links]
-    tooltip: This targets every object except the root in the linked set.
+    tooltip: Refers to all child prims in the linkset (every prim except the root).
     type: integer
     value: -3
   LINK_ALL_OTHERS:
     member-of: [Links]
-    tooltip: This targets every object in the linked set except the object with the
-      script.
+    tooltip: Refers to every other prim in the linkset, excluding the prim
+      containing the script.
     type: integer
     value: -2
   LINK_ROOT:
     member-of: [Link, Links]
-    tooltip: This targets the root of the linked set.
+    tooltip: Refers to the root prim of the linkset.
     type: integer
     value: 1
   LINK_SET:
     member-of: [Links]
-    tooltip: This targets every object in the linked set.
+    tooltip: Refers to every prim in the linkset.
     type: integer
     value: -1
   LINK_THIS:
     member-of: [Link, Links]
-    tooltip: The link number of the prim containing the script.
+    tooltip: Refers specifically to the single prim containing the running script.
     type: integer
     value: -4
   LIST_STAT_GEOMETRIC_MEAN:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the geometric mean of a
+      list of numbers.
     type: integer
     value: 9
   LIST_STAT_MAX:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to find the largest number in the list.
     type: integer
     value: 2
   LIST_STAT_MEAN:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the mean (average) of
+      the numbers in the list.
     type: integer
     value: 3
   LIST_STAT_MEDIAN:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the median of the
+      numbers in the list.
     type: integer
     value: 4
   LIST_STAT_MIN:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to find the smallest number in the list.
     type: integer
     value: 1
   LIST_STAT_NUM_COUNT:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to determine the count of float and
+      integer elements in the list.
     type: integer
     value: 8
   LIST_STAT_RANGE:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the range (maximum value
+      minus minimum value) of the list.
     type: integer
     value: 0
   LIST_STAT_STD_DEV:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the sample standard
+      deviation of a list of numbers.
     type: integer
     value: 5
   LIST_STAT_SUM:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the sum of the numbers
+      in the list.
     type: integer
     value: 6
   LIST_STAT_SUM_SQUARES:
     member-of: [ListStatisticsOperation]
-    tooltip: ''
+    tooltip: Option used with llListStatistics to calculate the sum of the squares
+      of the numbers in the list.
     type: integer
     value: 7
   LOOP:
     member-of: [TextureAnimMode]
-    tooltip: Loop the texture animation.
+    tooltip: Used with texture animation functions to cause the animation to loop
+      continuously.
     type: integer
     value: '0x2'
   MASK_BASE:
     member-of: [AssetPermissionCategory]
-    tooltip: ''
+    tooltip: Permissions mask option representing base permissions.
     type: integer
     value: 0
   MASK_COMBINED:
     member-of: [AssetPermissionCategoryFlag]
-    tooltip: Fold permissions for object inventory into results.
+    tooltip: Permissions mask option to include the object's inventory contents when
+      calculating permissions. Can be combined with other mask flags (e.g.,
+      MASK_OWNER | MASK_COMBINED).
     type: integer
     value: '0x10'
   MASK_EVERYONE:
     member-of: [AssetPermissionCategory]
-    tooltip: ''
+    tooltip: Permissions mask option representing permissions held by everyone.
     type: integer
     value: 3
   MASK_GROUP:
     member-of: [AssetPermissionCategory]
-    tooltip: ''
+    tooltip: Permissions mask option representing active group permissions.
     type: integer
     value: 2
   MASK_NEXT:
     member-of: [AssetPermissionCategory]
-    tooltip: ''
+    tooltip: Permissions mask option representing permissions the next owner will
+      inherit.
     type: integer
     value: 4
   MASK_OWNER:
     member-of: [AssetPermissionCategory]
-    tooltip: ''
+    tooltip: Permissions mask option representing current owner permissions.
     type: integer
     value: 1
   NAK:
-    tooltip: Indicates a notecard read was attempted and the notecard was not yet
-      cached on the server.
+    tooltip: Value returned by llGetNotecardLineSync (ASCII NAK surrounded by
+      newlines, i.e., codes 10, 21, 10) when requested notecard data is not in
+      the region's cache.
     type: string
     value: '\n\x15\n'
   NAVIGATE_TO_GOAL_REACHED_DIST:
     member-of: [CharacterNavigateParam]
     private: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   NULL_KEY:
-    tooltip: ''
+    tooltip: A special string constant used as a null or empty key value.
     type: string
     slua-type: uuid
     value: "00000000-0000-0000-0000-000000000000"
   OBJECT_ACCOUNT_LEVEL:
     member-of: [ObjectDetailsParam]
-    tooltip: Retrieves the account level of an avatar.\nReturns 0 when the avatar
-      has a basic account,\n 1 when the avatar has a premium account,\n 10 when the
-      avatar has a premium plus account,\n or -1 if the object is not an avatar.
+    tooltip: Flag used with llGetObjectDetails to retrieve an avatar's account
+      level. Returns 0 for Basic, 1 for Premium, 5 for Plus, 10 for Premium
+      Plus, or -1 if the target is not an avatar.
     type: integer
     value: 41
   OBJECT_ANIMATED_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the number of associated
-      animated objects
+    tooltip: Flag used with llGetObjectDetails. For an object, returns a boolean
+      indicating if the root is set as 'Animated Mesh'. For an agent, returns
+      the total number of 'Animated Mesh' attachments worn.
     type: integer
     value: 39
   OBJECT_ANIMATED_SLOTS_AVAILABLE:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the number of additional
-      animated object attachments allowed.
+    tooltip: Flag used with llGetObjectDetails to get the avatar's available
+      'Animated Mesh' attachment slot count (returns 0 if the ID is not an
+      avatar).
     type: integer
     value: 40
   OBJECT_ATTACHED_POINT:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the attachment point to which the object is attached.\nReturns 0
-      if the object is not an attachment (or is an avatar, etc).
+    tooltip: Flag used with llGetObjectDetails. Returns the integer attachment point
+      matching an ATTACH_* constant, or 0 if the target is not an attachment
+      (e.g., an avatar or unattached object).
     type: integer
     value: 19
   OBJECT_ATTACHED_SLOTS_AVAILABLE:
     member-of: [ObjectDetailsParam]
-    tooltip: Returns the number of attachment slots available.\nReturns 0 if the object
-      is not an avatar or none are available.
+    tooltip: Flag used with llGetObjectDetails to get an avatar's available
+      attachment slot count. Returns 0 if the ID is not an avatar or if no slots
+      are available.
     type: integer
     value: 35
   OBJECT_BODY_SHAPE_TYPE:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the body type of the
-      avatar, based on shape data.\nIf no data is available, -1.0 is returned.\nThis
-      is normally between 0 and 1.0, with 0.5 and larger considered 'male'
+    tooltip: Flag used with llGetObjectDetails to retrieve a float representing the
+      gender/sex setting of an avatar's shape (0.0 is standard female, 1.0 is
+      standard male, and values greater than or equal to 0.5 are considered
+      male). Returns -1.0 if not an avatar or if no data is available.
     type: integer
     value: 26
   OBJECT_CHARACTER_TIME:
     member-of: [ObjectDetailsParam]
-    tooltip: Units in seconds
+    tooltip: Flag used with llGetObjectDetails to get the average CPU time (in
+      seconds) spent on navigation if the target is a pathfinding character.
+      Returns 0 for non-characters.
     type: integer
     value: 17
   OBJECT_CLICK_ACTION:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the click action.\nThe
-      default is 0
+    tooltip: Flag used with llGetObjectDetails to get the click action of a prim.
+      Returns an integer corresponding to a CLICK_ACTION_* constant (default is
+      0).
     type: integer
     value: 28
   OBJECT_CREATION_TIME:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the time this object
-      was created
+    tooltip: Flag used with llGetObjectDetails to get the object's creation time
+      (established via build-menu rezzing or mesh uploads, not via
+      inventory/script rezzes, copying, or modifying). Returns an empty string
+      for avatars.
     type: integer
     value: 36
   OBJECT_CREATOR:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's creator key. If id is an avatar, a NULL_KEY is returned.
+    tooltip: Flag used with llGetObjectDetails to get the key of the prim's creator.
+      Returns NULL_KEY if the ID is an avatar.
     type: integer
     value: 8
   OBJECT_DAMAGE:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the damage value assigned to this object.
+    tooltip: Flag used with llGetObjectDetails to retrieve the amount of damage a
+      prim inflicts upon collision.
     type: integer
     value: 51
   OBJECT_DAMAGE_TYPE:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the damage type, if any, assigned to this object.
+    tooltip: Flag used with llGetObjectDetails to retrieve the type of damage a prim
+      inflicts on collision. Returns an integer matching a DAMAGE_TYPE_*
+      constant, a custom type, or a value repurposed by a combat system.
     type: integer
     value: 52
   OBJECT_DESC:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's description. If id is an avatar, an empty string is
-      returned.
+    tooltip: Flag used with llGetObjectDetails to retrieve the prim's description.
+      Returns an empty string if the ID is an avatar.
     type: integer
     value: 2
   OBJECT_GROUP:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the prims's group key. If id is an avatar, a NULL_KEY is returned.
+    tooltip: Flag used with llGetObjectDetails to get the prim's group key. Returns
+      NULL_KEY if the target is an avatar (which means a workaround is required
+      to get an avatar's active group).
     type: integer
     value: 7
   OBJECT_GROUP_TAG:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the agent's current group role tag. If id is an object, an empty
-      is returned.
+    tooltip: Flag used with llGetObjectDetails to get an avatar's active group
+      tag/title. Returns an empty string if the target is not an avatar.
     type: integer
     value: 33
   OBJECT_HEALTH:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets current health value for the object.
+    tooltip: Flag used with llGetObjectDetails to retrieve the current health value
+      of an avatar or prim.
     type: integer
     value: 50
   OBJECT_HOVER_HEIGHT:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get hover height of the
-      avatar\nIf no data is available, 0.0 is returned.
+    tooltip: Flag used with llGetObjectDetails to get the dynamic hover height of an
+      avatar (default is 0.0). Returns 0.0 if not an avatar or if no data is
+      available; does not reflect the shape's 'Hover' slider.
     type: integer
     value: 25
   OBJECT_LAST_OWNER_ID:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's last owner ID.
+    tooltip: Flag used with llGetObjectDetails to get the key of the previous owner.
+      For group-owned objects, returns the avatar who deeded it. Returns
+      NULL_KEY for avatars, untransferred objects, or objects taken to inventory
+      and re-rezzed.
     type: integer
     value: 27
   OBJECT_LINK_NUMBER:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's link number or 0 if unlinked.
+    tooltip: Flag used with llGetObjectDetails to get the index of the prim within
+      its linkset, or 0 if unlinked.
     type: integer
     value: 46
   OBJECT_MASS:
     member-of: [ObjectDetailsParam]
-    tooltip: Get the object's mass
+    tooltip: Flag used with llGetObjectDetails to retrieve the total mass (in
+      kilograms) of the object's linkset.
     type: integer
     value: 43
   OBJECT_MATERIAL:
     member-of: [ObjectDetailsParam]
-    tooltip: Get an object's material setting.
+    tooltip: Flag used with llGetObjectDetails to retrieve the physics material of
+      the object, returning an integer matching a PRIM_MATERIAL_* constant.
     type: integer
     value: 42
   OBJECT_NAME:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's name.
+    tooltip: Flag used with llGetObjectDetails to get the prim's name, or the legacy
+      name if the target is an avatar.
     type: integer
     value: 1
   OBJECT_OMEGA:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets an object's angular velocity.
+    tooltip: Flag used with llGetObjectDetails to get the rotational (angular)
+      velocity of an object in radians per second.
     type: integer
     value: 29
   OBJECT_OWNER:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets an object's owner's key. If id is group owned, a NULL_KEY is returned.
+    tooltip: Flag used with llGetObjectDetails to get the owner's key. If the target
+      is an avatar, their own key is returned. If group-owned, it returns
+      NULL_KEY.
     type: integer
     value: 6
   OBJECT_PATHFINDING_TYPE:
     member-of: [ObjectDetailsParam]
-    tooltip: Returns the pathfinding setting of any object in the region. It returns
-      an integer matching one of the OPT_* constants.
+    tooltip: Flag used with llGetObjectDetails to get the pathfinding setting of an
+      object in the region, returning an integer matching an OPT_* constant.
     type: integer
     value: 20
   OBJECT_PERMS:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the objects permissions
+    tooltip: Flag used with llGetObjectDetails to retrieve the permissions of the
+      object as five integers.
     type: integer
     value: 53
   OBJECT_PERMS_COMBINED:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's permissions including any inventory.
+    tooltip: Flag used with llGetObjectDetails to retrieve the permissions of the
+      object combined with all of its inventory items as five integers.
     type: integer
     value: 54
   OBJECT_PHANTOM:
     member-of: [ObjectDetailsParam]
-    tooltip: Returns boolean, detailing if phantom is enabled or disabled on the object.\nIf
-      id is an avatar or attachment, 0 is returned.
+    tooltip: Flag used with llGetObjectDetails to get a boolean indicating if
+      phantom is enabled on the object. Returns 0 if the target is an avatar or
+      attachment.
     type: integer
     value: 22
   OBJECT_PHYSICS:
     member-of: [ObjectDetailsParam]
-    tooltip: Returns boolean, detailing if physics is enabled or disabled on the object.\nIf
-      id is an avatar or attachment, 0 is returned.
+    tooltip: Flag used with llGetObjectDetails to get a boolean indicating if
+      physics is enabled on the object. Returns 0 if the target is an avatar or
+      attachment.
     type: integer
     value: 21
   OBJECT_PHYSICS_COST:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the physics cost of the object.
     type: integer
     value: 16
   OBJECT_POS:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's position in region coordinates.
+    tooltip: Flag used with llGetObjectDetails to get the prim's position in region
+      coordinates. For an avatar outside the region, the returned position is
+      relative to the script's region.
     type: integer
     value: 3
   OBJECT_PRIM_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the prim count of the object.  The script and target object  must
-      be owned by the same owner
+    tooltip: Flag used with llGetObjectDetails to get the prim count of the object.
+      Note that the script and target object must be owned by the same owner.
     type: integer
     value: 30
   OBJECT_PRIM_EQUIVALENCE:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the prim equivalence of the
+      object.
     type: integer
     value: 13
   OBJECT_RENDER_WEIGHT:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the Avatar_Rendering_Cost
-      of an avatar, based on values reported by nearby viewers.\nIf no data is available,
-      -1 is returned.\nThe maximum render weight stored by the simulator is 500000.
-      When called against an object, 0 is returned.
+    tooltip: Flag used with llGetObjectDetails to get the render weight (Avatar
+      Rendering Cost) of an avatar based on viewer reports. Returns 0 for
+      objects, -1 if unknown, and is capped at 500,000.
     type: integer
     value: 24
   OBJECT_RETURN_PARCEL:
     member-of: [ReturnObjectsScope]
-    tooltip: ''
+    tooltip: Scope flag used with llReturnObjectsByOwner to return all objects on
+      the same parcel as the script owned by the specified owner. Requires the
+      script owner to be an estate manager or the parcel owner.
     type: integer
     value: 1
   OBJECT_RETURN_PARCEL_OWNER:
     member-of: [ReturnObjectsScope]
-    tooltip: ''
+    tooltip: Scope flag used with llReturnObjectsByOwner to return all objects owned
+      by the specified owner that are located on parcels owned by the script's
+      owner.
     type: integer
     value: 2
   OBJECT_RETURN_REGION:
     member-of: [ReturnObjectsScope]
-    tooltip: ''
+    tooltip: Scope flag used with llReturnObjectsByOwner to return all objects in
+      the region owned by the specified owner. Only works if the script is owned
+      by the estate owner or an estate manager.
     type: integer
     value: 4
   OBJECT_REZZER_KEY:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to retrieve the key of the object or
+      avatar that rezzed the target object.
     type: integer
     value: 32
   OBJECT_REZ_TIME:
     member-of: [ObjectDetailsParam]
-    tooltip: Get the time when an object was rezzed.
+    tooltip: Flag used with llGetObjectDetails to retrieve the timestamp of when the
+      object was rezzed.
     type: integer
     value: 45
   OBJECT_ROOT:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the id of the root prim of the object requested.\nIf id is an avatar,
-      return the id of the root prim of the linkset the avatar is sitting on (or the
-      avatar's own id if the avatar is not sitting on an object within the region).
+    tooltip: Flag used with llGetObjectDetails to get the ID of the root prim. For
+      an avatar, returns the root prim of the linkset they are sitting on (or
+      the avatar's own ID if not sitting).
     type: integer
     value: 18
   OBJECT_ROT:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's rotation.
+    tooltip: Flag used with llGetObjectDetails to get the prim's rotation.
     type: integer
     value: 4
   OBJECT_RUNNING_SCRIPT_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the total number of running
+      scripts attached to the target object or agent.
     type: integer
     value: 9
   OBJECT_SCALE:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's size.
+    tooltip: Flag used with llGetObjectDetails to get the size (scale) of the object.
     type: integer
     value: 47
   OBJECT_SCRIPT_MEMORY:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the allocated script memory
+      (or its upper limit) in bytes for the object or agent. This value is
+      recomputed every 10-20 seconds.
     type: integer
     value: 11
   OBJECT_SCRIPT_TIME:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the average script CPU time
+      (in seconds) used per frame. Reports a 30-minute average, or the average
+      since entering the region if present for less than 30 minutes.
     type: integer
     value: 12
   OBJECT_SELECT_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the number of avatars
-      selecting any part of the object
+    tooltip: Flag used with llGetObjectDetails to get the total number of
+      agents/avatars actively selecting any link in the object. Returns 0 if the
+      target is an avatar.
     type: integer
     value: 37
   OBJECT_SERVER_COST:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the server cost of the object.
     type: integer
     value: 14
   OBJECT_SIT_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: This is a flag used with llGetObjectDetails to get the number of avatars
-      sitting on the object
+    tooltip: Flag used with llGetObjectDetails to get the total number of agents
+      sitting on any links in the object. Returns 0 if the target is an avatar.
     type: integer
     value: 38
   OBJECT_STREAMING_COST:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the streaming (download) cost
+      of the object.
     type: integer
     value: 15
   OBJECT_TEMP_ATTACHED:
     member-of: [ObjectDetailsParam]
-    tooltip: Returns boolean, indicating if object is a temp attachment.
+    tooltip: Flag used with llGetObjectDetails to get a boolean indicating whether
+      the object is temporarily attached.
     type: integer
     value: 34
   OBJECT_TEMP_ON_REZ:
     member-of: [ObjectDetailsParam]
-    tooltip: Returns boolean, detailing if temporary is enabled or disabled on the
-      object.
+    tooltip: Flag used with llGetObjectDetails to get a boolean indicating if
+      temporary-on-rez is enabled for the object.
     type: integer
     value: 23
   OBJECT_TEXT:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets an objects hover text.
+    tooltip: Flag used with llGetObjectDetails to get the floating (hover) text
+      displayed above the object.
     type: integer
     value: 44
   OBJECT_TEXT_ALPHA:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the alpha of an objects hover text.
+    tooltip: Flag used with llGetObjectDetails to get the alpha value of the
+      floating (hover) text displayed above the object.
     type: integer
     value: 49
   OBJECT_TEXT_COLOR:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the color of an objects hover text.
+    tooltip: Flag used with llGetObjectDetails to get the color vector of the
+      floating (hover) text displayed above the object.
     type: integer
     value: 48
   OBJECT_TOTAL_INVENTORY_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the total inventory count of the object.  The script and target
-      object must be owned by the same owner
+    tooltip: Flag used with llGetObjectDetails to get the total number of inventory
+      items inside the object. Requires the script and target object to share
+      the same owner.
     type: integer
     value: 31
   OBJECT_TOTAL_SCRIPT_COUNT:
     member-of: [ObjectDetailsParam]
-    tooltip: ''
+    tooltip: Flag used with llGetObjectDetails to get the total number of scripts
+      (both running and stopped) attached to the target object or agent.
     type: integer
     value: 10
   OBJECT_UNKNOWN_DETAIL:
-    tooltip: ''
+    tooltip: Flag returned by llGetObjectDetails when an invalid flag is requested.
     type: integer
     value: -1
   OBJECT_VELOCITY:
     member-of: [ObjectDetailsParam]
-    tooltip: Gets the object's velocity.
+    tooltip: Flag used with llGetObjectDetails to get the velocity vector of the
+      target object.
     type: integer
     value: 5
   OPT_AVATAR:
@@ -2732,8 +2972,8 @@ constants:
     value: 6
   OPT_LEGACY_LINKSET:
     member-of: [ObjectPathfindingType]
-    tooltip: Returned for movable obstacles, movable phantoms, physical, and volumedetect
-      objects.
+    tooltip: Returned for movable obstacles, movable phantoms, physical, and
+      volumedetect objects.
     type: integer
     value: 0
   OPT_MATERIAL_VOLUME:
@@ -2758,787 +2998,912 @@ constants:
     value: 3
   OVERRIDE_GLTF_BASE_ALPHA:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
+      for the face(s). Only impacts rendering when the alpha mode is set to
+      PRIM_GLTF_ALPHA_MODE_BLEND.
     type: integer
     value: 2
   OVERRIDE_GLTF_BASE_ALPHA_MASK:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
+      cutoff level on the face(s) when the alpha mode is set to mask.
     type: integer
     value: 4
   OVERRIDE_GLTF_BASE_ALPHA_MODE:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
+      mode on the face(s) to one of the valid blend modes.
     type: integer
     value: 3
   OVERRIDE_GLTF_BASE_COLOR_FACTOR:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the
+      tinting color (specified in linear RGB) used for the base color. Use
+      llsRGB2Linear to convert colors from Blinn-Phong to PBR.
     type: integer
     value: 1
   OVERRIDE_GLTF_BASE_DOUBLE_SIDED:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides. If set to TRUE,
+      the texture on the face(s) will be rendered as double-sided.
     type: integer
     value: 5
   OVERRIDE_GLTF_EMISSIVE_FACTOR:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the tint
+      (specified in linear RGB) used for the emissive texture on the face(s).
     type: integer
     value: 8
   OVERRIDE_GLTF_METALLIC_FACTOR:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to adjust the
+      metallic factor on the specified face(s) to a value between 0 and 1.
     type: integer
     value: 6
   OVERRIDE_GLTF_ROUGHNESS_FACTOR:
     member-of: [GLTFOverride]
-    tooltip: ''
+    tooltip: GLTF override setting used with llSetLinkGLTFOverrides to adjust the
+      roughness factor on the specified face(s) to a value between 0 and 1.
     type: integer
     value: 7
   PARCEL_COUNT_GROUP:
     member-of: [ParcelPrimCountCategory]
-    tooltip: ''
+    tooltip: Used with llGetParcelPrimCount to get the total land impact of objects
+      not owned by the parcel owner but set to or owned by the parcel's group.
     type: integer
     value: 2
   PARCEL_COUNT_OTHER:
     member-of: [ParcelPrimCountCategory]
-    tooltip: ''
+    tooltip: Used with llGetParcelPrimCount to get the land impact of all objects
+      that are neither owned by the parcel owner nor set to or owned by the
+      parcel's group.
     type: integer
     value: 3
   PARCEL_COUNT_OWNER:
     member-of: [ParcelPrimCountCategory]
-    tooltip: ''
+    tooltip: Used with llGetParcelPrimCount to get the total land impact of objects
+      owned by the parcel owner.
     type: integer
     value: 1
   PARCEL_COUNT_SELECTED:
     member-of: [ParcelPrimCountCategory]
-    tooltip: ''
+    tooltip: Used with llGetParcelPrimCount to get the total land impact of all
+      objects currently selected or sat on.
     type: integer
     value: 4
   PARCEL_COUNT_TEMP:
     member-of: [ParcelPrimCountCategory]
-    tooltip: ''
+    tooltip: Used with llGetParcelPrimCount to get the total land impact of
+      temporary (temp-on-rez) objects.
     type: integer
     value: 5
   PARCEL_COUNT_TOTAL:
     member-of: [ParcelPrimCountCategory]
-    tooltip: ''
+    tooltip: Used with llGetParcelPrimCount to get the total land impact of all
+      objects on the parcel(s), excluding temporary (temp-on-rez) objects.
     type: integer
     value: 0
   PARCEL_DETAILS_AREA:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel's area, in square meters. (5 chars.).
+    tooltip: Flag used with llGetParcelDetails to retrieve the parcel's area in
+      square meters (sqm).
     type: integer
     value: 4
   PARCEL_DETAILS_DESC:
     member-of: [ParcelDetailsParam]
-    tooltip: The description of the parcel. (127 chars).
+    tooltip: Flag used with llGetParcelDetails to retrieve the description of the
+      parcel (up to 127 characters).
     type: integer
     value: 1
   PARCEL_DETAILS_FLAGS:
     member-of: [ParcelDetailsParam]
-    tooltip: Flags set on the parcel
+    tooltip: Flag used with llGetParcelDetails to retrieve the parcel flags set on
+      this parcel (see llGetParcelFlags for listings and meanings).
     type: integer
     value: 12
   PARCEL_DETAILS_GROUP:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel group's key. (36 chars.).
+    tooltip: Flag used with llGetParcelDetails to retrieve the parcel group's
+      36-character key.
     type: integer
     value: 3
   PARCEL_DETAILS_ID:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel's key. (36 chars.).
+    tooltip: Flag used with llGetParcelDetails to retrieve the parcel's 36-character
+      UUID/key.
     type: integer
     value: 5
   PARCEL_DETAILS_LANDING_LOOKAT:
     member-of: [ParcelDetailsParam]
-    tooltip: Lookat vector set for teleport routing.
+    tooltip: Flag used with llGetParcelDetails to retrieve the lookat vector set for
+      the landing point (teleport routing) on this parcel, if any.
     type: integer
     value: 10
   PARCEL_DETAILS_LANDING_POINT:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel's landing point, if any.
+    tooltip: Flag used with llGetParcelDetails to retrieve the landing point vector
+      set for this parcel, if any.
     type: integer
     value: 9
   PARCEL_DETAILS_NAME:
     member-of: [ParcelDetailsParam]
-    tooltip: The name of the parcel. (63 chars.).
+    tooltip: Flag used with llGetParcelDetails to retrieve the name of the parcel
+      (up to 63 characters).
     type: integer
     value: 0
   PARCEL_DETAILS_OWNER:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel owner's key. (36 chars.).
+    tooltip: Flag used with llGetParcelDetails to retrieve the parcel owner's
+      36-character key.
     type: integer
     value: 2
   PARCEL_DETAILS_PRIM_CAPACITY:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel's prim capacity.
+    tooltip: Flag used with llGetParcelDetails to retrieve the total prim capacity
+      on this and all same-owner parcels, sim-wide (see llGetParcelMaxPrims for
+      same-parcel-only and/or sim-wide reporting).
     type: integer
     value: 7
   PARCEL_DETAILS_PRIM_USED:
     member-of: [ParcelDetailsParam]
-    tooltip: The number of prims used on this parcel.
+    tooltip: Flag used with llGetParcelDetails to retrieve the total prim usage on
+      this and all same-owner parcels, sim-wide (see llGetParcelPrimCount to get
+      prim counts by owner, group, or temporary status).
     type: integer
     value: 8
   PARCEL_DETAILS_SCRIPT_DANGER:
     member-of: [ParcelDetailsParam]
-    tooltip: There are restrictions on this parcel that may impact script execution.
+    tooltip: Flag used with llGetParcelDetails to check if the script is in danger
+      (due to restrictions that impact script execution) on the indicated
+      parcel; see llScriptDanger.
     type: integer
     value: 13
   PARCEL_DETAILS_SEE_AVATARS:
     member-of: [ParcelDetailsParam]
-    tooltip: The parcel's avatar visibility setting. (1 char.).
+    tooltip: Flag used with llGetParcelDetails to retrieve the 'See and chat with
+      residents on this parcel' avatar visibility setting.
     type: integer
     value: 6
   PARCEL_DETAILS_TP_ROUTING:
     member-of: [ParcelDetailsParam]
-    tooltip: Parcel's teleport routing setting.
+    tooltip: Flag used with llGetParcelDetails to retrieve the teleport routing
+      setting for this parcel (0 = TP_ROUTING_BLOCKED, 1 = TP_ROUTING_LANDINGP,
+      2 = TP_ROUTING_FREE; rules are only enforced if a landing point is set).
     type: integer
     value: 11
   PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel allows all
+      objects to enter.
     type: integer
     value: '0x08000000'
   PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if group members or scripts in
+      group-deeded objects are allowed to create/rez objects on the parcel.
     type: integer
     value: '0x4000000'
   PARCEL_FLAG_ALLOW_CREATE_OBJECTS:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel allows anyone to
+      create objects.
     type: integer
     value: '0x40'
   PARCEL_FLAG_ALLOW_DAMAGE:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if damage is enabled on the
+      parcel.
     type: integer
     value: '0x20'
   PARCEL_FLAG_ALLOW_FLY:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if flying is allowed on the
+      parcel.
     type: integer
     value: '0x1'
   PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel restricts object
+      entry to only group-owned and owner-owned objects.
     type: integer
     value: '0x10000000'
   PARCEL_FLAG_ALLOW_GROUP_SCRIPTS:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel allows scripts
+      owned by the parcel's group to run.
     type: integer
     value: '0x2000000'
   PARCEL_FLAG_ALLOW_LANDMARK:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel allows landmarks
+      to be created.
     type: integer
     value: '0x8'
   PARCEL_FLAG_ALLOW_SCRIPTS:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if scripts (including outside
+      scripts) are allowed to run on the parcel.
     type: integer
     value: '0x2'
   PARCEL_FLAG_ALLOW_TERRAFORM:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel allows anyone to
+      terraform the land.
     type: integer
     value: '0x10'
   PARCEL_FLAG_LINDEN_HOMES:
     member-of: [ParcelFlag]
     private: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x800000'
   PARCEL_FLAG_LOCAL_SOUND_ONLY:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel restricts
+      spatialized sounds to the parcel (preventing outside sound from being
+      heard inside).
     type: integer
     value: '0x8000'
   PARCEL_FLAG_RESTRICT_PUSHOBJECT:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel restricts the
+      use of llPushObject by non-owners (or non-group officers if group-owned).
     type: integer
     value: '0x200000'
   PARCEL_FLAG_USE_ACCESS_GROUP:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel limits access to
+      group members.
     type: integer
     value: '0x100'
   PARCEL_FLAG_USE_ACCESS_LIST:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel limits access to
+      a specific list of residents (avatars).
     type: integer
     value: '0x200'
   PARCEL_FLAG_USE_BAN_LIST:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel uses a ban list
+      (including restricting access based on payment information).
     type: integer
     value: '0x400'
   PARCEL_FLAG_USE_LAND_PASS_LIST:
     member-of: [ParcelFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetParcelFlags to check if the parcel restricts access
+      via purchasable land passes (sold for L$).
     type: integer
     value: '0x800'
   PARCEL_MEDIA_COMMAND_AGENT:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to apply the specified media
+      command to the designated agent only.
     type: integer
     value: 7
   PARCEL_MEDIA_COMMAND_AUTO_ALIGN:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to toggle or set the parcel
+      media option 'Auto scale content'.
     type: integer
     value: 9
   PARCEL_MEDIA_COMMAND_DESC:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
-    tooltip: Use this to get or set the parcel media description.
+    tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+      or set the parcel media description.
     type: integer
     value: 12
   PARCEL_MEDIA_COMMAND_LOOP:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to start the media stream
+      playing from the current frame and have it loop back to the beginning when
+      it reaches the end.
     type: integer
     value: 3
   PARCEL_MEDIA_COMMAND_LOOP_SET:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
-    tooltip: Used to get or set the parcel's media looping variable.
+    tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+      or set the parcel's media looping variable or loop duration (which may
+      have functionality limitations; see VWR-19712).
     type: integer
     value: 13
   PARCEL_MEDIA_COMMAND_PAUSE:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to pause the media stream on
+      the current frame.
     type: integer
     value: 1
   PARCEL_MEDIA_COMMAND_PLAY:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to play the media stream
+      from its current frame, stopping when the end is reached.
     type: integer
     value: 2
   PARCEL_MEDIA_COMMAND_SIZE:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
-    tooltip: Use this to get or set the parcel media pixel resolution.
+    tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+      or set the parcel media pixel resolution.
     type: integer
     value: 11
   PARCEL_MEDIA_COMMAND_STOP:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to stop the media stream and
+      rewind it to the first frame.
     type: integer
     value: 0
   PARCEL_MEDIA_COMMAND_TEXTURE:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+      or set the parcel's media texture.
     type: integer
     value: 4
   PARCEL_MEDIA_COMMAND_TIME:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to jump to a specific
+      timestamp in the media stream, specified in floating-point seconds.
     type: integer
     value: 6
   PARCEL_MEDIA_COMMAND_TYPE:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
-    tooltip: Use this to get or set the parcel media MIME type (e.g. "text/html").
+    tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+      or set the parcel media MIME type (e.g., 'text/html').
     type: integer
     value: 10
   PARCEL_MEDIA_COMMAND_UNLOAD:
     member-of: [ParcelMediaCommand]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList to completely unload the
+      media and restore the face's original texture.
     type: integer
     value: 8
   PARCEL_MEDIA_COMMAND_URL:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
-    tooltip: ''
+    tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+      or set the parcel's media URL.
     type: integer
     value: 5
   PARCEL_SALE_AGENT:
     member-of: [ParcelSaleParam]
-    tooltip: The agent authorized to purchase the parcel.
+    tooltip: Option used with llSetParcelForSale to specify the agent ID authorized
+      to buy the parcel. If none is set, any agent can purchase it.
     type: integer
     value: 2
   PARCEL_SALE_OBJECTS:
     member-of: [ParcelSaleParam]
-    tooltip: Are the objects on the parcel included in the sale?
+    tooltip: Option used with llSetParcelForSale. If set to TRUE, objects on the
+      parcel are included in the sale.
     type: integer
     value: 3
   PARCEL_SALE_PRICE:
     member-of: [ParcelSaleParam]
-    tooltip: The price of the parcel. If no authorized agent is set, must be greater than 0.
+    tooltip: Option used with llSetParcelForSale to set the parcel price. If no
+      authorized agent is set, the price must be greater than 0.
     type: integer
     value: 1
   PARCEL_SALE_OK:
     member-of: [ParcelSaleError]
-    tooltip: The sale information was successfully set.
+    tooltip: Status code indicating the parcel sale information was successfully set.
     type: integer
     value: 0
   PARCEL_SALE_ERROR_NO_PARCEL:
     member-of: [ParcelSaleError]
-    tooltip: The parcel could not be found.
+    tooltip: Error code indicating the parcel could not be found.
     type: integer
     value: 1
   PARCEL_SALE_ERROR_NO_PERMISSIONS:
     member-of: [ParcelSaleError]
-    tooltip: The script does not have the required permissions to set the sale information.
+    tooltip: Error code indicating the script lacks the required permissions to set
+      the parcel sale information.
     type: integer
     value: 2
   PARCEL_SALE_ERROR_IN_ESCROW:
     member-of: [ParcelSaleError]
-    tooltip: The parcel is currently in escrow and cannot be set for sale.
+    tooltip: Error code indicating the parcel is in escrow and cannot be put up for
+      sale.
     type: integer
     value: 3
   PARCEL_SALE_ERROR_INVALID_PRICE:
     member-of: [ParcelSaleError]
-    tooltip: The price set for the parcel is invalid (e.g., less than or equal to 0).
+    tooltip: Error code indicating the specified parcel price is invalid (e.g., less
+      than or equal to 0).
     type: integer
     value: 4
   PARCEL_SALE_ERROR_BAD_PARAMS:
     member-of: [ParcelSaleError]
-    tooltip: The parameters provided to set the sale information are invalid.
+    tooltip: Error code indicating the parameters provided to set the parcel sale
+      information are invalid.
     type: integer
     value: 5
   PASSIVE:
     member-of: [DetectType]
-    tooltip: Static in-world objects.
+    tooltip: Identifies static or non-moving in-world objects (which do not consume
+      active server resources). In llDetectedType(), indicates non-physical
+      objects. In llSensor()/llSensorRepeat() filters, searches for
+      non-physical, non-scripted, inactive, or non-moving physical objects.
     type: integer
     value: '0x4'
   PASS_ALWAYS:
     member-of: [PassMode]
-    tooltip: Always pass the event.
+    tooltip: Used with event-passing functions (e.g., llPassTouches,
+      llPassCollisions) to ensure events are always passed from the child prim
+      to the root prim, regardless of whether they are handled by child script
+      handlers.
     type: integer
     value: 1
   PASS_IF_NOT_HANDLED:
     member-of: [PassMode]
-    tooltip: Pass the event if there is no script handling the event in the prim.
+    tooltip: Used with event-passing functions (default behavior) to pass events
+      from the child prim to the root prim only if there is no script handling
+      the event in the child.
     type: integer
     value: 0
   PASS_NEVER:
     member-of: [PassMode]
-    tooltip: Always pass the event.
+    tooltip: Used with event-passing functions to ensure events are never passed
+      from the child prim to the root prim, regardless of whether they are
+      handled by child script handlers.
     type: integer
     value: 2
   PATROL_PAUSE_AT_WAYPOINTS:
     member-of: [CharacterPatrolPointsParam]
-    tooltip: ''
+    tooltip: Option parameter for llPatrolPoints (defaults to FALSE). If TRUE, the
+      character slows down and momentarily pauses at each waypoint. If FALSE,
+      the character moves to the next waypoint at full speed with no pause.
     type: integer
     value: 0
   PAYMENT_INFO_ON_FILE:
     member-of: [AgentDataPaymentInfo]
-    tooltip: ''
+    tooltip: Agent data flag returned by llRequestAgentData indicating if the user
+      has payment information on file.
     type: integer
     value: 1
   PAYMENT_INFO_USED:
     member-of: [AgentDataPaymentInfo]
-    tooltip: ''
+    tooltip: Agent data flag returned by llRequestAgentData indicating if the user
+      has ever used their payment information.
     type: integer
     value: 2
   PAY_DEFAULT:
     member-of: [PayButton]
-    tooltip: ''
+    tooltip: Used with llSetPayPrice to use the default value for the specified
+      quick pay button.
     type: integer
     value: -2
   PAY_HIDE:
     member-of: [PayButton]
-    tooltip: ''
+    tooltip: Used with llSetPayPrice to hide the specified quick pay button completely.
     type: integer
     value: -1
   PERMISSION_DEBIT:
     member-of: [ScriptPermission]
-    tooltip: If this permission is enabled, the object can successfully call llGiveMoney
-      or llTransferLindenDollars to debit the owners account.
+    tooltip: Runtime permission that allows the script to successfully call
+      llGiveMoney or llTransferLindenDollars to debit the owner's account.
     type: integer
     value: '0x00002'
   PERMISSION_TAKE_CONTROLS:
     member-of: [ScriptPermission]
-    tooltip: If this permission enabled, the object can successfully call the llTakeControls
-      library call.
+    tooltip: Runtime permission that allows the script to successfully call the
+      llTakeControls function to intercept the agent's controls.
     type: integer
     value: '0x00004'
   PERMISSION_REMAP_CONTROLS:
     member-of: [ScriptPermission]
-    tooltip: (not yet implemented)
+    tooltip: (Not yet implemented)
     type: integer
     value: '0x00008'
   PERMISSION_TRIGGER_ANIMATION:
     member-of: [ScriptPermission]
-    tooltip: If this permission is enabled, the object can successfully call llStartAnimation
-      for the avatar that owns this.
+    tooltip: Runtime permission that allows the script to start or stop animations
+      on the agent (such as using llStartAnimation).
     type: integer
     value: '0x00010'
   PERMISSION_ATTACH:
     member-of: [ScriptPermission]
-    tooltip: If this permission is enabled, the object can successfully call llAttachToAvatar
-      to attach to the given avatar.
+    tooltip: Runtime permission that allows the script to successfully attach to or
+      detach from the agent using llAttachToAvatar.
     type: integer
     value: '0x00020'
   PERMISSION_RELEASE_OWNERSHIP:
     member-of: [ScriptPermission]
-    tooltip: (not yet implemented)
+    tooltip: (Not yet implemented)
     type: integer
     value: '0x00040'
   PERMISSION_CHANGE_LINKS:
     member-of: [ScriptPermission]
-    tooltip: If this permission is enabled, the object can successfully call llCreateLink,
-      llBreakLink, and llBreakAllLinks to change links to other objects.
+    tooltip: Runtime permission that allows the script to successfully create,
+      break, or modify links to other objects using llCreateLink, llBreakLink,
+      or llBreakAllLinks.
     type: integer
     value: '0x00080'
   PERMISSION_CHANGE_JOINTS:
     member-of: [ScriptPermission]
-    tooltip: (not yet implemented)
+    tooltip: (Not yet implemented)
     type: integer
     value: '0x00100'
   PERMISSION_CHANGE_PERMISSIONS:
     member-of: [ScriptPermission]
-    tooltip: (not yet implemented)
+    tooltip: (Not yet implemented)
     type: integer
     value: '0x00200'
   PERMISSION_TRACK_CAMERA:
     member-of: [ScriptPermission]
-    tooltip: ''
+    tooltip: Runtime permission that allows the script to track the agent's camera
+      position and rotation.
     type: integer
     value: '0x00400'
   PERMISSION_CONTROL_CAMERA:
     member-of: [ScriptPermission]
-    tooltip: ''
+    tooltip: Runtime permission that allows the script to control the agent's
+      camera. The agent must be sitting on or attached to the object, and
+      permission is automatically revoked on standing up or detaching.
     type: integer
     value: '0x00800'
   PERMISSION_TELEPORT:
     member-of: [ScriptPermission]
-    tooltip: ''
+    tooltip: Runtime permission required to teleport the agent using the
+      llTeleportAgent function.
     type: integer
     value: '0x01000'
   PERMISSION_SILENT_ESTATE_MANAGEMENT:
     member-of: [ScriptPermission]
-    tooltip: A script with this permission does not notify the object owner when it
-      modifies estate access rules via llManageEstateAccess.
+    tooltip: Runtime permission that allows the script to manage estate access rules
+      via llManageEstateAccess without notifying the object owner of the
+      changes.
     type: integer
     value: '0x04000'
   PERMISSION_OVERRIDE_ANIMATIONS:
     member-of: [ScriptPermission]
-    tooltip: Permission to override default animations.
+    tooltip: Runtime permission that allows the script to configure and override
+      default animations on the agent.
     type: integer
     value: '0x08000'
   PERMISSION_RETURN_OBJECTS:
     member-of: [ScriptPermission]
-    tooltip: ''
+    tooltip: Runtime permission required to use the llReturnObjectsByID and
+      llReturnObjectsByOwner functions to return objects from parcels.
     type: integer
     value: '0x10000'
   PERMISSION_PRIVILEGED_LAND_ACCESS:
     member-of: [ScriptPermission]
-    tooltip: Grants the script privileged access to land parcel functions, such as parcel sale.
+    tooltip: Runtime permission that grants the script privileged access to land
+      parcel functions, which is required to use llSetParcelForSale.
     type: integer
     value: '0x80000'
   PERM_ALL:
     member-of: [AssetPermission]
-    tooltip: ''
+    tooltip: Permissions mask representing a combination of move, modify, copy, and
+      transfer permissions.
     type: integer
     value: '0x7FFFFFFF'
   PERM_COPY:
     member-of: [AssetPermission]
-    tooltip: ''
+    tooltip: Permissions mask representing copy permission.
     type: integer
     value: '0x8000'
   PERM_MODIFY:
     member-of: [AssetPermission]
-    tooltip: ''
+    tooltip: Permissions mask representing modify permission.
     type: integer
     value: '0x4000'
   PERM_MOVE:
     member-of: [AssetPermission]
-    tooltip: ''
+    tooltip: Permissions mask representing move permission.
     type: integer
     value: '0x80000'
   PERM_TRANSFER:
     member-of: [AssetPermission]
-    tooltip: ''
+    tooltip: Permissions mask representing transfer permission.
     type: integer
     value: '0x2000'
   PI:
-    tooltip: 3.14159265 - The number of radians in a semi-circle.
+    tooltip: The mathematical constant Pi (3.14159265), representing the number of
+      radians in a half circle (semi-circle). When used in sensor functions, it
+      specifies a full sphere scan.
     type: float
     value: '3.14159265'
   PING_PONG:
     member-of: [TextureAnimMode]
-    tooltip: Play animation going forwards, then backwards.
+    tooltip: Used with texture animation functions to cause the animation to play
+      forward first, and then in reverse.
     type: integer
     value: '0x8'
   PI_BY_TWO:
-    tooltip: 1.57079633 - The number of radians in a quarter circle.
+    tooltip: The constant Pi/2 (1.57079633), representing the number of radians in a
+      quarter circle. When used in sensor functions, it specifies a hemisphere
+      scan.
     type: float
     value: '1.57079633'
   PRIM_ALLOW_UNSIT:
     member-of: [PrimParam]
-    tooltip: Prim parameter for restricting manual standing for seated avatars in
-      an experience.\nIgnored if the avatar was not seated via a call to llSitOnLink.
+    tooltip: Prim parameter for allowing or restricting manual standing for avatars
+      seated on this prim within a valid experience. Ignored if the avatar was
+      not seated via llSitOnLink. When restriction is active, participating
+      seated avatars cannot manually stand or select another prim to sit on.
     type: integer
     value: 39
   PRIM_ALPHA_MODE:
     member-of: [PrimParam]
-    tooltip: Prim parameter for materials using integer face, integer alpha_mode,
-      integer alpha_cutoff.\nDefines how the alpha channel of the diffuse texture
-      should be rendered.\nValid options for alpha_mode are PRIM_ALPHA_MODE_BLEND,
-      _NONE, _MASK, and _EMISSIVE.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.
+    tooltip: Prim parameter used to set diffuse texture alpha rendering mode
+      attributes. Requires face, alpha_mode (PRIM_ALPHA_MODE_BLEND, _NONE,
+      _MASK, or _EMISSIVE), and alpha_cutoff (used only for _MASK) parameters.
     type: integer
     value: 38
   PRIM_ALPHA_MODE_BLEND:
     member-of: [AlphaMode]
-    tooltip: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
-      texture's alpha channel should be rendered as alpha-blended.
+    tooltip: Prim parameter setting for PRIM_ALPHA_MODE. Directs the face to use
+      alpha blending for diffuse texture rendering (if an alpha channel exists).
+      Also used as the default value to clear material settings from a prim
+      face.
     type: integer
     value: 1
   PRIM_ALPHA_MODE_EMISSIVE:
     member-of: [AlphaMode]
-    tooltip: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
-      texture's alpha channel should be rendered as an emissivity mask.
+    tooltip: Prim parameter setting for PRIM_ALPHA_MODE. Renders the diffuse
+      texture's alpha channel as an emissivity mask. Pixels render with an
+      emissivity corresponding to their opacity under all lighting conditions
+      (fully opaque pixels effectively render as 'full bright').
     type: integer
     value: 3
   PRIM_ALPHA_MODE_MASK:
     member-of: [AlphaMode]
-    tooltip: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
-      texture's alpha channel should be rendered as fully opaque for alpha values
-      above alpha_cutoff and fully transparent otherwise.
+    tooltip: Prim parameter setting for PRIM_ALPHA_MODE. Renders the diffuse
+      texture's alpha channel on a binary per-pixel basis; pixels more opaque
+      than the alpha cutoff render as fully opaque, while pixels below the
+      cutoff render as fully transparent.
     type: integer
     value: 2
   PRIM_ALPHA_MODE_NONE:
     member-of: [AlphaMode]
-    tooltip: Prim parameter setting for PRIM_ALPHA_MODE.\nIndicates that the diffuse
-      texture's alpha channel should be ignored.
+    tooltip: Prim parameter setting for PRIM_ALPHA_MODE. Directs the face to ignore
+      the alpha channel of the diffuse texture and render as completely opaque
+      (default setting when a material face lacks an alpha channel).
     type: integer
     value: 0
   PRIM_BUMP_BARK:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: bark."
     type: integer
     value: 4
   PRIM_BUMP_BLOBS:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: petridish (blobby amoeba-like shapes)."
     type: integer
     value: 12
   PRIM_BUMP_BRICKS:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: bricks."
     type: integer
     value: 5
   PRIM_BUMP_BRIGHT:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: brightness (generated from highlights)."
     type: integer
     value: 1
   PRIM_BUMP_CHECKER:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: checker."
     type: integer
     value: 6
   PRIM_BUMP_CONCRETE:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: concrete."
     type: integer
     value: 7
   PRIM_BUMP_DARK:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: darkness (generated from lowlights)."
     type: integer
     value: 2
   PRIM_BUMP_DISKS:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: discs (packed circles)."
     type: integer
     value: 10
   PRIM_BUMP_GRAVEL:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: gravel."
     type: integer
     value: 11
   PRIM_BUMP_LARGETILE:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: stonetile (large tile)."
     type: integer
     value: 14
   PRIM_BUMP_NONE:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: none (no bump map)."
     type: integer
     value: 0
   PRIM_BUMP_SHINY:
     member-of: [PrimParam]
-    tooltip: ''
+    tooltip: Prim parameter used to get or set both the shininess and bump mapping
+      settings of a face.
     type: integer
     value: 19
   PRIM_BUMP_SIDING:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: siding."
     type: integer
     value: 13
   PRIM_BUMP_STONE:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: cutstone (blocks)."
     type: integer
     value: 9
   PRIM_BUMP_STUCCO:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: stucco."
     type: integer
     value: 15
   PRIM_BUMP_SUCTION:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: suction (rings)."
     type: integer
     value: 16
   PRIM_BUMP_TILE:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: crustytile."
     type: integer
     value: 8
   PRIM_BUMP_WEAVE:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: weave."
     type: integer
     value: 17
   PRIM_BUMP_WOOD:
     member-of: [PrimBump]
-    tooltip: ''
+    tooltip: "Face bump mapping setting: woodgrain."
     type: integer
     value: 3
   PRIM_CAST_SHADOWS:
     member-of: [PrimParam]
     deprecated:
       reason: Not implemented.
-    tooltip: ''
+    tooltip: Deprecated prim parameter representing shadow casting settings for the
+      primitive.
     type: integer
     value: 24
   PRIM_CLICK_ACTION:
     member-of: [PrimParam]
-    tooltip: '[PRIM_CLICK_ACTION, integer CLICK_ACTION_*]'
+    tooltip: Prim parameter followed by a CLICK_ACTION_* constant to specify the
+      default action taken when a user clicks or touches the prim.
     type: integer
     value: 43
   PRIM_COLLISION_SOUND:
     member-of: [PrimParam]
-    tooltip: Collision sound uuid and volume for this prim
+    tooltip: Prim parameter to set the collision sound UUID and volume level for the
+      prim.
     type: integer
     value: 53
   PRIM_COLOR:
     member-of: [PrimParam]
-    tooltip: |
-      [PRIM_COLOR, integer face, vector color, float alpha]
-
-      integer face – face number or ALL_SIDES
-      vector color – color in RGB <R, G, B> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white)
-      float alpha – from 0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)
+    tooltip: Prim parameter [PRIM_COLOR, integer face, vector color, float alpha] to
+      get or set the Blinn-Phong color (RGB vector) and opacity (float alpha
+      from 0.0 to 1.0) of a face.
     type: integer
     value: 18
   PRIM_DAMAGE:
     member-of: [PrimParam]
-    tooltip: Damage and damage type assigned to this prim.
+    tooltip: Prim parameter used to get or set the damage amount and damage type
+      delivered by the prim on collision.
     type: integer
     value: 51
   PRIM_DESC:
     member-of: [PrimParam]
-    tooltip: '[PRIM_DESC, string description]'
+    tooltip: Prim parameter [PRIM_DESC, string description] to get or set the prim's
+      description (equivalent to llGetObjectDesc/llSetObjectDesc).
     type: integer
     value: 28
   PRIM_FLEXIBLE:
     member-of: [PrimParam]
-    tooltip: |
-      [ PRIM_FLEXIBLE, integer boolean, integer softness, float gravity, float friction, float wind, float tension, vector force ]
-
-      integer boolean – TRUE enables, FALSE disables
-      integer softness – ranges from 0 to 3
-      float gravity – ranges from -10.0 to 10.0
-      float friction – ranges from 0.0 to 10.0
-      float wind – ranges from 0.0 to 10.0
-      float tension – ranges from 0.0 to 10.0
-      vector force
+    tooltip: Prim parameter [PRIM_FLEXIBLE, integer boolean, integer softness, float
+      gravity, float friction, float wind, float tension, vector force] to get
+      or set the prim's flexible configuration.
     type: integer
     value: 21
   PRIM_FULLBRIGHT:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_FULLBRIGHT, integer face, integer boolean ]'
+    tooltip: Prim parameter [PRIM_FULLBRIGHT, integer face, integer boolean] to get
+      or set whether full-bright rendering is enabled on the specified face.
     type: integer
     value: 20
   PRIM_GLOW:
     member-of: [PrimParam]
-    tooltip: 'PRIM_GLOW is used to get or set the glow status of the face.\n[ PRIM_GLOW, integer face, float intensity ]'
+    tooltip: Prim parameter [PRIM_GLOW, integer face, float intensity] to get or set
+      the glow intensity on a face (the compiler integer value is 25 if the
+      named constant is rejected).
     type: integer
     value: 25
   PRIM_GLTF_ALPHA_MODE_BLEND:
     member-of: [GLTFAlphaMode]
-    tooltip: Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "BLEND".
+    tooltip: "GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Renders the material
+      with transparency (alpha blending) in linear color space. Transparency
+      from the texture is multiplied by the material's opacity multiplier. Note:
+      This mode can suffer from depth sorting and performance issues."
     type: integer
     value: 1
   PRIM_GLTF_ALPHA_MODE_MASK:
     member-of: [GLTFAlphaMode]
-    tooltip: Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "MASK".
+    tooltip: GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Renders the material
+      as fully opaque where the alpha value is greater than the alpha cutoff,
+      and fully transparent otherwise.
     type: integer
     value: 2
   PRIM_GLTF_ALPHA_MODE_OPAQUE:
     member-of: [GLTFAlphaMode]
-    tooltip: Prim parameter setting for PRIM_GLTF_BASE_COLOR alpha mode "OPAQUE".
+    tooltip: GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Ignores the alpha
+      channel entirely and renders the face material as completely opaque.
     type: integer
     value: 0
   PRIM_GLTF_BASE_COLOR:
     member-of: [PrimParam]
-    tooltip: Prim parameter for materials using integer face, string texture, vector
-      repeats, vector offsets, float rotation_in_radians, vector color, integer alpha_mode,
-      float alpha_cutoff, boolean double_sided.\nValid options for alpha_mode are
-      PRIM_ALPHA_MODE_BLEND, _NONE, and _MASK.\nalpha_cutoff is used only for PRIM_ALPHA_MODE_MASK.
+    tooltip: Prim parameter to get or set the GLTF base color override of an
+      object's face. Requires face, texture, repeats, offsets, rotation,
+      linear_color (in linear space; use llsRGB2Linear), alpha_mode
+      (PRIM_GLTF_ALPHA_MODE_*), alpha_cutoff, and double_sided arguments.
     type: integer
     value: 48
   PRIM_GLTF_EMISSIVE:
     member-of: [PrimParam]
-    tooltip: Prim parameter for GLTF materials using integer face, string texture,
-      vector repeats, vector offsets, float rotation_in_radians, vector color
+    tooltip: Prim parameter to get or set the GLTF emission override of a face.
+      Requires face, texture, repeats, offsets, rotation, and emissive_tint
+      (specified in linear space; use llsRGB2Linear).
     type: integer
     value: 46
   PRIM_GLTF_METALLIC_ROUGHNESS:
     member-of: [PrimParam]
-    tooltip: Prim parameter for GLTF materials using integer face, string texture,
-      vector repeats, vector offsets, float rotation_in_radians, float metallic_factor,
-      float roughness_factor
+    tooltip: Prim parameter to get or set the GLTF occlusion/metallic/roughness
+      override of a face. Requires face, texture, repeats, offsets, rotation,
+      metallic_factor, and roughness_factor arguments.
     type: integer
     value: 47
   PRIM_GLTF_NORMAL:
     member-of: [PrimParam]
-    tooltip: Prim parameter for GLTF materials using integer face, string texture,
-      vector repeats, vector offsets, float rotation_in_radians
+    tooltip: Prim parameter to get or set the GLTF normal map override of a face.
+      Requires face, texture, repeats, offsets, and rotation arguments.
     type: integer
     value: 45
   PRIM_HEALTH:
     member-of: [PrimParam]
-    tooltip: Health value for this prim
+    tooltip: Prim parameter used to get or set the health of the prim. Objects
+      default to 0 health.
     type: integer
     value: 52
   PRIM_HOLE_CIRCLE:
     member-of: [PrimTypeHole]
-    tooltip: ''
+    tooltip: Parameter used with certain PRIM_TYPE_* flags to make a circular hole
+      via the hole_shape parameter.
     type: integer
     value: '0x10'
   PRIM_HOLE_DEFAULT:
     member-of: [PrimTypeHole]
-    tooltip: ''
+    tooltip: Parameter used with certain PRIM_TYPE_* flags to make a hole of the
+      same shape as the outer shape via the hole_shape parameter.
     type: integer
     value: '0x00'
   PRIM_HOLE_SQUARE:
     member-of: [PrimTypeHole]
-    tooltip: ''
+    tooltip: Parameter used with certain PRIM_TYPE_* flags to make a squarish hole
+      via the hole_shape parameter.
     type: integer
     value: '0x20'
   PRIM_HOLE_TRIANGLE:
     member-of: [PrimTypeHole]
-    tooltip: ''
+    tooltip: Parameter used with certain PRIM_TYPE_* flags to make a triangular hole
+      via the hole_shape parameter.
     type: integer
     value: '0x30'
   PRIM_LINK_TARGET:
     member-of: [PrimParam]
-    tooltip: |
-      [ PRIM_LINK_TARGET, integer link_target ]
-
-      Used to get or set multiple links with a single PrimParameters call.
+    tooltip: Prim parameter [PRIM_LINK_TARGET, integer link_target] used to get or
+      set properties for multiple linked prims within a single primitive
+      parameters call.
     type: integer
     value: 34
   PRIM_MATERIAL:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_MATERIAL, integer PRIM_MATERIAL_* ]'
+    tooltip: Prim parameter [PRIM_MATERIAL, integer PRIM_MATERIAL_*] to get or set
+      the prim's material. The material determines the default collision sound,
+      sprite, friction coefficient, and restitution coefficient (elasticity)
+      without affecting mass.
     type: integer
     value: 2
   PRIM_MATERIAL_DENSITY:
@@ -3546,12 +3911,12 @@ constants:
     private: true
     deprecated:
       use: DENSITY
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x1'
   PRIM_MATERIAL_FLESH:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: flesh."
     type: integer
     value: 4
   PRIM_MATERIAL_FRICTION:
@@ -3559,12 +3924,12 @@ constants:
     private: true
     deprecated:
       use: FRICTION
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x2'
   PRIM_MATERIAL_GLASS:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: glass (features very low friction)."
     type: integer
     value: 2
   PRIM_MATERIAL_GRAVITY_MULTIPLIER:
@@ -3572,24 +3937,26 @@ constants:
     private: true
     deprecated:
       use: GRAVITY_MULTIPLIER
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x8'
   PRIM_MATERIAL_LIGHT:
     member-of: [PhysicsMaterialPreset]
     deprecated:
       use: PRIM_FULLBRIGHT
-    tooltip: ''
+    tooltip: Deprecated prim material constant. Light is now a face property instead
+      of a prim property; equivalent functionality is achieved using
+      [PRIM_FULLBRIGHT, ALL_SIDES, TRUE].
     type: integer
     value: 7
   PRIM_MATERIAL_METAL:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: metal."
     type: integer
     value: 1
   PRIM_MATERIAL_PLASTIC:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: plastic."
     type: integer
     value: 5
   PRIM_MATERIAL_RESTITUTION:
@@ -3597,247 +3964,244 @@ constants:
     private: true
     deprecated:
       use: RESTITUTION
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x4'
   PRIM_MATERIAL_RUBBER:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: rubber."
     type: integer
     value: 6
   PRIM_MATERIAL_STONE:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: stone."
     type: integer
     value: 0
   PRIM_MATERIAL_WOOD:
     member-of: [PhysicsMaterialPreset]
-    tooltip: ''
+    tooltip: "Prim material constant: wood."
     type: integer
     value: 3
   PRIM_MEDIA_ALT_IMAGE_ENABLE:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets the default image state (the image that the user sees
-      before a piece of media is active) for the chosen face. The default image is
-      specified by Second Life's server for that media type.
+    tooltip: "Boolean. Gets or sets the default image state (the image a user sees
+      before media is active) on a face. The default is specified by the server
+      for that media type. Note: This flag is not currently implemented."
     type: integer
     value: 0
   PRIM_MEDIA_AUTO_LOOP:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets whether auto-looping is enabled.
+    tooltip: Boolean. Gets or sets whether auto-looping is enabled for the face media.
     type: integer
     value: 4
   PRIM_MEDIA_AUTO_PLAY:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets whether the media auto-plays when a Resident can view
-      it.
+    tooltip: Boolean. Gets or sets whether media auto-plays when a resident is able
+      to view it.
     type: integer
     value: 5
   PRIM_MEDIA_AUTO_SCALE:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets whether auto-scaling is enabled. Auto-scaling forces
-      the media to the full size of the texture.
+    tooltip: Boolean. Gets or sets whether auto-scaling is enabled, which forces the
+      media to fill the entire texture size.
     type: integer
     value: 6
   PRIM_MEDIA_AUTO_ZOOM:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets whether clicking the media triggers auto-zoom and
-      auto-focus on the media.
+    tooltip: Boolean. Gets or sets whether clicking the media triggers auto-zoom and
+      auto-focus.
     type: integer
     value: 7
   PRIM_MEDIA_CONTROLS:
     member-of: [PrimMediaParam]
-    tooltip: Integer. Gets/Sets the style of controls. Can be either PRIM_MEDIA_CONTROLS_STANDARD
-      or PRIM_MEDIA_CONTROLS_MINI.
+    tooltip: Integer. Gets or sets the style of media controls (can be set to
+      PRIM_MEDIA_CONTROLS_STANDARD or PRIM_MEDIA_CONTROLS_MINI).
     type: integer
     value: 1
   PRIM_MEDIA_CONTROLS_MINI:
     member-of: [PrimMediaControl]
-    tooltip: Mini web navigation controls; does not include an address bar.
+    tooltip: Mini web navigation controls constant; does not include an address bar.
     type: integer
     value: 1
   PRIM_MEDIA_CONTROLS_STANDARD:
     member-of: [PrimMediaControl]
-    tooltip: Standard web navigation controls.
+    tooltip: Standard web navigation controls constant.
     type: integer
     value: 0
   PRIM_MEDIA_CURRENT_URL:
     member-of: [PrimMediaParam]
-    tooltip: String. Gets/Sets the current url displayed on the chosen face. Changing
-      this URL causes navigation. 1024 characters Maximum.
+    tooltip: String. Gets or sets the current URL displayed on the chosen face
+      (maximum 1024 characters). Changing this URL triggers media navigation.
     type: integer
     value: 2
   PRIM_MEDIA_FIRST_CLICK_INTERACT:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets whether the first click interaction is enabled.
+    tooltip: "Boolean. Gets or sets whether the first-click interaction is enabled.
+      Note: This flag is non-functional."
     type: integer
     value: 8
   PRIM_MEDIA_HEIGHT_PIXELS:
     member-of: [PrimMediaParam]
-    tooltip: Integer. Gets/Sets the height of the media in pixels.
+    tooltip: Integer. Gets or sets the height of the media in pixels.
     type: integer
     value: 10
   PRIM_MEDIA_HOME_URL:
     member-of: [PrimMediaParam]
-    tooltip: String. Gets/Sets the home URL for the chosen face. 1024 characters maximum.
+    tooltip: String. Gets or sets the home URL for the chosen face (maximum 1024
+      characters).
     type: integer
     value: 3
   PRIM_MEDIA_MAX_HEIGHT_PIXELS:
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2048
   PRIM_MEDIA_MAX_URL_LENGTH:
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1024
   PRIM_MEDIA_MAX_WHITELIST_COUNT:
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 64
   PRIM_MEDIA_MAX_WHITELIST_SIZE:
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1024
   PRIM_MEDIA_MAX_WIDTH_PIXELS:
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2048
   PRIM_MEDIA_PARAM_MAX:
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 14
   PRIM_MEDIA_PERMS_CONTROL:
     member-of: [PrimMediaParam]
-    tooltip: 'Integer. Gets/Sets the permissions mask that control who can see the
-      media control bar above the object:: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP,
-      PRIM_MEDIA_PERM_NONE, PRIM_MEDIA_PERM_OWNER'
+    tooltip: Integer. Gets or sets the permissions mask controlling who can see the
+      media control bar (PRIM_MEDIA_PERM_ANYONE, _GROUP, _NONE, or _OWNER).
     type: integer
     value: 14
   PRIM_MEDIA_PERMS_INTERACT:
     member-of: [PrimMediaParam]
-    tooltip: 'Integer. Gets/Sets the permissions mask that control who can interact
-      with the object: PRIM_MEDIA_PERM_ANYONE, PRIM_MEDIA_PERM_GROUP, PRIM_MEDIA_PERM_NONE,
-      PRIM_MEDIA_PERM_OWNER'
+    tooltip: Integer. Gets or sets the permissions mask controlling who can interact
+      with the media (PRIM_MEDIA_PERM_ANYONE, _GROUP, _NONE, or _OWNER).
     type: integer
     value: 13
   PRIM_MEDIA_PERM_ANYONE:
     member-of: [PrimMediaPerm]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 4
   PRIM_MEDIA_PERM_GROUP:
     member-of: [PrimMediaPerm]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   PRIM_MEDIA_PERM_NONE:
     member-of: [PrimMediaPerm]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 0
   PRIM_MEDIA_PERM_OWNER:
     member-of: [PrimMediaPerm]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   PRIM_MEDIA_WHITELIST:
     member-of: [PrimMediaParam]
-    tooltip: String. Gets/Sets the white-list as a string of escaped, comma-separated
-      URLs. This string can hold up to 64 URLs or 1024 characters, whichever comes
-      first.
+    tooltip: String. Gets or sets the whitelist as a string of escaped,
+      comma-separated URLs (supports up to 64 URLs or 1024 characters, whichever
+      comes first).
     type: integer
     value: 12
   PRIM_MEDIA_WHITELIST_ENABLE:
     member-of: [PrimMediaParam]
-    tooltip: Boolean. Gets/Sets whether navigation is restricted to URLs in PRIM_MEDIA_WHITELIST.
+    tooltip: Boolean. Gets or sets whether media navigation is restricted to the
+      URLs listed in PRIM_MEDIA_WHITELIST.
     type: integer
     value: 11
   PRIM_MEDIA_WIDTH_PIXELS:
     member-of: [PrimMediaParam]
-    tooltip: Integer. Gets/Sets the width of the media in pixels.
+    tooltip: Integer. Gets or sets the width of the media in pixels.
     type: integer
     value: 9
   PRIM_NAME:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_NAME, string name ]'
+    tooltip: Prim parameter [PRIM_NAME, string name] to get or set the prim's name
+      (equivalent to llGetObjectName/llSetObjectName).
     type: integer
     value: 27
   PRIM_NORMAL:
     member-of: [PrimParam]
-    tooltip: Prim parameter for materials using integer face, string texture, vector
-      repeats, vector offsets, float rotation_in_radians
+    tooltip: Prim parameter to get or set the Blinn-Phong normal map texture
+      settings of a face. Requires face, texture, repeats, offsets, and
+      rotation_in_radians arguments.
     type: integer
     value: 37
   PRIM_OMEGA:
     member-of: [PrimParam]
-    tooltip: |
-      [ PRIM_OMEGA, vector axis, float spinrate, float gain ]
-
-      vector axis – arbitrary axis to rotate the object around
-      float spinrate – rate of rotation in radians per second
-      float gain – also modulates the final spinrate and disables the rotation behavior if zero
+    tooltip: Prim parameter [PRIM_OMEGA, vector axis, float spinrate, float gain] to
+      get, set, or disable a client-side physical-like rotation (analogous to
+      llTargetOmega).
     type: integer
     value: 32
   PRIM_PHANTOM:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_PHANTOM, integer boolean ]'
+    tooltip: Prim parameter [PRIM_PHANTOM, integer boolean] to get or set whether
+      phantom status is enabled.
     type: integer
     value: 5
   PRIM_PHYSICS:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_PHYSICS, integer boolean ]'
+    tooltip: Prim parameter [PRIM_PHYSICS, integer boolean] to get or set whether
+      the object responds to Second Life physics.
     type: integer
     value: 3
   PRIM_PHYSICS_SHAPE_CONVEX:
     member-of: [PhysicsShapeType]
-    tooltip: Use the convex hull of the prim shape for physics (this is the default
-      for mesh objects).
+    tooltip: Physics shape type setting. Uses the convex hull of the prim shape to
+      generate its physics representation (the default for mesh objects).
     type: integer
     value: 2
   PRIM_PHYSICS_SHAPE_NONE:
     member-of: [PhysicsShapeType]
-    tooltip: 'Ignore this prim in the physics shape. NB: This cannot be applied to
-      the root prim.'
+    tooltip: "Physics shape type setting. Directs the physics engine to ignore this
+      prim entirely, preventing it from contributing to the linkset's physics
+      shape. Note: Cannot be applied to the root prim."
     type: integer
     value: 1
   PRIM_PHYSICS_SHAPE_PRIM:
     member-of: [PhysicsShapeType]
-    tooltip: Use the normal prim shape for physics (this is the default for all non-mesh
+    tooltip: Physics shape type setting. Uses the actual visible shape of the prim
+      to determine its physics representation (the default for all non-mesh
       objects).
     type: integer
     value: 0
   PRIM_PHYSICS_SHAPE_TYPE:
     member-of: [PrimParam]
-    tooltip: "Allows you to set the physics shape type of a prim via lsl. Permitted\
-      \ values are:\n\t\t\tPRIM_PHYSICS_SHAPE_NONE, PRIM_PHYSICS_SHAPE_PRIM, PRIM_PHYSICS_SHAPE_CONVEX"
+    tooltip: Prim parameter used to get or set the type of shape the physics engine
+      uses for the prim (PRIM_PHYSICS_SHAPE_NONE, _PRIM, or _CONVEX). Mainly
+      used for physics optimization.
     type: integer
     value: 30
   PRIM_POINT_LIGHT:
     member-of: [PrimParam]
-    tooltip: |
-      [ PRIM_POINT_LIGHT, integer boolean, vector linear_color, float intensity, float radius, float falloff ]
-
-      integer boolean – TRUE enables, FALSE disables
-      vector linear_color – linear color in RGB <R, G, B&> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white)
-      float intensity – ranges from 0.0 to 1.0
-      float radius – ranges from 0.1 to 20.0
-      float falloff – ranges from 0.01 to 2.0
+    tooltip: Prim parameter [PRIM_POINT_LIGHT, integer boolean, vector linear_color,
+      float intensity, float radius, float falloff] to configure local lighting.
+      Accepts color in linear space (use llsRGB2Linear to convert from sRGB).
     type: integer
     value: 23
   PRIM_POSITION:
     member-of: [PrimParam]
-    tooltip: |
-      [ PRIM_POSITION, vector position ]
-
-      vector position – position in region or local coordinates depending upon the situation
+    tooltip: Prim parameter [PRIM_POSITION, vector position] to get or set the
+      position of the prim in region coordinates (or local coordinates depending
+      on the script context).
     type: integer
     value: 6
   PRIM_POS_LOCAL:
     member-of: [PrimParam]
-    tooltip: |
-      [ PRIM_POS_LOCAL, vector position ]
-
-      vector position - position in local coordinates
+    tooltip: Prim parameter [PRIM_POS_LOCAL, vector position] to get or set the
+      local position of a prim (equivalent to llGetLocalPos/llSetPos).
     type: integer
     value: 33
   PRIM_PROJECTOR:
@@ -3845,444 +4209,516 @@ constants:
     # llGetPrimitiveParams cannot read PRIM_PROJECTOR:
     # https://feedback.secondlife.com/scripting-features/p/make-prim-projector-readable
     # https://community.secondlife.com/forums/topic/486118-only-set-ambiance-on-prim_projector#comment-2446570
-    tooltip: '[ PRIM_PROJECTOR, string texture, float fov, float focus, float ambiance ]'
+    tooltip: Prim parameter [PRIM_PROJECTOR, string texture, float fov, float focus,
+      float ambiance] to configure light projection settings. If the prim is not
+      configured as a projector, the texture key will return NULL_KEY.
     type: integer
     value: 42
   PRIM_REFLECTION_PROBE:
     member-of: [PrimParam]
-    tooltip: Allows you to configure the object as a custom-placed reflection probe,
-      for image-based lighting (IBL). Only objects in the influence volume of the
-      reflection probe object are affected.
+    tooltip: Prim parameter to configure the object as a custom-placed reflection
+      probe for Image-Based Lighting (IBL). Only affects objects inside its
+      volume of influence.
     type: integer
     value: 44
   PRIM_REFLECTION_PROBE_BOX:
     member-of: [ReflectionProbeType]
-    tooltip: This is a flag option used with llGetPrimitiveParams and related functions
-      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection probe
-      is a box. When unset, the reflection probe is a sphere.
+    tooltip: Flag option used with PRIM_REFLECTION_PROBE. When set, the reflection
+      probe volume is a box; when unset, it defaults to a sphere.
     type: integer
     value: 1
   PRIM_REFLECTION_PROBE_DYNAMIC:
     member-of: [ReflectionProbeType]
-    tooltip: This is a flag option used with llGetPrimitiveParams and related functions
-      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection probe
-      includes avatars in IBL effects. When unset, the reflection probe excludes avatars.
+    tooltip: Flag option used with PRIM_REFLECTION_PROBE. When set, the probe
+      dynamically includes avatars in its image-based lighting reflections
+      (which carries a rendering performance cost).
     type: integer
     value: 2
   PRIM_REFLECTION_PROBE_MIRROR:
     member-of: [ReflectionProbeType]
-    tooltip: This is a flag option used with llGetPrimitiveParams and related functions
-      when the parameter is PRIM_REFLECTION_PROBE. When set, the reflection probe
-      acts as a mirror.
+    tooltip: "Flag option used with PRIM_REFLECTION_PROBE. When set, intersecting
+      low-roughness PBR materials act as mirrors. Note: Mirrors do not reflect
+      avatars unless PRIM_REFLECTION_PROBE_DYNAMIC is also enabled, and they
+      carry a performance cost."
     type: integer
     value: 4
   PRIM_RENDER_MATERIAL:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_RENDER_MATERIAL, integer face, string material ]'
+    tooltip: "Prim parameter [PRIM_RENDER_MATERIAL, integer face, string material]
+      to get or set face material settings. Note: Setting this clears most
+      PRIM_GLTF_* properties on the face, except for repeats, offsets, and
+      rotation_in_radians."
     type: integer
     value: 49
   PRIM_ROTATION:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_ROT_LOCAL, rotation global_rot ]'
+    tooltip: Prim parameter [PRIM_ROTATION, rotation global_rot] to get or set the
+      global rotation of the prim (equivalent to llGetRot/llSetRot; note that
+      setting this on child prims may be broken).
     type: integer
     value: 8
   PRIM_ROT_LOCAL:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_ROT_LOCAL, rotation local_rot ]'
+    tooltip: Prim parameter [PRIM_ROT_LOCAL, rotation local_rot] to get or set the
+      local rotation of a prim (equivalent to llGetLocalRot/llSetLocalRot).
     type: integer
     value: 29
   PRIM_SCRIPTED_SIT_ONLY:
     member-of: [PrimParam]
-    tooltip: Prim parameter for restricting manual sitting on this prim.\nSitting
-      must be initiated via call to llSitOnLink.
+    tooltip: Prim parameter restricting manual sitting on this prim. When active,
+      sitting can only be initiated via llSitOnLink; manual sitting attempts
+      fail. This restriction applies even outside experience-enabled regions.
     type: integer
     value: 40
   PRIM_SCULPT_FLAG_ANIMESH:
     member-of: [PrimTypeSculptFlag]
-    tooltip: Mesh is animated.
+    tooltip: Read-only flag for PRIM_TYPE_SCULPT to query whether the object is an
+      Animated Mesh (Animesh).
     type: integer
     value: 32
   PRIM_SCULPT_FLAG_INVERT:
     member-of: [PrimTypeSculptFlag]
-    tooltip: Render inside out (inverts the normals).
+    tooltip: Flag for PRIM_TYPE_SCULPT to render the sculpted prim inside-out by
+      inverting the normals of each polygon.
     type: integer
     value: 64
   PRIM_SCULPT_FLAG_MIRROR:
     member-of: [PrimTypeSculptFlag]
-    tooltip: Render an X axis mirror of the sculpty.
+    tooltip: Flag for PRIM_TYPE_SCULPT to render a mirror-image of the sculpted
+      prim, mirrored across the X-axis.
     type: integer
     value: 128
   PRIM_SCULPT_TYPE_CYLINDER:
     member-of: [PrimTypeSculptType]
-    tooltip: ''
+    tooltip: Sculpt type option for PRIM_TYPE_SCULPT that stitches the left side to
+      the right to produce a cylinder-shaped sculpted prim.
     type: integer
     value: 4
   PRIM_SCULPT_TYPE_MASK:
     member-of: [PrimTypeSculptType]
-    tooltip: ''
+    tooltip: Bitmask used when parsing sculpted prim properties (PRIM_TYPE_SCULPT)
+      from llGetPrimitiveParams to separate the base sculpt type from modifying
+      flags (invert or mirror).
     type: integer
     value: 7
   PRIM_SCULPT_TYPE_MESH:
     member-of: [PrimTypeSculptType]
-    tooltip: ''
+    tooltip: Sculpt type option for PRIM_TYPE_SCULPT indicating the object is a
+      uploaded Mesh model.
     type: integer
     value: 5
   PRIM_SCULPT_TYPE_PLANE:
     member-of: [PrimTypeSculptType]
-    tooltip: ''
+    tooltip: Sculpt type option for PRIM_TYPE_SCULPT that performs no stitching or
+      converging, producing a flat plane-shaped sculpted prim.
     type: integer
     value: 3
   PRIM_SCULPT_TYPE_SPHERE:
     member-of: [PrimTypeSculptType]
-    tooltip: ''
+    tooltip: Sculpt type option for PRIM_TYPE_SCULPT that stitches the left side to
+      the right and separately converges the top and bottom to produce a
+      sphere-shaped sculpted prim.
     type: integer
     value: 1
   PRIM_SCULPT_TYPE_TORUS:
     member-of: [PrimTypeSculptType]
-    tooltip: ''
+    tooltip: Sculpt type option for PRIM_TYPE_SCULPT that stitches top-to-bottom and
+      left-to-right to produce a torus-shaped sculpted prim.
     type: integer
     value: 2
   PRIM_SHINY_HIGH:
     member-of: [PrimShiny]
-    tooltip: ''
+    tooltip: Sets the highest intensity legacy face shininess setting.
     type: integer
     value: 3
   PRIM_SHINY_LOW:
     member-of: [PrimShiny]
-    tooltip: ''
+    tooltip: Sets the lowest intensity legacy face shininess setting.
     type: integer
     value: 1
   PRIM_SHINY_MEDIUM:
     member-of: [PrimShiny]
-    tooltip: ''
+    tooltip: Sets a medium intensity legacy face shininess setting.
     type: integer
     value: 2
   PRIM_SHINY_NONE:
     member-of: [PrimShiny]
-    tooltip: ''
+    tooltip: Disables the legacy face shininess setting.
     type: integer
     value: 0
   PRIM_SIT_FLAGS:
     member-of: [PrimParam]
-    tooltip: ''
+    tooltip: Prim parameter used to get or set sit-related flags currently active on
+      the prim.
     type: integer
     value: 50
   PRIM_SIT_TARGET:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_SIT_TARGET, integer boolean, vector offset, rotation rot ]'
+    tooltip: Prim parameter [PRIM_SIT_TARGET, integer boolean, vector offset,
+      rotation rot] to get or set the prim's sit target. Setting the boolean to
+      FALSE deactivates the target. Unlike llLinkSitTarget, offset <0.0, 0.0,
+      0.0> can be explicitly set.
     type: integer
     value: 41
   PRIM_SIZE:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_SIZE, vector size ]'
+    tooltip: Prim parameter [PRIM_SIZE, vector size] to get or set the prim's
+      physical dimensions (equivalent to llGetScale/llSetScale).
     type: integer
     value: 7
   PRIM_SLICE:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_SLICE, vector slice ]'
+    tooltip: Prim parameter [PRIM_SLICE, vector slice] to get or set the prim's
+      slice values (a shape attribute equivalent to advanced cut).
     type: integer
     value: 35
   PRIM_SPECULAR:
     member-of: [PrimParam]
-    tooltip: Prim parameter for materials using integer face, string texture, vector
-      repeats, vector offsets, float rotation_in_radians, vector color, integer glossy,
-      integer environment
+    tooltip: Prim parameter to get or set the Blinn-Phong specular map texture
+      settings of a face. Requires face, texture, repeats, offsets,
+      rotation_in_radians, color, glossy, and environment arguments.
     type: integer
     value: 36
   PRIM_TEMP_ON_REZ:
     member-of: [PrimParam]
-    tooltip: ''
+    tooltip: Prim parameter used to get or set the object's temporary status.
+      Temporary objects live until the next garbage collection cycle (about 1
+      minute), do not count against normal prim limits, but are subject to
+      regional limits.
     type: integer
     value: 4
   PRIM_TEXGEN:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_TEXGEN, integer face, PRIM_TEXGEN_* ]'
+    tooltip: Prim parameter [PRIM_TEXGEN, integer face, integer mode] to get or set
+      the texture mapping mode of the face.
     type: integer
     value: 22
   PRIM_TEXGEN_DEFAULT:
     member-of: [PrimTexgen]
-    tooltip: ''
+    tooltip: Texture mapping mode setting for PRIM_TEXGEN. Specifies that texture
+      repeat units are measured in texture repeats per face.
     type: integer
     value: 0
   PRIM_TEXGEN_PLANAR:
     member-of: [PrimTexgen]
-    tooltip: ''
+    tooltip: Texture mapping mode setting for PRIM_TEXGEN. Specifies that texture
+      repeat units are measured in repeats per half-meter (unlike the in-world
+      editor, which measures in repeats per meter).
     type: integer
     value: 1
   PRIM_TEXT:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_TEXT, string text, vector color, float alpha ]'
+    tooltip: Prim parameter [PRIM_TEXT, string text, vector color, float alpha] to
+      get or set the object's floating/hover text (equivalent to llSetText).
     type: integer
     value: 26
   PRIM_TEXTURE:
     member-of: [PrimParam]
-    tooltip: '[ PRIM_TEXTURE, integer face, string texture, vector repeats, vector offsets, float rotation_in_radians ]'
+    tooltip: Prim parameter [PRIM_TEXTURE, integer face, string texture, vector
+      repeats, vector offsets, float rotation_in_radians] to get or set the
+      Blinn-Phong diffuse texture settings of a face.
     type: integer
     value: 17
   PRIM_TYPE:
     member-of: [PrimParam]
-    tooltip: ''
+    tooltip: Prim parameter used to get or set the geometric shape type
+      (PRIM_TYPE_*) and its associated parameters.
     type: integer
     value: 9
   PRIM_TYPE_BOX:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a box and
+      configure its shape properties.
     type: integer
     value: 0
   PRIM_TYPE_CYLINDER:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a cylinder and
+      configure its shape properties.
     type: integer
     value: 1
   PRIM_TYPE_PRISM:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a prism and
+      configure its shape properties.
     type: integer
     value: 2
   PRIM_TYPE_RING:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a ring and
+      configure its shape properties.
     type: integer
     value: 6
   PRIM_TYPE_SCULPT:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a sculpted
+      prim (sculpty) or mesh of a specific type.
     type: integer
     value: 7
   PRIM_TYPE_SPHERE:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a sphere and
+      configure its shape properties.
     type: integer
     value: 3
   PRIM_TYPE_TORUS:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a torus and
+      configure its shape properties.
     type: integer
     value: 4
   PRIM_TYPE_TUBE:
     member-of: [PrimType]
-    tooltip: ''
+    tooltip: Shape parameter for PRIM_TYPE used to define the prim as a tube and
+      configure its shape properties.
     type: integer
     value: 5
   PROFILE_NONE:
     member-of: [ScriptProfileMode]
-    tooltip: Disables profiling
+    tooltip: Disables script profiling.
     type: integer
     value: 0
   PROFILE_SCRIPT_MEMORY:
     member-of: [ScriptProfileMode]
-    tooltip: Enables memory profiling
+    tooltip: Enables script memory profiling, tracking the maximum amount of memory
+      consumed while it is active.
     type: integer
     value: 1
   PSYS_PART_BF_DEST_COLOR:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Scales the RGBA values by the RGBA values of the destination.
     type: integer
     value: 2
   PSYS_PART_BF_ONE:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: PSYS_PART_BF_ONE
     type: integer
     value: 0
   PSYS_PART_BF_ONE_MINUS_DEST_COLOR:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Scales the RGBA values by the inverted RGBA values of the destination.
     type: integer
     value: 4
   PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Scales the RGBA values by the inverted alpha values of the particle source.
     type: integer
     value: 9
   PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Scales the RGBA values by the inverted RGBA values of the particle source.
     type: integer
     value: 5
   PSYS_PART_BF_SOURCE_ALPHA:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Scales the RGBA values by the alpha values of the particle source.
     type: integer
     value: 7
   PSYS_PART_BF_SOURCE_COLOR:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Scales the RGBA values by the RGBA values of the particle source.
     type: integer
     value: 3
   PSYS_PART_BF_ZERO:
     member-of: [ParticleBlendFunc]
-    tooltip: ''
+    tooltip: Zeros out the source or destination RGBA values.
     type: integer
     value: 1
   PSYS_PART_BLEND_FUNC_DEST:
     member-of: [ParticleParam]
-    tooltip: ''
+    tooltip: Integer parameter defining the destination blending function.
     type: integer
     value: 25
   PSYS_PART_BLEND_FUNC_SOURCE:
     member-of: [ParticleParam]
-    tooltip: ''
+    tooltip: Integer parameter defining the source blending function.
     type: integer
     value: 24
   PSYS_PART_BOUNCE_MASK:
     member-of: [ParticleFlag]
-    tooltip: Particles bounce off of a plane at the objects Z height.
+    tooltip: Particle flag causing particles to bounce off a plane at the emitter
+      object's Z height.
     type: integer
     value: '0x4'
   PSYS_PART_EMISSIVE_MASK:
     member-of: [ParticleFlag]
-    tooltip: The particle glows.
+    tooltip: Particle flag that makes particles full-bright and unaffected by global
+      lighting (sunlight). Otherwise, particles are lit by current global
+      lighting or local point lights.
     type: integer
     value: '0x100'
   PSYS_PART_END_ALPHA:
     member-of: [ParticleParam]
-    tooltip: A float which determines the ending alpha of the object.
+    tooltip: Float parameter that determines the ending alpha (transparency) of the
+      particles.
     type: integer
     value: 4
   PSYS_PART_END_COLOR:
     member-of: [ParticleParam]
-    tooltip: A vector <r, g, b> which determines the ending color of the object.
+    tooltip: Vector parameter <r, g, b> that determines the ending color of the
+      particles.
     type: integer
     value: 3
   PSYS_PART_END_GLOW:
     member-of: [ParticleParam]
-    tooltip: ''
+    tooltip: Float parameter that determines the ending glow value of the particles.
     type: integer
     value: 27
   PSYS_PART_END_SCALE:
     member-of: [ParticleParam]
-    tooltip: A vector <sx, sy, z>, which is the ending size of the particle billboard
-      in meters (z is ignored).
+    tooltip: Vector parameter <sx, sy, z> defining the ending size of the particle
+      billboard in meters (z-axis value is ignored).
     type: integer
     value: 6
   PSYS_PART_FLAGS:
     member-of: [ParticleParam]
-    tooltip: Each particle that is emitted by the particle system is simulated based
-      on the following flags. To use multiple flags, bitwise or (|) them together.
+    tooltip: Integer bitfield parameter specifying the simulation flags for emitted
+      particles. Multiple flags can be combined using bitwise OR (|).
     type: integer
     value: 0
   PSYS_PART_FOLLOW_SRC_MASK:
     member-of: [ParticleFlag]
-    tooltip: The particle position is relative to the source objects position.
+    tooltip: Particle flag causing particle positions to remain relative to the
+      position and movement of the emitter. Enabling this flag disables the
+      PSYS_SRC_BURST_RADIUS rule.
     type: integer
     value: '0x10'
   PSYS_PART_FOLLOW_VELOCITY_MASK:
     member-of: [ParticleFlag]
-    tooltip: The particle orientation is rotated so the vertical axis faces towards
-      the particle velocity.
+    tooltip: Particle flag causing particles to rotate and orient their vertical
+      'top' toward their direction of movement or emission. Otherwise, they
+      remain vertically oriented with the top of the texture facing up.
     type: integer
     value: '0x20'
   PSYS_PART_INTERP_COLOR_MASK:
     member-of: [ParticleFlag]
-    tooltip: Interpolate both the color and alpha from the start value to the end
-      value.
+    tooltip: Particle flag causing the particle's color and alpha to smoothly
+      interpolate from their START values to their END values over its lifetime.
     type: integer
     value: '0x1'
   PSYS_PART_INTERP_SCALE_MASK:
     member-of: [ParticleFlag]
-    tooltip: Interpolate the particle scale from the start value to the end value.
+    tooltip: Particle flag causing the particle's size/scale to transition from its
+      START setting to its END setting over its lifetime.
     type: integer
     value: '0x2'
   PSYS_PART_MAX_AGE:
     member-of: [ParticleParam]
-    tooltip: Age in seconds of a particle at which it dies.
+    tooltip: Float parameter specifying the lifetime (age in seconds) of an
+      individual particle before it dies.
     type: integer
     value: 7
   PSYS_PART_RIBBON_MASK:
     member-of: [ParticleFlag]
-    tooltip: ''
+    tooltip: Particle flag that joins emitted particles into a continuous ribbon
+      strip. Textures stretch to join adjacent edges. Width is controlled by the
+      'x' start/end scale; 'y' controls maximum visibility distance. Ribbon
+      segments are not camera-facing, mimic the emitter's Z-axis, and require
+      horizontal movement to render.
     type: integer
     value: '0x400'
   PSYS_PART_START_ALPHA:
     member-of: [ParticleParam]
-    tooltip: A float which determines the starting alpha of the object.
+    tooltip: Float parameter that determines the starting alpha (transparency) of
+      the particles.
     type: integer
     value: 2
   PSYS_PART_START_COLOR:
     member-of: [ParticleParam]
-    tooltip: A vector <r, g, b> which determines the starting color of the object.
+    tooltip: Vector parameter <r, g, b> that determines the starting color of the
+      particles.
     type: integer
     value: 1
   PSYS_PART_START_GLOW:
     member-of: [ParticleParam]
-    tooltip: ''
+    tooltip: Float parameter that determines the starting glow value of the particles.
     type: integer
     value: 26
   PSYS_PART_START_SCALE:
     member-of: [ParticleParam]
-    tooltip: A vector <sx, sy, z>, which is the starting size of the particle billboard
-      in meters (z is ignored).
+    tooltip: Vector parameter <sx, sy, z> defining the starting size of the particle
+      billboard in meters (z-axis value is ignored).
     type: integer
     value: 5
   PSYS_PART_TARGET_LINEAR_MASK:
     member-of: [ParticleFlag]
-    tooltip: ''
+    tooltip: Particle flag causing emitted particles to move in a straight,
+      evenly-spaced line toward the PSYS_SRC_TARGET_KEY target. Ignores non-DROP
+      patterns, radius, burst speeds, angles, omega, acceleration, and wind.
+      Combining with bounce while target is below emitter deflects particles
+      upward.
     type: integer
     value: '0x80'
   PSYS_PART_TARGET_POS_MASK:
     member-of: [ParticleFlag]
-    tooltip: The particle heads towards the location of the target object as defined
-      by PSYS_SRC_TARGET_KEY.
+    tooltip: Particle flag causing emitted particles to change course and travel
+      toward the target specified by PSYS_SRC_TARGET_KEY during their lifetime.
+      If no valid or reachable target is set, particles target the emitting prim
+      itself.
     type: integer
     value: '0x40'
   PSYS_PART_WIND_MASK:
     member-of: [ParticleFlag]
-    tooltip: Particles have their velocity damped towards the wind velocity.
+    tooltip: Particle flag that applies wind as a secondary force on the particles,
+      damping their velocity toward the wind velocity.
     type: integer
     value: '0x8'
   PSYS_SRC_ACCEL:
     member-of: [ParticleParam]
-    tooltip: A vector <x, y, z> which is the acceleration to apply on particles.
+    tooltip: Vector parameter <x, y, z> specifying the constant acceleration to
+      apply to particles.
     type: integer
     value: 8
   PSYS_SRC_ANGLE_BEGIN:
     member-of: [ParticleParam]
-    tooltip: Area in radians specifying where particles will NOT be created (for ANGLE
-      patterns)
+    tooltip: Float parameter specifying the angle in radians where particles will
+      not be created (for ANGLE patterns).
     type: integer
     value: 22
   PSYS_SRC_ANGLE_END:
     member-of: [ParticleParam]
-    tooltip: Area in radians filled with particles (for ANGLE patterns) (if lower
-      than PSYS_SRC_ANGLE_BEGIN, acts as PSYS_SRC_ANGLE_BEGIN itself, and PSYS_SRC_ANGLE_BEGIN
-      acts as PSYS_SRC_ANGLE_END).
+    tooltip: Float parameter specifying the ending angle in radians to be filled
+      with particles (for ANGLE patterns). If smaller than angle_begin, their
+      roles are swapped.
     type: integer
     value: 23
   PSYS_SRC_BURST_PART_COUNT:
     member-of: [ParticleParam]
-    tooltip: How many particles to release in a burst.
+    tooltip: Integer parameter specifying the number of particles to release in each
+      burst.
     type: integer
     value: 15
   PSYS_SRC_BURST_RADIUS:
     member-of: [ParticleParam]
-    tooltip: What distance from the center of the object to create the particles.
+    tooltip: Float parameter specifying the radial distance from the emitter's
+      center at which particles are created.
     type: integer
     value: 16
   PSYS_SRC_BURST_RATE:
     member-of: [ParticleParam]
-    tooltip: How often to release a particle burst (float seconds).
+    tooltip: Float parameter specifying the interval in seconds between particle bursts.
     type: integer
     value: 13
   PSYS_SRC_BURST_SPEED_MAX:
     member-of: [ParticleParam]
-    tooltip: Maximum speed that a particle should be moving.
+    tooltip: Float parameter specifying the maximum initial speed of emitted particles.
     type: integer
     value: 18
   PSYS_SRC_BURST_SPEED_MIN:
     member-of: [ParticleParam]
-    tooltip: Minimum speed that a particle should be moving.
+    tooltip: Float parameter specifying the minimum initial speed of emitted particles.
     type: integer
     value: 17
   PSYS_SRC_INNERANGLE:
     member-of: [ParticleParam]
-    tooltip: "Specifies the inner angle of the arc created by the PSYS_SRC_PATTERN_ANGLE\
-      \ or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area specified will\
-      \ NOT have particles in it."
+    tooltip: Float parameter specifying the inner angle of the arc for ANGLE or
+      ANGLE_CONE patterns. The specified inner area will not contain particles.
     type: integer
     value: 10
   PSYS_SRC_MAX_AGE:
     member-of: [ParticleParam]
-    tooltip: How long this particle system should last, 0.0 means forever.
+    tooltip: Float parameter specifying the active duration of the particle system
+      in seconds (0.0 means forever).
     type: integer
     value: 19
   # These were present in the lexer, but not in the syntax file, they're marked private for consistency.
@@ -4290,654 +4726,734 @@ constants:
   PSYS_SRC_OBJ_REL_MASK:
     member-of: [ParticleParam]
     private: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x1'
   PSYS_SRC_OMEGA:
     member-of: [ParticleParam]
-    tooltip: Sets the angular velocity to rotate the axis that SRC_PATTERN_ANGLE and
-      SRC_PATTERN_ANGLE_CONE use.
+    tooltip: Vector parameter setting the angular velocity used to rotate the
+      emission axis for ANGLE and ANGLE_CONE patterns.
     type: integer
     value: 21
   PSYS_SRC_OUTERANGLE:
     member-of: [ParticleParam]
-    tooltip: "Specifies the outer angle of the arc created by the PSYS_SRC_PATTERN_ANGLE\
-      \ or PSYS_SRC_PATTERN_ANGLE_CONE source pattern.\n\t\t\tThe area between the\
-      \ outer and inner angle will be filled with particles."
+    tooltip: Float parameter specifying the outer angle of the arc for ANGLE or
+      ANGLE_CONE patterns. The area between the outer and inner angles is filled
+      with particles.
     type: integer
     value: 11
   PSYS_SRC_PATTERN:
     member-of: [ParticleParam]
-    tooltip: "The pattern which is used to generate particles.\n\t\t\tUse one of the\
-      \ following values: PSYS_SRC_PATTERN Values."
+    tooltip: Integer parameter specifying the generation pattern
+      (PSYS_SRC_PATTERN_*) used to emit particles.
     type: integer
     value: 9
   PSYS_SRC_PATTERN_ANGLE:
     member-of: [ParticleSourcePattern]
-    tooltip: Shoot particles across a 2 dimensional area defined by the arc created
-      from PSYS_SRC_OUTERANGLE. There will be an open area defined by PSYS_SRC_INNERANGLE
-      within the larger arc.
+    tooltip: Emission pattern that sprays particles outward in a flat circular,
+      semi-circular, arc, or ray-shaped 2D area (around the prim's local X-axis)
+      as defined by the start/end and inner/outer angle parameters.
     type: integer
     value: '0x04'
   PSYS_SRC_PATTERN_ANGLE_CONE:
     member-of: [ParticleSourcePattern]
-    tooltip: Shoot particles out in a 3 dimensional cone with an outer arc of PSYS_SRC_OUTERANGLE
-      and an inner open area defined by PSYS_SRC_INNERANGLE.
+    tooltip: Emission pattern that sprays particles outward in a 3D spherical,
+      conical, or ring-shaped area defined by the start/end and inner/outer
+      angle parameters. Can emulate the EXPLODE pattern if angles are set to 0.0
+      and PI.
     type: integer
     value: '0x08'
   PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY:
     member-of: [ParticleSourcePattern]
-    tooltip: ''
+    tooltip: Incomplete emission pattern that behaves identically to the DROP
+      pattern. Intended to invert the ANGLE parameters to define an empty area
+      where particles are not sprayed.
     type: integer
     value: '0x10'
   PSYS_SRC_PATTERN_DROP:
     member-of: [ParticleSourcePattern]
-    tooltip: Drop particles at the source position.
+    tooltip: Emission pattern that drops particles at the source position with no
+      initial velocity. Overrides burst radius, minimum speed, and maximum speed
+      settings to 0.0.
     type: integer
     value: '0x01'
   PSYS_SRC_PATTERN_EXPLODE:
     member-of: [ParticleSourcePattern]
-    tooltip: Shoot particles out in all directions, using the burst parameters.
+    tooltip: Emission pattern that shoots particles outward in all directions using
+      the burst parameters.
     type: integer
     value: '0x02'
   PSYS_SRC_TARGET_KEY:
     member-of: [ParticleParam]
-    tooltip: The key of a target object to move towards if PSYS_PART_TARGET_POS_MASK
-      is enabled.
+    tooltip: Key (UUID) of the target object that particles travel toward when
+      PSYS_PART_TARGET_POS_MASK or PSYS_PART_TARGET_LINEAR_MASK is enabled.
     type: integer
     value: 20
   PSYS_SRC_TEXTURE:
     member-of: [ParticleParam]
-    tooltip: An asset name for the texture to use for the particles.
+    tooltip: String parameter specifying the inventory name or UUID asset key of the
+      texture used for the particles.
     type: integer
     value: 12
   PUBLIC_CHANNEL:
-    tooltip: PUBLIC_CHANNEL is an integer constant that, when passed to llSay, llWhisper,
-      or llShout as a channel parameter, will print text to the publicly heard chat
-      channel.
+    tooltip: Integer constant representing the open local chat channel. Passing this
+      to chat functions (llSay, llWhisper, llShout) prints text to the publicly
+      heard chat seen by nearby users and objects.
     type: integer
     value: 0
   PURSUIT_FUZZ_FACTOR:
     member-of: [CharacterPursueParam]
-    tooltip: Selects a random destination near the offset.
+    tooltip: Option for llPursue that selects a random destination near the
+      PURSUIT_OFFSET (range is 0 to 1, where 1 is most random). Requires a
+      non-zero PURSUIT_OFFSET.
     type: integer
     value: 3
   PURSUIT_GOAL_TOLERANCE:
     member-of: [CharacterPursueParam]
-    tooltip: ''
+    tooltip: Option for llPursue defining how close (between 0.25m and 10m) the
+      character must be to consider the goal reached.
     type: integer
     value: 5
   PURSUIT_INTERCEPT:
     member-of: [CharacterPursueParam]
-    tooltip: Define whether the character attempts to predict the target's location.
+    tooltip: Option for llPursue specifying whether the pathfinding character
+      attempts to predict and intercept the target's future location.
     type: integer
     value: 4
   PURSUIT_OFFSET:
     member-of: [CharacterPursueParam]
-    tooltip: Go to a position offset from the target.
+    tooltip: Option for llPursue specifying a constant position offset relative to
+      the target for the character to navigate toward.
     type: integer
     value: 1
   PU_EVADE_HIDDEN:
     member-of: [CharacterPathUpdateType]
-    tooltip: Triggered when an llEvade character thinks it has hidden from its pursuer.
+    tooltip: Path update status code triggered when an llEvade character determines
+      it has successfully hidden from its pursuer.
     type: integer
     value: '0x07'
   PU_EVADE_SPOTTED:
     member-of: [CharacterPathUpdateType]
-    tooltip: Triggered when an llEvade character switches from hiding to running
+    tooltip: Path update status code triggered when an llEvade character switches
+      from hiding to running.
     type: integer
     value: '0x08'
   PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED:
     member-of: [CharacterPathUpdateType]
-    tooltip: ''
+    tooltip: Path update failure code triggered when a character enters a region
+      where dynamic pathfinding has been disabled in the Region Debug Console.
     type: integer
     value: 10
   PU_FAILURE_INVALID_GOAL:
     member-of: [CharacterPathUpdateType]
-    tooltip: Goal is not on the navigation-mesh and cannot be reached.
+    tooltip: Path update failure code triggered when the specified goal is not on
+      the region's navigation mesh (navmesh) and is unreachable.
     type: integer
     value: '0x03'
   PU_FAILURE_INVALID_START:
     member-of: [CharacterPathUpdateType]
-    tooltip: Character cannot navigate from the current location - e.g., the character
-      is off the navmesh or too high above it.
+    tooltip: Path update failure code triggered when the character is at an
+      unnavigable starting position (e.g., off the navmesh or too high above
+      it).
     type: integer
     value: '0x02'
   PU_FAILURE_NO_NAVMESH:
     member-of: [CharacterPathUpdateType]
-    tooltip: This is a fatal error reported to a character when there is no navmesh
-      for the region. This usually indicates a server failure and users should file
-      a bug report and include the time and region in which they received this message.
+    tooltip: Path update fatal error triggered when there is no navmesh generated
+      for the region (typically indicates a server failure).
     type: integer
     value: '0x09'
   PU_FAILURE_NO_VALID_DESTINATION:
     member-of: [CharacterPathUpdateType]
-    tooltip: There is no good place for the character to go - e.g., it is patrolling
-      and all the patrol points are now unreachable.
+    tooltip: Path update failure code triggered when no reachable destinations
+      remain (e.g., all patrol waypoints are blocked).
     type: integer
     value: '0x06'
   PU_FAILURE_OTHER:
     member-of: [CharacterPathUpdateType]
-    tooltip: ''
+    tooltip: Path update failure code representing an unspecified or general failure.
     type: integer
     value: 1000000
   PU_FAILURE_PARCEL_UNREACHABLE:
     member-of: [CharacterPathUpdateType]
-    tooltip: ''
+    tooltip: Path update failure code triggered when a character is blocked from
+      entering a parcel (e.g., the parcel is full or object entry was disabled
+      after the navmesh was baked).
     type: integer
     value: 11
   PU_FAILURE_TARGET_GONE:
     member-of: [CharacterPathUpdateType]
-    tooltip: Target (for llPursue or llEvade) can no longer be tracked - e.g., it
-      left the region or is an avatar that is now more than about 30m outside the
-      region.
+    tooltip: Path update failure code triggered when an llPursue or llEvade target
+      can no longer be tracked (e.g., they left the region or went more than
+      ~30m outside region boundaries).
     type: integer
     value: '0x05'
   PU_FAILURE_UNREACHABLE:
     member-of: [CharacterPathUpdateType]
-    tooltip: Goal is no longer reachable for some reason - e.g., an obstacle blocks
-      the path.
+    tooltip: Path update failure code triggered when a previously valid goal becomes
+      unreachable (e.g., an obstacle blocks the path).
     type: integer
     value: '0x04'
   PU_GOAL_REACHED:
     member-of: [CharacterPathUpdateType]
-    tooltip: Character has reached the goal and will stop or choose a new goal (if
-      wandering).
+    tooltip: Path update status code triggered when the character reaches its goal
+      and either stops or chooses a new goal (if wandering).
     type: integer
     value: '0x01'
   PU_SLOWDOWN_DISTANCE_REACHED:
     member-of: [CharacterPathUpdateType]
-    tooltip: Character is near current goal.
+    tooltip: Path update status code triggered when the character enters the
+      slowdown distance near its current goal.
     type: integer
     value: '0x00'
   RAD_TO_DEG:
-    tooltip: 57.2957795 - Number of degrees per radian. You can use this number to
-      convert radians to degrees by multiplying the radians by this number.
+    tooltip: The constant 57.2957795 (precise value is 180/PI). Multiply a value in
+      radians by this number to convert it to degrees.
     type: float
     value: '57.2957795'
   RCERR_CAST_TIME_EXCEEDED:
     member-of: [RayCastError]
-    tooltip: ''
+    tooltip: Raycast error indicating the parcel or agent exceeded the maximum
+      allocated raycast time. Waiting a few frames and retrying will usually
+      succeed as resources replenish.
     type: integer
     value: -3
   RCERR_SIM_PERF_LOW:
     member-of: [RayCastError]
-    tooltip: ''
+    tooltip: Raycast error indicating the request failed due to low simulator
+      performance. Wait before retrying, and if possible, reduce scene
+      complexity.
     type: integer
     value: -2
   RCERR_UNKNOWN:
     member-of: [RayCastError]
-    tooltip: ''
+    tooltip: Raycast error indicating an unspecified failure.
     type: integer
     value: -1
   RC_DATA_FLAGS:
     member-of: [RayCastParam]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to configure returned data.
     type: integer
     value: 2
   RC_DETECT_PHANTOM:
     member-of: [RayCastParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   RC_GET_LINK_NUM:
     member-of: [RayCastData]
-    tooltip: ''
+    tooltip: Flag used with llCastRay causing the results stride to include the
+      specific link number that was hit.
     type: integer
     value: 4
   RC_GET_NORMAL:
     member-of: [RayCastData]
-    tooltip: ''
+    tooltip: Flag used with llCastRay causing the results stride to include the
+      surface normal vector of the impact point.
     type: integer
     value: 1
   RC_GET_ROOT_KEY:
     member-of: [RayCastData]
-    tooltip: ''
+    tooltip: Flag used with llCastRay that returns the key of the hit object's root
+      prim instead of the hit child prim.
     type: integer
     value: 2
   RC_MAX_HITS:
     member-of: [RayCastParam]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to set the maximum number of hits to return
+      (up to 256). To avoid performance issues, keep this value small.
     type: integer
     value: 3
   RC_REJECT_AGENTS:
     member-of: [RayCastRejectType]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to prevent the detection of avatars.
     type: integer
     value: 1
   RC_REJECT_LAND:
     member-of: [RayCastRejectType]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to ignore the actual terrain ground (land).
     type: integer
     value: 8
   RC_REJECT_NONPHYSICAL:
     member-of: [RayCastRejectType]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to ignore non-physical objects.
     type: integer
     value: 4
   RC_REJECT_PHYSICAL:
     member-of: [RayCastRejectType]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to ignore physical objects.
     type: integer
     value: 2
   RC_REJECT_TYPES:
     member-of: [RayCastParam]
-    tooltip: ''
+    tooltip: Flag used with llCastRay to define a mask for ignoring specific types
+      of objects and avatars.
     type: integer
     value: 0
   REGION_FLAG_ALLOW_DAMAGE:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if the region is entirely
+      damage-enabled.
     type: integer
     value: '0x1'
   REGION_FLAG_ALLOW_DIRECT_TELEPORT:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if direct teleportation is
+      allowed in the region.
     type: integer
     value: '0x100000'
   REGION_FLAG_BLOCK_FLY:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if flying is blocked/disabled
+      in the region.
     type: integer
     value: '0x80000'
   REGION_FLAG_BLOCK_FLYOVER:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: '0x8000000'
   REGION_FLAG_BLOCK_TERRAFORM:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if terraforming is disabled in
+      the region.
     type: integer
     value: '0x40'
   REGION_FLAG_DISABLE_COLLISIONS:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if collisions have been
+      disabled in the region.
     type: integer
     value: '0x1000'
   REGION_FLAG_DISABLE_PHYSICS:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if physics has been disabled
+      in the region.
     type: integer
     value: '0x4000'
   REGION_FLAG_FIXED_SUN:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if the sun's position is fixed
+      in the region.
     type: integer
     value: '0x10'
   REGION_FLAG_RESTRICT_PUSHOBJECT:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if llPushObject is restricted
+      in the region.
     type: integer
     value: '0x400000'
   REGION_FLAG_SANDBOX:
     member-of: [RegionFlag]
-    tooltip: ''
+    tooltip: Flag used with llGetRegionFlags to check if the region is designated as
+      a sandbox.
     type: integer
     value: '0x100'
   REMOTE_DATA_CHANNEL:
     member-of: [RemoteDataEventType]
     deprecated: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   REMOTE_DATA_REPLY:
     member-of: [RemoteDataEventType]
     deprecated: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 3
   REMOTE_DATA_REQUEST:
     member-of: [RemoteDataEventType]
     deprecated: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   REQUIRE_LINE_OF_SIGHT:
     member-of: [CharacterPursueParam]
-    tooltip: Define whether the character needs a line-of-sight to give chase.
+    tooltip: Option flag for llPursue defining whether the character requires a
+      physical line-of-sight to chase the target. When active, it will not
+      target positions blocked by solid obstacles.
     type: integer
     value: 2
   RESTITUTION:
     member-of: [PhysicsMaterialParam]
-    tooltip: Used with llSetPhysicsMaterial to enable the density value. Must be between
-      0.0 and 1.0
+    tooltip: Used with llSetPhysicsMaterial to enable the restitution (bounciness)
+      value (must be between 0.0 and 1.0) which overrides the previous value.
     type: integer
     value: 4
   REVERSE:
     member-of: [TextureAnimMode]
-    tooltip: Play animation in reverse direction.
+    tooltip: Used with texture animation functions to cause the animation to play in
+      reverse (from end to start).
     type: integer
     value: '0x4'
   REZ_ACCEL:
     member-of: [RezParam]
-    tooltip: Acceleration forced applied to the rezzed object. [vector force, integer
-      rel]
+    tooltip: Rez parameter specifying a constant acceleration force to apply to the
+      rezzed object (as a [vector force, integer relative] pair). If relative is
+      TRUE, the vector is in local coordinates.
     type: integer
     value: 5
   REZ_DAMAGE:
     member-of: [RezParam]
-    tooltip: Damage applied by the object when it collides with an agent. [float damage]
+    tooltip: Rez parameter specifying the float damage amount the rezzed object
+      inflicts on an agent upon collision.
     type: integer
     value: 8
   REZ_DAMAGE_TYPE:
     member-of: [RezParam]
-    tooltip: Set the damage type applied when this object collides. [integer damage_type]
+    tooltip: Rez parameter specifying the integer damage type applied on collision
+      (supports DAMAGE_TYPE_* constants, custom types, or a repurposed damage
+      field).
     type: integer
     value: 12
   REZ_FLAGS:
     member-of: [RezParam]
-    tooltip: Rez flags to set on the newly rezzed object. [integer flags]
+    tooltip: Rez parameter specifying the integer bitfield of flags to apply to the
+      newly created object.
     type: integer
     value: 1
   REZ_FLAG_BLOCK_GRAB_OBJECT:
     member-of: [RezFlag]
-    tooltip: Prevent grabbing the object.
+    tooltip: Rez flag that disables grabbing on the newly rezzed object.
     type: integer
     value: '0x0080'
   REZ_FLAG_DIE_ON_COLLIDE:
     member-of: [RezFlag]
-    tooltip: Object will die after its first collision.
+    tooltip: Rez flag causing the object to die/delete after its first collision.
     type: integer
     value: '0x0008'
   REZ_FLAG_DIE_ON_NOENTRY:
     member-of: [RezFlag]
-    tooltip: Object will die if it attempts to enter a parcel that it can not.
+    tooltip: Rez flag causing the object to die/delete if it attempts to enter an
+      unauthorized parcel.
     type: integer
     value: '0x0010'
   REZ_FLAG_NO_COLLIDE_FAMILY:
     member-of: [RezFlag]
-    tooltip: Object will not trigger collision events with other objects created by
-      the same rezzer.
+    tooltip: Rez flag preventing collision events from triggering when colliding
+      with other objects created by the same rezzer.
     type: integer
     value: '0x0040'
   REZ_FLAG_NO_COLLIDE_OWNER:
     member-of: [RezFlag]
-    tooltip: Object will not trigger collision events with its owner.
+    tooltip: Rez flag preventing collision events from triggering when colliding
+      with its owner.
     type: integer
     value: '0x0020'
   REZ_FLAG_PHANTOM:
     member-of: [RezFlag]
-    tooltip: Make the object phantom on rez.
+    tooltip: Rez flag causing the object to be created as phantom.
     type: integer
     value: '0x0004'
   REZ_FLAG_PHYSICAL:
     member-of: [RezFlag]
-    tooltip: Make the object physical on rez.
+    tooltip: Rez flag causing the object to be created with physics enabled.
     type: integer
     value: '0x0002'
   REZ_FLAG_TEMP:
     member-of: [RezFlag]
-    tooltip: Flag the object as temp on rez.
+    tooltip: Rez flag causing the object to be created as temporary.
     type: integer
     value: '0x0001'
   REZ_LOCK_AXES:
     member-of: [RezParam]
-    tooltip: Prevent the object from rotating around some axes. [vector locks]
+    tooltip: Rez parameter [vector locks] used to prevent the physical object from
+      rotating or spinning around specified axes. Setting a coordinate to a
+      non-zero value locks that axis.
     type: integer
     value: 11
   REZ_OMEGA:
     member-of: [RezParam]
-    tooltip: Omega applied to the rezzed object. [vector axis, integer rel, float
-      spin, float gain]
+    tooltip: Rez parameter specifying the initial angular velocity (omega) applied
+      to the object. Accepts [vector axis, integer relative, float spin, float
+      gain]. If relative is TRUE, the axis vector is in local coordinates.
     type: integer
     value: 7
   REZ_PARAM:
     member-of: [RezParam]
-    tooltip: Integer value to pass to the object as its rez parameter. [integer param]
+    tooltip: Rez parameter specifying the integer start parameter passed into the
+      newly rezzed object's on_rez event.
     type: integer
     value: 0
   REZ_PARAM_STRING:
     member-of: [RezParam]
-    tooltip: A string value to pass to the object as its rez parameter. [string param]
+    tooltip: Rez parameter specifying an initialization string (up to 1024 bytes)
+      passed to the root prim of the newly rezzed object, readable via
+      llGetStartString.
     type: integer
     value: 13
   REZ_POS:
     member-of: [RezParam]
-    tooltip: Position at which to rez the new object. [vector position, integer rel,
-      integer atroot]
+    tooltip: Rez parameter [vector position, integer relative, integer at_root] to
+      specify where to rez the object. Can be in region coordinates or relative
+      to the rezzing object, and centered on either the object's center or the
+      root prim.
     type: integer
     value: 2
   REZ_ROT:
     member-of: [RezParam]
-    tooltip: Rotation applied to newly rezzed object. [rotation rot, integer rel]
+    tooltip: Rez parameter specifying the initial rotation to apply to the newly
+      rezzed object. Can be relative to the rezzing object or absolute.
     type: integer
     value: 3
   REZ_SOUND:
     member-of: [RezParam]
-    tooltip: Sound attached to the rezzed object. [string name, float volume, integer
-      loop]
+    tooltip: Rez parameter [string name_or_uuid, float volume, integer loop] to
+      attach and play a sound from inventory or a UUID asset key. If loop is
+      TRUE, it loops continuously.
     type: integer
     value: 9
   REZ_SOUND_COLLIDE:
     member-of: [RezParam]
-    tooltip: Sound played by the object on a collision. [string name, float volume]
+    tooltip: Rez parameter [string name_or_uuid, float volume] specifying a sound
+      (from inventory or a UUID asset key) to play upon collision with another
+      object, the ground, or an avatar.
     type: integer
     value: 10
   REZ_TORQUE:
     member-of: [RezParam]
     private: true
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 6
   REZ_VEL:
     member-of: [RezParam]
-    tooltip: Initial velocity of rezzed object. [vector vel, integer rel, integer
-      inherit]
+    tooltip: Rez parameter specifying the initial velocity to apply to the object.
+      Accepts [vector velocity, integer local, integer inherit]. If inherit is
+      TRUE, it adds the rezzing object's velocity.
     type: integer
     value: 4
   ROTATE:
     member-of: [TextureAnimMode]
-    tooltip: Animate texture rotation.
+    tooltip: Used with texture animation functions to animate the texture's
+      rotation. Cannot be combined with SCALE.
     type: integer
     value: '0x20'
   SCALE:
     member-of: [TextureAnimMode]
-    tooltip: Animate the texture scale.
+    tooltip: Used with texture animation functions to animate the texture's scale.
+      Cannot be combined with ROTATE.
     type: integer
     value: '0x40'
   SCRIPTED:
     member-of: [DetectType]
-    tooltip: Scripted in-world objects.
+    tooltip: Identifies scripted in-world objects. In llDetectedType(), indicates
+      the target has at least one active script. In llSensor()/llSensorRepeat()
+      filters, searches for objects containing active scripts that are currently
+      running.
     type: integer
     value: '0x8'
   SIM_STAT_ACTIVE_SCRIPT_COUNT:
     member-of: [SimulatorStat]
-    tooltip: Number of active scripts.
+    tooltip: Returns the total number of active scripts in the region.
     type: integer
     value: 12
   SIM_STAT_AGENT_COUNT:
     member-of: [SimulatorStat]
-    tooltip: Number of agents in region.
+    tooltip: Returns the total number of agents in the region.
     type: integer
     value: 10
   SIM_STAT_AGENT_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent in 'agent' segment of simulation frame.
+    tooltip: Returns the time spent in the 'agent' segment of the simulation frame.
     type: integer
     value: 7
   SIM_STAT_AGENT_UPDATES:
     member-of: [SimulatorStat]
-    tooltip: Agent updates per second.
+    tooltip: Returns the number of agent updates per second.
     type: integer
     value: 2
   SIM_STAT_AI_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent on AI step.
+    tooltip: Returns the time spent on the AI step.
     type: integer
     value: 26
   SIM_STAT_ASSET_DOWNLOADS:
     member-of: [SimulatorStat]
-    tooltip: Pending asset download count.
+    tooltip: Returns the pending asset download count.
     type: integer
     value: 15
   SIM_STAT_ASSET_UPLOADS:
     member-of: [SimulatorStat]
-    tooltip: Pending asset upload count.
+    tooltip: Returns the pending asset upload count.
     type: integer
     value: 16
   SIM_STAT_CHILD_AGENT_COUNT:
     member-of: [SimulatorStat]
-    tooltip: Number of child agents in region.
+    tooltip: Returns the number of child (neighboring) agents in the region.
     type: integer
     value: 11
   SIM_STAT_FRAME_MS:
     member-of: [SimulatorStat]
-    tooltip: Total frame time.
+    tooltip: Returns the total frame time.
     type: integer
     value: 3
   SIM_STAT_IMAGE_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent in 'image' segment of simulation frame.
+    tooltip: Returns the time spent in the 'image' segment of the simulation frame.
     type: integer
     value: 8
   SIM_STAT_IO_PUMP_MS:
     member-of: [SimulatorStat]
-    tooltip: Pump IO time.
+    tooltip: Returns the pump IO time.
     type: integer
     value: 24
   SIM_STAT_NET_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent in 'network' segment of simulation frame.
+    tooltip: Returns the time spent in the 'network' segment of the simulation frame.
     type: integer
     value: 4
   SIM_STAT_OTHER_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent in 'other' segment of simulation frame.
+    tooltip: Returns the time spent in the main simulation 'other' segment of the
+      frame, which encapsulates task, script, and miscellaneous updates.
     type: integer
     value: 5
   SIM_STAT_PACKETS_IN:
     member-of: [SimulatorStat]
-    tooltip: Packets in per second.
+    tooltip: Returns the average number of incoming packets per second.
     type: integer
     value: 13
   SIM_STAT_PACKETS_OUT:
     member-of: [SimulatorStat]
-    tooltip: Packets out per second.
+    tooltip: Returns the average number of outgoing packets per second.
     type: integer
     value: 14
   SIM_STAT_PCT_CHARS_STEPPED:
     member-of: [SimulatorStat]
-    tooltip: Returns the % of pathfinding characters skipped each frame, averaged
-      over the last minute.\nThe returned value corresponds to the "Characters Updated"
-      stat in the viewer's Statistics Bar.
+    tooltip: Returns the percentage of pathfinding characters updated (or skipped)
+      each frame, averaged over the last minute. Corresponds to the 'Characters
+      Updated' stat in the viewer's Statistics Bar.
     type: integer
     value: 0
   SIM_STAT_PHYSICS_FPS:
     member-of: [SimulatorStat]
-    tooltip: Physics simulation FPS.
+    tooltip: Returns the physics simulation frames per second (FPS).
     type: integer
     value: 1
   SIM_STAT_PHYSICS_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent in 'physics' segment of simulation frame.
+    tooltip: Returns the time spent in the 'physics' segment of the simulation frame.
     type: integer
     value: 6
   SIM_STAT_PHYSICS_OTHER_MS:
     member-of: [SimulatorStat]
-    tooltip: Physics other time.
+    tooltip: Returns the average update time for the physics 'other' segment.
     type: integer
     value: 20
   SIM_STAT_PHYSICS_SHAPE_MS:
     member-of: [SimulatorStat]
-    tooltip: Physics shape update time.
+    tooltip: Returns the average update time for the physics 'shape' segment.
     type: integer
     value: 19
   SIM_STAT_PHYSICS_STEP_MS:
     member-of: [SimulatorStat]
-    tooltip: Physics step time.
+    tooltip: Returns the average physics step time.
     type: integer
     value: 18
   SIM_STAT_SCRIPT_EPS:
     member-of: [SimulatorStat]
-    tooltip: Script events per second.
+    tooltip: Returns the number of script events per second.
     type: integer
     value: 21
   SIM_STAT_SCRIPT_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent in 'script' segment of simulation frame.
+    tooltip: Returns the time spent in the 'script' segment of the simulation frame.
     type: integer
     value: 9
   SIM_STAT_SCRIPT_RUN_PCT:
     member-of: [SimulatorStat]
-    tooltip: Percent of scripts run during frame.
+    tooltip: Returns the percentage of scripts run during the frame.
     type: integer
     value: 25
   SIM_STAT_SLEEP_MS:
     member-of: [SimulatorStat]
-    tooltip: Time spent sleeping.
+    tooltip: Returns the time spent sleeping.
     type: integer
     value: 23
   SIM_STAT_SPARE_MS:
     member-of: [SimulatorStat]
-    tooltip: Spare time left after frame.
+    tooltip: Returns the spare time left after the frame.
     type: integer
     value: 22
   SIM_STAT_UNACKED_BYTES:
     member-of: [SimulatorStat]
-    tooltip: Total unacknowledged bytes.
+    tooltip: Returns the total number of unacknowledged bytes.
     type: integer
     value: 17
   SIT_FLAG_ALLOW_UNSIT:
     member-of: [SitFlag]
-    tooltip: The prim allows a seated avatar to stand up.
+    tooltip: Sit flag indicating that a seated avatar is allowed to manually stand
+      up (unsit) from a sit target. Applies only to agents who were seated via
+      an LSL script like llSitOnLink.
     type: integer
     value: '0x0002'
   SIT_FLAG_NO_COLLIDE:
     member-of: [SitFlag]
-    tooltip: The seated avatar's hit box is disabled when seated on this prim.
+    tooltip: Sit flag that disables the avatar's collision volume/hitbox while
+      seated on this sit target.
     type: integer
     value: '0x0010'
   SIT_FLAG_NO_DAMAGE:
     member-of: [SitFlag]
-    tooltip: Damage will not be forwarded to an avatar seated on this prim.
+    tooltip: Sit flag that prevents damage from being distributed or forwarded to
+      agents sitting on this sit target.
     type: integer
     value: '0x0020'
   SIT_FLAG_SCRIPTED_ONLY:
     member-of: [SitFlag]
-    tooltip: An avatar may not manually sit on this prim.
+    tooltip: Sit flag that restricts sits to script-controlled actions only,
+      preventing avatars from manually sitting on this prim.
     type: integer
     value: '0x0004'
   SIT_FLAG_SIT_TARGET:
     member-of: [SitFlag]
-    tooltip: The prim has an explicitly set sit target.
+    tooltip: Read-only sit flag indicating whether the prim has an active sit
+      target. Set or cleared using llSitTarget, llLinkSitTarget, or
+      PRIM_SIT_TARGET, and read via llGetLinkSitFlags or PRIM_SIT_FLAGS.
     type: integer
     value: '0x0001'
   SIT_INVALID_AGENT:
     member-of: [SitError]
-    tooltip: Avatar ID did not specify a valid avatar.
+    tooltip: Sit error code indicating that the specified agent/avatar ID could not
+      be found or is invalid.
     type: integer
     value: -4
   SIT_INVALID_LINK:
     member-of: [SitError]
-    tooltip: Link ID did not specify a valid prim in the linkset or resolved to multiple
-      prims.
+    tooltip: Sit error code indicating that the link ID does not specify a valid
+      prim, is not found, or resolves to multiple prims.
     type: integer
     value: -5
   SIT_INVALID_OBJECT:
     member-of: [SitError]
-    tooltip: Attempt to force an avatar to sit on an attachment or other invalid target.
+    tooltip: Sit error code returned when attempting to force an avatar to sit on an
+      invalid target (such as an attachment) that cannot be sat upon.
     type: integer
     value: -7
   SIT_NOT_EXPERIENCE:
     member-of: [SitError]
-    tooltip: Attempt to force an avatar to sit outside an experience.
+    tooltip: Sit error code returned if the script is not running within a valid
+      experience, lacks a valid experience key, or the experience is not
+      permitted at the current location.
     type: integer
     value: -1
   SIT_NO_ACCESS:
     member-of: [SitError]
-    tooltip: Avatar does not have access to the parcel containing the target linkset
-      of the forced sit.
+    tooltip: Sit error code indicating that the avatar lacks access to the parcel
+      where the target prim/linkset is located.
     type: integer
     value: -6
   SIT_NO_EXPERIENCE_PERMISSION:
     member-of: [SitError]
-    tooltip: Avatar has not granted permission to force sits.
+    tooltip: Sit error code indicating that the agent has not granted experience
+      permissions to force sits.
     type: integer
     value: -2
   SIT_NO_SIT_TARGET:
     member-of: [SitError]
-    tooltip: No available sit target in linkset for forced sit.
+    tooltip: Sit error code indicating that no open or available sit target could be
+      found in the linkset.
     type: integer
     value: -3
   SIT_OK:
@@ -4948,893 +5464,982 @@ constants:
   SKY_ABSORPTION_CONFIG:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 16
   SKY_AMBIENT:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: The ambient color of the environment
+    tooltip: Environmental setting for the ambient color used in the scene.
     type: integer
     value: 0
   SKY_BLUE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Blue settings for environment
+    tooltip: Environmental setting containing the colors used to calculate blue
+      density and blue horizon in the sky.
     type: integer
     value: 22
   SKY_CLOUDS:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Settings controlling cloud density and configuration
+    tooltip: Environmental cloud parameters including color, coverage percentage,
+      scale, variance, scroll speed (X/Y), density, detail exponents, and
+      default texture status.
     type: integer
     value: 2
   SKY_CLOUD_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Texture ID used by clouds
+    tooltip: Environmental setting containing the inventory name or UUID of the
+      texture used for the clouds.
     type: integer
     value: 19
   SKY_DENSITY_PROFILE_COUNTS:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Counts for density profiles of each type.
+    tooltip: Environmental setting representing counts for each density profile type.
     type: integer
     value: 3
   SKY_DOME:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Sky dome information.
+    tooltip: "Environmental setting containing sky dome parameters: offset, radius,
+      and maximum altitude."
     type: integer
     value: 4
   SKY_GAMMA:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: The gamma value applied to the scene.
+    tooltip: Environmental setting for the gamma value applied to the scene
+      (repurposed in viewer 7.0+ as the HDR Scale value in the EEP editor).
     type: integer
     value: 5
   SKY_GLOW:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Glow color applied to the sun and moon.
+    tooltip: "Environmental setting for sun and moon glow parameters: size and focus."
     type: integer
     value: 6
   SKY_HAZE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Haze settings for environment
+    tooltip: Environmental setting containing the values used to calculate the light
+      scattering impact of blue density and blue horizon on the scene.
     type: integer
     value: 23
   SKY_LIGHT:
     member-of: [EnvironmentParamReadOnly]
-    tooltip: Miscellaneous lighting values.
+    tooltip: "Environmental setting containing lighting parameters: dominant light
+      direction (unit vector), current light color (fade_color in sRGB), and
+      total ambient color (sRGB)."
     type: integer
     value: 8
   SKY_MIE_CONFIG:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: MIE scatting profile parameters.
+    tooltip: Environmental setting for Mie scattering profile parameters.
     type: integer
     value: 17
   SKY_MOON:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Environmental moon details.
+    tooltip: "Environmental moon parameters: rotation, scale, brightness,
+      is_default_texture, direction vector, ambient color, and diffuse color."
     type: integer
     value: 9
   SKY_MOON_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Environmental moon texture.
+    tooltip: Environmental setting containing the inventory name or UUID of the
+      texture used for the moon.
     type: integer
     value: 20
   SKY_PLANET:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Planet information used in rendering the sky.
+    tooltip: "Environmental planet rendering parameters: planet_radius,
+      sky_bottom_radius, and sky_top_radius."
     type: integer
     value: 10
   SKY_RAYLEIGH_CONFIG:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Rayleigh scatting profile parameters.
+    tooltip: Environmental setting for Rayleigh scattering profile parameters.
     type: integer
     value: 18
   SKY_REFLECTION_PROBE_AMBIANCE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Settings the ambience of the reflection probe.
+    tooltip: "Environmental setting for the minimum ambiance value of all reflection
+      probes. Note: Supported in the GLTF Materials project, requiring
+      compatible viewers and testing areas."
     type: integer
     value: 24
   SKY_REFRACTION:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Sky refraction parameters for rainbows and optical effects.
+    tooltip: "Environmental sky refraction parameters for rainbows and optical
+      effects: moisture_level, droplet_radius, and ice_level."
     type: integer
     value: 11
   SKY_STAR_BRIGHTNESS:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Brightness value for the stars.
+    tooltip: Environmental setting for the brightness value applied to stars.
     type: integer
     value: 13
   SKY_SUN:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Detailed sun information
+    tooltip: "Environmental sun parameters: rotation, scale, color,
+      is_default_texture, direction vector, ambient color, and diffuse color."
     type: integer
     value: 14
   SKY_SUN_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Environmental sun texture
+    tooltip: Environmental setting containing the inventory name or UUID of the
+      texture used for the sun.
     type: integer
     value: 21
   SKY_TEXTURE_DEFAULTS:
     member-of: [EnvironmentParamReadOnly]
-    tooltip: Is the environment using the default textures.
+    tooltip: Environmental check returning 1 if the sky textures are set to their
+      default values, or 0 if they use custom textures.
     type: integer
     value: 1
   SKY_TRACKS:
     member-of: [EnvironmentParamReadOnly]
-    tooltip: Track elevations for this region.
+    tooltip: Environmental setting containing the track altitudes used for sky
+      transitions in the region.
     type: integer
     value: 15
   SMOOTH:
     member-of: [TextureAnimMode]
-    tooltip: Slide in the X direction, instead of playing separate frames.
+    tooltip: Used with texture animation functions to cause the animation to slide
+      smoothly in the X direction (or transition smoothly in SCALE/ROTATE modes)
+      instead of making instant frame changes.
     type: integer
     value: '0x10'
   SOUND_LOOP:
     member-of: [PlaySoundFlag]
-    tooltip: Sound will loop until stopped.
+    tooltip: Sound playback option that loops the sound continuously on the prim
+      until stopped.
     type: integer
     value: '0x01'
   SOUND_PLAY:
     member-of: [PlaySoundFlag]
-    tooltip: Sound will play normally.
+    tooltip: Sound playback option (default) that plays the sound once, attached to
+      the prim.
     type: integer
     value: '0x00'
   SOUND_SYNC:
     member-of: [PlaySoundFlag]
-    tooltip: Sound will be synchronized with the nearest master.
+    tooltip: Sound playback option that synchronizes playback to the nearest active
+      sound master (see llLoopSoundMaster).
     type: integer
     value: '0x04'
   SOUND_TRIGGER:
     member-of: [PlaySoundFlag]
-    tooltip: Sound will be triggered at the prim's location and not attached.
+    tooltip: Sound playback option that triggers a non-attached sound once at the
+      prim's current location (does not move with the prim). This flag overrides
+      all other sound playback options.
     type: integer
     value: '0x02'
   SQRT2:
-    tooltip: 1.41421356 - The square root of 2.
+    tooltip: The mathematical constant representing the square root of 2 (1.41421356).
     type: float
     value: '1.41421356'
   STATUS_BLOCK_GRAB:
     member-of: [ObjectStatusParam]
-    tooltip: Controls whether the object can be grabbed.\nA grab is the default action
-      when in third person, and is available as the hand tool in build mode. This
-      is useful for physical objects that you don't want other people to be able to
-      trivially disturb. The default is FALSE
+    tooltip: Status flag (default FALSE) that blocks click-and-drag grab movements
+      on unlinked prims or the root prim of a linkset. Useful for preventing
+      physical objects from being trivially disturbed.
     type: integer
     value: '0x40'
   STATUS_BLOCK_GRAB_OBJECT:
     member-of: [ObjectStatusParam]
-    tooltip: Prevent click-and-drag movement on all prims in the object.
+    tooltip: Status flag that blocks click-and-drag grab movements on all prims
+      across the entire linkset.
     type: integer
     value: '0x400'
   STATUS_BOUNDS_ERROR:
     member-of: [PrimMediaError]
-    tooltip: Argument(s) passed to function had a bounds error.
+    tooltip: Status code indicating that one or more arguments passed to the
+      function had a bounds error.
     type: integer
     value: 1002
   STATUS_CAST_SHADOWS:
     member-of: [ObjectStatusParam]
     deprecated:
       reason: Not implemented.
-    tooltip: ''
+    tooltip: Unused legacy status flag intended to configure an object's ability to
+      cast shadows.
     type: integer
     value: '0x200'
   STATUS_DIE_AT_EDGE:
     member-of: [ObjectStatusParam]
-    tooltip: Controls whether the object is returned to the owner's inventory if it
-      wanders off the edge of the world.\nIt is useful to set this status TRUE for
-      things like bullets or rockets. The default is TRUE
+    tooltip: Status flag (default TRUE) that causes the object to be deleted (and
+      not returned) if it goes off-world (useful for bullets or rockets).
+      Overridden by STATUS_RETURN_AT_EDGE.
     type: integer
     value: '0x80'
   STATUS_DIE_AT_NO_ENTRY:
     member-of: [ObjectStatusParam]
-    tooltip: Controls whether the object dies if it attempts to enter a parcel that
-      does not allow object entry or does not have enough capacity.\nIt is useful
-      to set this status TRUE for things like bullets or rockets. The default is FALSE
+    tooltip: Status flag (default FALSE) that causes the object to be deleted if it
+      attempts to enter an unauthorized or full parcel. No-copy objects ignore
+      this setting and remain in-world.
     type: integer
     value: '0x800'
   STATUS_INTERNAL_ERROR:
     member-of: [PrimMediaError]
-    tooltip: An internal error occurred.
+    tooltip: Status code indicating an internal error occurred.
     type: integer
     value: 1999
   STATUS_MALFORMED_PARAMS:
     member-of: [PrimMediaError]
-    tooltip: Function was called with malformed parameters.
+    tooltip: Status code indicating the function was called with malformed parameters.
     type: integer
     value: 1000
   STATUS_NOT_FOUND:
     member-of: [PrimMediaError]
-    tooltip: Object or other item was not found.
+    tooltip: Status code indicating that the specified object or item was not found.
     type: integer
     value: 1003
   STATUS_NOT_SUPPORTED:
     member-of: [PrimMediaError]
-    tooltip: Feature not supported.
+    tooltip: Status code indicating the requested feature is not supported.
     type: integer
     value: 1004
   STATUS_OK:
     member-of: [PrimMediaError]
-    tooltip: Result of function call was a success.
+    tooltip: Status code indicating the function call completed successfully.
     type: integer
     value: 0
   STATUS_PHANTOM:
     member-of: [ObjectStatusParam]
-    tooltip: Controls/indicates whether the object collides or not.\nSetting the value
-      to TRUE makes the object non-colliding with all objects. It is a good idea to
-      use this for most objects that move or rotate, but are non-physical. It is also
-      useful for simulating volumetric lighting. The default is FALSE.
+    tooltip: Status flag (default FALSE) that makes the entire object
+      phantom/non-colliding when set to TRUE, allowing avatars and objects to
+      pass through it.
     type: integer
     value: '0x10'
   STATUS_PHYSICS:
     member-of: [ObjectStatusParam]
-    tooltip: Controls/indicates whether the object moves physically.\nThis controls
-      the same flag that the UI check-box for Physical controls. The default is FALSE.
+    tooltip: Status flag (default FALSE) that controls whether the object responds
+      to physical interactions, gravity, and forces.
     type: integer
     value: '0x1'
   STATUS_RETURN_AT_EDGE:
     member-of: [ObjectStatusParam]
-    tooltip: ''
+    tooltip: Status flag causing the object to be returned to its owner when it goes
+      off-world, overriding STATUS_DIE_AT_EDGE.
     type: integer
     value: '0x100'
   STATUS_ROTATE_X:
     member-of: [ObjectStatusParam]
-    tooltip: ''
+    tooltip: Status flag (default TRUE) that allows physical rotation on the
+      object's local X-axis. Setting to FALSE prevents physical rotation on this
+      axis.
     type: integer
     value: '0x2'
   STATUS_ROTATE_Y:
     member-of: [ObjectStatusParam]
-    tooltip: ''
+    tooltip: Status flag (default TRUE) that allows physical rotation on the
+      object's local Y-axis. Setting to FALSE prevents physical rotation on this
+      axis.
     type: integer
     value: '0x4'
   STATUS_ROTATE_Z:
     member-of: [ObjectStatusParam]
-    tooltip: "Controls/indicates whether the object can physically rotate around\n\
-      \t\t\tthe specific axis or not. This flag has no meaning\n\t\t\tfor non-physical\
-      \ objects. Set the value to FALSE\n\t\t\tif you want to disable rotation around\
-      \ that axis. The\n\t\t\tdefault is TRUE for a physical object.\n\t\t\tA useful\
-      \ example to think about when visualizing\n\t\t\tthe effect is a sit-and-spin\
-      \ device. They spin around the\n\t\t\tZ axis (up) but not around the X or Y\
-      \ axis."
+    tooltip: Status flag (default TRUE for physical objects) that allows physical
+      rotation on the object's local Z-axis. Setting to FALSE prevents physical
+      rotation on this axis.
     type: integer
     value: '0x8'
   STATUS_SANDBOX:
     member-of: [ObjectStatusParam]
-    tooltip: "Controls/indicates whether the object can cross region boundaries\n\t\
-      \t\tand move more than 20 meters from its creation\n\t\t\tpoint. The default\
-      \ if FALSE."
+    tooltip: Status flag (default FALSE) that restricts the object's physical
+      movement to within its creation region and a short distance (10 to 20
+      meters) from its creation point to prevent it from escaping.
     type: integer
     value: '0x20'
   STATUS_TYPE_MISMATCH:
     member-of: [PrimMediaError]
-    tooltip: Argument(s) passed to function had a type mismatch.
+    tooltip: Status code indicating that one or more arguments passed to the
+      function had a type mismatch.
     type: integer
     value: 1001
   STATUS_WHITELIST_FAILED:
     member-of: [PrimMediaError]
-    tooltip: Whitelist Failed.
+    tooltip: Status code indicating a media domain whitelist check has failed.
     type: integer
     value: 2001
   STRING_TRIM:
     member-of: [StringTrimType]
-    tooltip: ''
+    tooltip: Trims whitespace off both the beginning and the end of the string.
     type: integer
     value: '0x03'
   STRING_TRIM_HEAD:
     member-of: [StringTrimType]
-    tooltip: ''
+    tooltip: Trims whitespace/spaces off the beginning of the string.
     type: integer
     value: '0x01'
   STRING_TRIM_TAIL:
     member-of: [StringTrimType]
-    tooltip: ''
+    tooltip: Trims whitespace/spaces off the end of the string.
     type: integer
     value: '0x02'
   TARGETED_EMAIL_OBJECT_OWNER:
     member-of: [EmailTarget]
-    tooltip: Send email to the owner of the object
+    tooltip: Flag used with llTargetedEmail to send the email message to the owner
+      of the calling object.
     type: integer
     value: '0x02'
   TARGETED_EMAIL_ROOT_CREATOR:
     member-of: [EmailTarget]
-    tooltip: Send email to the creator of the root object
+    tooltip: Flag used with llTargetedEmail to send the email message to the creator
+      of the root object.
     type: integer
     value: '0x01'
   TERRAIN_DETAIL_1:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: Terrain parameter used with llSetGroundTexture to set the texture or
+      material (via UUID, inventory name, or default NULL_KEY) for terrain
+      detail layer 1.
     type: integer
     value: 0
   TERRAIN_DETAIL_2:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   TERRAIN_DETAIL_3:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   TERRAIN_DETAIL_4:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 3
   TERRAIN_HEIGHT_RANGE_NE:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 7
   TERRAIN_HEIGHT_RANGE_NW:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 6
   TERRAIN_HEIGHT_RANGE_SE:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 5
   TERRAIN_HEIGHT_RANGE_SW:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 4
   TERRAIN_PBR_OFFSET_1:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: Terrain parameter used with llSetGroundTexture to set the UV offset
+      (ignoring the Z value) for drawing terrain layer 1. Only works for PBR
+      textures.
     type: integer
     value: 16
   TERRAIN_PBR_OFFSET_2:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 17
   TERRAIN_PBR_OFFSET_3:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 18
   TERRAIN_PBR_OFFSET_4:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 19
   TERRAIN_PBR_ROTATION_1:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: Terrain parameter used with llSetGroundTexture to set the rotation of
+      the PBR texture for layer 1 in radians. Only works for PBR textures.
     type: integer
     value: 12
   TERRAIN_PBR_ROTATION_2:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 13
   TERRAIN_PBR_ROTATION_3:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 14
   TERRAIN_PBR_ROTATION_4:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 15
   TERRAIN_PBR_SCALE_1:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: Terrain parameter used with llSetGroundTexture to set the UV scale
+      (repeats per meter, ignoring Z value) for terrain layer 1. Only works for
+      PBR textures.
     type: integer
     value: 8
   TERRAIN_PBR_SCALE_2:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 9
   TERRAIN_PBR_SCALE_3:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 10
   TERRAIN_PBR_SCALE_4:
     member-of: [GroundTextureParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 11
   TEXTURE_BLANK:
-    tooltip: ''
+    tooltip: The asset UUID representing the default 'Blank' texture.
     type: string
     slua-type: uuid
     value: "5748decc-f629-461c-9a36-a35a221fe21f"
   TEXTURE_DEFAULT:
-    tooltip: ''
+    tooltip: ""
     type: string
     slua-type: uuid
     value: "89556747-24cb-43ed-920b-47caed15465f"
   TEXTURE_MEDIA:
-    tooltip: ''
+    tooltip: The asset UUID representing the default 'Default Media' texture.
     type: string
     slua-type: uuid
     value: "8b5fec65-8d8d-9dc5-cda8-8fdf2716e361"
   TEXTURE_PLYWOOD:
-    tooltip: ''
+    tooltip: The asset UUID representing the default 'Plywood' texture.
     type: string
     slua-type: uuid
     value: "89556747-24cb-43ed-920b-47caed15465f"
   TEXTURE_TRANSPARENT:
-    tooltip: ''
+    tooltip: The asset UUID representing the '*Default Transparent Texture' in the
+      library (included with viewers).
     type: string
     slua-type: uuid
     value: "8dcd4a48-2d37-4909-9f78-f7a9eb4ef903"
   TOUCH_INVALID_FACE:
     # not enum as it can return positive integers also
-    tooltip: ''
+    tooltip: Value returned by llDetectedTouchFace when the touch position is not valid.
     type: integer
     value: -1
   TOUCH_INVALID_TEXCOORD:
-    tooltip: ''
+    tooltip: Value returned by llDetectedTouchUV and llDetectedTouchST when the
+      touch position is not valid.
     type: vector
     value: <-1.0, -1.0, 0.0>
   TOUCH_INVALID_VECTOR:
-    tooltip: ''
+    tooltip: Value returned by llDetectedTouchPos, llDetectedTouchNormal, and
+      llDetectedTouchBinormal when the touch position is not valid.
     type: vector
     value: <0.0, 0.0, 0.0>
   TP_ROUTING_BLOCKED:
     member-of: [ParcelTeleportRouting]
-    tooltip: Direct teleporting is blocked on this parcel.
+    tooltip: Teleport routing setting indicating that direct teleporting is blocked
+      on the parcel.
     type: integer
     value: 0
   TP_ROUTING_FREE:
     member-of: [ParcelTeleportRouting]
-    tooltip: Teleports are unrestricted on this parcel.
+    tooltip: Teleport routing setting indicating that teleports are unrestricted on
+      the parcel.
     type: integer
     value: 2
   TP_ROUTING_LANDINGP:
     member-of: [ParcelTeleportRouting]
-    tooltip: Teleports are routed to a landing point if set on this parcel.
+    tooltip: Teleport routing setting indicating that teleports are routed to the
+      parcel's landing point (if one has been set).
     type: integer
     value: 1
   TRANSFER_BAD_OPTS:
     member-of: [TransferError]
-    tooltip: Invalid inventory options.
+    tooltip: Inventory transfer error code indicating that an invalid option was
+      passed in the options list.
     type: integer
     value: -1
   TRANSFER_BAD_ROOT:
     member-of: [TransferError]
-    tooltip: The root path specified in TRANSFER_DEST contained an invalid directory
-      or was reduced to nothing.
+    tooltip: Inventory transfer error code indicating that the root path specified
+      in TRANSFER_DEST was invalid or resolved to nothing.
     type: integer
     value: -5
   TRANSFER_DEST:
     member-of: [GiveAgentInventoryParam]
-    tooltip: The root folder to transfer inventory into.
+    tooltip: Inventory option specifying the destination root folder to transfer
+      inventory into.
     type: integer
     value: 0
   TRANSFER_FLAGS:
     member-of: [GiveAgentInventoryParam]
-    tooltip: Flags to control the behavior of inventory transfer.
+    tooltip: Inventory parameter specifying flags to control the behavior of
+      inventory transfers.
     type: integer
     value: 1
   TRANSFER_FLAG_COPY:
     member-of: [TransferOwnershipFlag]
-    tooltip: Gives a copy of the object being transfered. Implies TRANSFER_FLAG_TAKE.
+    tooltip: Inventory transfer flag that copies the transferred object and places
+      it in the recipient's inventory (implies TRANSFER_FLAG_TAKE).
     type: integer
     value: '0x0004'
   TRANSFER_FLAG_RESERVED:
     member-of: [TransferOwnershipFlag]
-    tooltip: Reserved for future expansion.
+    tooltip: Inventory transfer flag reserved for future expansion; do not use.
     type: integer
     value: '0x0001'
   TRANSFER_FLAG_TAKE:
     member-of: [TransferOwnershipFlag]
-    tooltip: On a successful transfer, automatically takes the object into inventory.
+    tooltip: Inventory transfer flag that automatically removes the object from the
+      world and places it in the recipient's inventory once accepted.
     type: integer
     value: '0x0002'
   TRANSFER_NO_ATTACHMENT:
     member-of: [TransferError]
-    tooltip: Can not transfer ownership of an attached object.
+    tooltip: Inventory transfer error code indicating ownership of an attached
+      object cannot be transferred.
     type: integer
     value: -7
   TRANSFER_NO_ITEMS:
     member-of: [TransferError]
-    tooltip: No items in the inventory list are eligible for transfer.
+    tooltip: Inventory transfer error code indicating that the list was empty or
+      contained only non-transferable items.
     type: integer
     value: -4
   TRANSFER_NO_PERMS:
     member-of: [TransferError]
-    tooltip: The object does not have transfer permissions.
+    tooltip: Inventory transfer error code indicating the object lacks transfer
+      permissions.
     type: integer
     value: -6
   TRANSFER_NO_TARGET:
     member-of: [TransferError]
-    tooltip: Could not find the receiver in the current region.
+    tooltip: Inventory transfer error code indicating the receiving agent could not
+      be found in the current region.
     type: integer
     value: -2
   TRANSFER_OK:
     member-of: [TransferError]
-    tooltip: Inventory transfer offer was successfully made.
+    tooltip: Status code indicating that the inventory transfer was successful or
+      the transfer offer was successfully made.
     type: integer
     value: 0
   TRANSFER_THROTTLE:
     member-of: [TransferError]
-    tooltip: Inventory throttle hit.
+    tooltip: Inventory transfer error code indicating that the transfer rate has
+      exceeded the inventory transfer throttle.
     type: integer
     value: -3
   TRAVERSAL_TYPE:
     member-of: [CharacterParam]
-    tooltip: One of TRAVERSAL_TYPE_FAST, TRAVERSAL_TYPE_SLOW, and TRAVERSAL_TYPE_NONE.
+    tooltip: Pathfinding parameter specifying the character's movement traversal
+      type. Expects TRAVERSAL_TYPE_SLOW (default), _FAST, or _NONE.
     type: integer
     value: 7
   TRAVERSAL_TYPE_FAST:
     member-of: [CharacterTraversalType]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 1
   TRAVERSAL_TYPE_NONE:
     member-of: [CharacterTraversalType]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 2
   TRAVERSAL_TYPE_SLOW:
     member-of: [CharacterTraversalType]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 0
   'TRUE':
-    tooltip: An integer constant for boolean comparisons. Has the value '1'.
+    tooltip: Mnemonic constant representing a boolean TRUE value (integer 1). Used
+      in conditional structures or variables to improve script readability.
     type: integer
     slua-removed: true
     value: 1
   TWO_PI:
-    tooltip: 6.28318530 - The radians of a circle.
+    tooltip: The mathematical constant representing the number of radians in a full
+      circle (6.28318530, twice the value of PI).
     type: float
     value: '6.28318530'
   TYPE_FLOAT:
     member-of: [ListEntryType]
     slua-deprecated:
       use: '"number"'
-    tooltip: The list entry is a float.
+    tooltip: Variable type constant indicating the list entry or value is a float.
     type: integer
     value: 2
   TYPE_INTEGER:
     member-of: [ListEntryType]
     slua-deprecated:
       use: '"number"'
-    tooltip: The list entry is an integer.
+    tooltip: Variable type constant indicating the list entry or value is an integer.
     type: integer
     value: 1
   TYPE_INVALID:
     member-of: [ListEntryType]
     slua-deprecated:
       use: 'nil'
-    tooltip: The list entry is invalid.
+    tooltip: Variable type constant indicating the list entry or value is invalid.
     type: integer
     value: 0
   TYPE_KEY:
     member-of: [ListEntryType]
     slua-deprecated:
       use: '"uuid"'
-    tooltip: The list entry is a key.
+    tooltip: Variable type constant indicating the list entry or value is a key.
     type: integer
     value: 4
   TYPE_ROTATION:
     member-of: [ListEntryType]
     slua-deprecated:
       use: '"quaternion"'
-    tooltip: The list entry is a rotation.
+    tooltip: Variable type constant indicating the list entry or value is a rotation.
     type: integer
     value: 6
   TYPE_STRING:
     member-of: [ListEntryType]
     slua-deprecated:
       use: '"string"'
-    tooltip: The list entry is a string.
+    tooltip: Variable type constant indicating the list entry or value is a string.
     type: integer
     value: 3
   TYPE_VECTOR:
     member-of: [ListEntryType]
     slua-deprecated:
       use: '"vector"'
-    tooltip: The list entry is a vector.
+    tooltip: Variable type constant indicating the list entry or value is a vector.
     type: integer
     value: 5
   URL_REQUEST_DENIED:
-    tooltip: ''
+    tooltip: ""
     type: string
     value: URL_REQUEST_DENIED
   URL_REQUEST_GRANTED:
-    tooltip: ''
+    tooltip: ""
     type: string
     value: URL_REQUEST_GRANTED
   VEHICLE_ANGULAR_DEFLECTION_EFFICIENCY:
     member-of: [VehicleFloatParam]
-    tooltip: A slider between minimum (0.0) and maximum (1.0) deflection of angular
-      orientation. That is, its a simple scalar for modulating the strength of angular
-      deflection such that the vehicles preferred axis of motion points toward its
-      real velocity.
+    tooltip: Vehicle float parameter (range 0.0 to 1.0) acting as a scalar to
+      modulate the strength of angular deflection, reorienting the vehicle's
+      preferred axis toward its true velocity.
     type: integer
     value: 32
   VEHICLE_ANGULAR_DEFLECTION_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The time-scale for exponential success of linear deflection deflection.
-      Its another way to specify the strength of the vehicles tendency to reorient
-      itself so that its preferred axis of motion agrees with its true velocity.
+    tooltip: Vehicle float parameter specifying the exponential timescale for the
+      vehicle to achieve full angular deflection, reorienting its preferred axis
+      of motion to match its true velocity.
     type: integer
     value: 33
   VEHICLE_ANGULAR_FRICTION_TIMESCALE:
     member-of: [VehicleVectorParam]
-    tooltip: "A vector of timescales for exponential decay of the vehicle's angular\
-      \ velocity about its preferred axes of motion (at, left, up).\n\t\t\tRange =\
-      \ [0.07, inf) seconds for each element of the vector."
+    tooltip: Vehicle vector parameter specifying the timescales (range [0.07,
+      infinity) seconds per axis) for the exponential decay of angular velocity
+      about the vehicle's preferred axes (at, left, up).
     type: integer
     value: 17
   VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The timescale for exponential decay of the angular motors magnitude.
+    tooltip: Vehicle float parameter specifying the exponential timescale (in
+      seconds) for the angular motor's magnitude and effectiveness to decay
+      toward zero.
     type: integer
     value: 35
   VEHICLE_ANGULAR_MOTOR_DIRECTION:
     member-of: [VehicleVectorParam]
-    tooltip: The direction and magnitude (in preferred frame) of the vehicle's angular
-      motor. The vehicle will accelerate (or decelerate if necessary) to match its
-      velocity to its motor.
+    tooltip: Vehicle vector parameter specifying the direction and magnitude of the
+      angular velocity (in radians per second) that the vehicle's angular motor
+      attempts to achieve.
     type: integer
     value: 19
   VEHICLE_ANGULAR_MOTOR_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The timescale for exponential approach to full angular motor velocity.
+    tooltip: Vehicle float parameter specifying the exponential timescale for the
+      vehicle's angular motor to achieve full power and velocity.
     type: integer
     value: 34
   VEHICLE_BANKING_EFFICIENCY:
     member-of: [VehicleFloatParam]
-    tooltip: A slider between anti (-1.0), none (0.0), and maxmum (1.0) banking strength.
+    tooltip: Vehicle float parameter (range -1.0 to 1.0) controlling banking
+      efficiency, where negative values lean out of turns and positive values
+      lean into turns. This parameter makes banking affect steering; use angular
+      motors to bank.
     type: integer
     value: 38
   VEHICLE_BANKING_MIX:
     member-of: [VehicleFloatParam]
-    tooltip: A slider between static (0.0) and dynamic (1.0) banking. "Static" means
-      the banking scales only with the angle of roll, whereas "dynamic" is a term
-      that also scales with the vehicles linear speed.
+    tooltip: Vehicle float parameter (range 0.0 to 1.0) controlling the mix between
+      static banking (scales only with roll angle) and dynamic banking
+      (additionally scales with linear speed).
     type: integer
     value: 39
   VEHICLE_BANKING_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The timescale for banking to exponentially approach its maximum effect.
-      This is another way to scale the strength of the banking effect, however it
-      affects the term that is proportional to the difference between what the banking
-      behavior is trying to do, and what the vehicle is actually doing.
+    tooltip: Vehicle float parameter specifying the exponential timescale for the
+      banking behavior to take full effect.
     type: integer
     value: 40
   VEHICLE_BUOYANCY:
     member-of: [VehicleFloatParam]
-    tooltip: A slider between minimum (0.0) and maximum anti-gravity (1.0).
+    tooltip: Vehicle float parameter (range -1.0 to 1.0) defining buoyancy, where
+      -1.0 represents double gravity and 1.0 represents full anti-gravity.
     type: integer
     value: 27
   VEHICLE_FLAG_BLOCK_INTERFERENCE:
     member-of: [VehicleFlag]
-    tooltip: Prevent other scripts from pushing vehicle.
+    tooltip: Vehicle flag that prevents attachments worn by passengers from pushing
+      the vehicle via llPushObject or other scripting functions.
     type: integer
     value: '0x400'
   VEHICLE_FLAG_CAMERA_DECOUPLED:
     member-of: [VehicleFlag]
-    tooltip: ''
+    tooltip: Vehicle flag used with mouselook steering/banking. When set, the
+      passenger's mouselook camera rotates independently of the vehicle's
+      orientation.
     type: integer
     value: '0x200'
   VEHICLE_FLAG_HOVER_GLOBAL_HEIGHT:
     member-of: [VehicleFlag]
-    tooltip: Hover at global height.
+    tooltip: Vehicle flag that forces the hover behavior to maintain a global height
+      rather than hovering relative to the ground or water.
     type: integer
     value: '0x10'
   VEHICLE_FLAG_HOVER_TERRAIN_ONLY:
     member-of: [VehicleFlag]
-    tooltip: Ignore water height when hovering.
+    tooltip: Vehicle flag that forces the hover behavior to ignore water height and
+      hover exclusively relative to the terrain/land.
     type: integer
     value: '0x8'
   VEHICLE_FLAG_HOVER_UP_ONLY:
     member-of: [VehicleFlag]
-    tooltip: Hover does not push down. Use this flag for hovering vehicles that should
-      be able to jump above their hover height.
+    tooltip: Vehicle flag preventing hover from pushing downward, allowing hovering
+      vehicles to jump or fly above their designated hover height.
     type: integer
     value: '0x20'
   VEHICLE_FLAG_HOVER_WATER_ONLY:
     member-of: [VehicleFlag]
-    tooltip: Ignore terrain height when hovering.
+    tooltip: Vehicle flag that forces the hover behavior to ignore terrain height
+      and hover exclusively relative to water.
     type: integer
     value: '0x4'
   VEHICLE_FLAG_LIMIT_MOTOR_UP:
     member-of: [VehicleFlag]
-    tooltip: Prevents ground vehicles from motoring into the sky.
+    tooltip: Vehicle flag that prevents ground vehicles from motoring upward into
+      the sky. When combined with banking, banking strength decays when the
+      vehicle is airborne (no longer colliding) to prevent steering mid-jump.
     type: integer
     value: '0x40'
   VEHICLE_FLAG_LIMIT_ROLL_ONLY:
     member-of: [VehicleFlag]
-    tooltip: For vehicles with vertical attractor that want to be able to climb/dive,
-      for instance, aeroplanes that want to use the banking feature.
+    tooltip: Vehicle flag for vehicles with a vertical attractor that need to climb
+      or dive, allowing airplanes to use the banking feature.
     type: integer
     value: '0x2'
   VEHICLE_FLAG_MOUSELOOK_BANK:
     member-of: [VehicleFlag]
-    tooltip: ''
+    tooltip: Vehicle flag that enables mouselook control, remapping left-right
+      camera motions (yaw) to rotations about the vehicle's local X-axis.
     type: integer
     value: '0x100'
   VEHICLE_FLAG_MOUSELOOK_STEER:
     member-of: [VehicleFlag]
-    tooltip: ''
+    tooltip: Vehicle flag that enables steering via mouse, directing the angular
+      motor to align the vehicle's local X-axis with the direction of the
+      client-side camera.
     type: integer
     value: '0x80'
   VEHICLE_FLAG_NO_DEFLECTION_UP:
     member-of: [VehicleFlag]
-    tooltip: This flag prevents linear deflection parallel to world z-axis. This is
-      useful for preventing ground vehicles with large linear deflection, like bumper
-      cars, from climbing their linear deflection into the sky.
+    tooltip: Vehicle flag that prevents linear deflection parallel to the world
+      Z-axis, preventing ground vehicles (such as bumper cars) from climbing
+      into the sky.
     type: integer
     value: '0x1'
   VEHICLE_FLAG_NO_FLY_UP:
     member-of: [VehicleFlag]
     deprecated:
       use: VEHICLE_FLAG_NO_DEFLECTION_UP
-    tooltip: Old, changed to VEHICLE_FLAG_NO_DEFLECTION_UP
+    tooltip: Obsolete legacy name for VEHICLE_FLAG_NO_DEFLECTION_UP.
     type: integer
     value: '0x1'
   VEHICLE_HOVER_EFFICIENCY:
     member-of: [VehicleFloatParam]
-    tooltip: 'A slider between minimum (0.0 = bouncy) and maximum (1.0 = fast as possible)
-      damped motion of the hover behavior. '
+    tooltip: Vehicle float parameter (range 0.0 to 1.0) controlling hover damping,
+      where 0.0 is bouncy and 1.0 is critically damped.
     type: integer
     value: 25
   VEHICLE_HOVER_HEIGHT:
     member-of: [VehicleFloatParam]
-    tooltip: The height (above the terrain or water, or global) at which the vehicle
-      will try to hover.
+    tooltip: Vehicle float parameter specifying the height at which the vehicle
+      attempts to hover. Set to 0.0 to disable hover.
     type: integer
     value: 24
   VEHICLE_HOVER_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: Period of time (in seconds) for the vehicle to achieve its hover height.
+    tooltip: Vehicle float parameter specifying the timescale (period of time in
+      seconds) for the vehicle to achieve its hover height.
     type: integer
     value: 26
   VEHICLE_LINEAR_DEFLECTION_EFFICIENCY:
     member-of: [VehicleFloatParam]
-    tooltip: A slider between minimum (0.0) and maximum (1.0) deflection of linear
-      velocity. That is, its a simple scalar for modulating the strength of linear
-      deflection.
+    tooltip: Vehicle float parameter (range 0.0 to 1.0) modulating the efficiency
+      and strength of linear deflection.
     type: integer
     value: 28
   VEHICLE_LINEAR_DEFLECTION_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The timescale for exponential success of linear deflection deflection.
-      It is another way to specify how much time it takes for the vehicle's linear
-      velocity to be redirected to its preferred axis of motion.
+    tooltip: Vehicle float parameter specifying the exponential timescale for the
+      vehicle to redirect its linear velocity along its preferred X-axis.
     type: integer
     value: 29
   VEHICLE_LINEAR_FRICTION_TIMESCALE:
     member-of: [VehicleVectorParam]
-    tooltip: "A vector of timescales for exponential decay of the vehicle's linear\
-      \ velocity along its preferred axes of motion (at, left, up).\n\t\t\tRange =\
-      \ [0.07, inf) seconds for each element of the vector."
+    tooltip: Vehicle vector parameter specifying the timescales (range [0.07,
+      infinity) seconds per axis) for the exponential decay of linear velocity
+      along the vehicle's preferred axes (at, left, up).
     type: integer
     value: 16
   VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The timescale for exponential decay of the linear motors magnitude.
+    tooltip: Vehicle float parameter specifying the exponential timescale (in
+      seconds) for the linear motor's magnitude and effectiveness to decay
+      toward zero.
     type: integer
     value: 31
   VEHICLE_LINEAR_MOTOR_DIRECTION:
     member-of: [VehicleVectorParam]
-    tooltip: "The direction and magnitude (in preferred frame) of the vehicle's linear\
-      \ motor. The vehicle will accelerate (or decelerate if necessary) to match its\
-      \ velocity to its motor.\n\t\t\tRange of magnitude = [0, 30] meters/second."
+    tooltip: Vehicle vector parameter specifying the direction and magnitude of the
+      linear velocity (range [0, 30] m/s) that the vehicle's linear motor
+      attempts to achieve.
     type: integer
     value: 18
   VEHICLE_LINEAR_MOTOR_OFFSET:
     member-of: [VehicleVectorParam]
-    tooltip: ''
+    tooltip: Vehicle vector parameter specifying the offset from the vehicle's
+      center of mass where the linear motor force is applied.
     type: integer
     value: 20
   VEHICLE_LINEAR_MOTOR_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The timescale for exponential approach to full linear motor velocity.
+    tooltip: Vehicle float parameter specifying the exponential timescale for the
+      vehicle to reach its full linear motor velocity.
     type: integer
     value: 30
   VEHICLE_REFERENCE_FRAME:
     member-of: [VehicleRotationParam]
-    tooltip: A rotation of the vehicle's preferred axes of motion and orientation (at,
-      left, up) with respect to the vehicle's local frame (x, y, z).
+    tooltip: Vehicle rotation parameter setting the orientation of the vehicle's
+      preferred axes of motion (at, left, up) relative to its local geometric
+      frame (x, y, z).
     type: integer
     value: 44
   VEHICLE_TYPE_AIRPLANE:
     member-of: [VehicleType]
-    tooltip: Uses linear deflection for lift, no hover, and banking to turn.\nSee
-      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_AIRPLANE
+    tooltip: Vehicle type constant for aircraft that use linear deflection for lift,
+      banking to turn, and no hover.
     type: integer
     value: 4
   VEHICLE_TYPE_BALLOON:
     member-of: [VehicleType]
-    tooltip: Hover, and friction, but no deflection.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BALLOON
+    tooltip: Vehicle type constant for balloons that use hover and friction but no
+      deflection.
     type: integer
     value: 5
   VEHICLE_TYPE_BOAT:
     member-of: [VehicleType]
-    tooltip: Hovers over water with lots of friction and some anglar deflection.\nSee
-      http://wiki.secondlife.com/wiki/VEHICLE_TYPE_BOAT
+    tooltip: Vehicle type constant for boats that hover over water with high
+      friction and minor angular deflection.
     type: integer
     value: 3
   VEHICLE_TYPE_CAR:
     member-of: [VehicleType]
-    tooltip: Another vehicle that bounces along the ground but needs the motors to
-      be driven from external controls or timer events.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_CAR
+    tooltip: Vehicle type constant for land vehicles that bounce along the ground
+      and rely on external controls or timer events to drive their motors.
     type: integer
     value: 2
   VEHICLE_TYPE_NONE:
     member-of: [VehicleType]
-    tooltip: ''
+    tooltip: Constant used to disable and turn off vehicle physics support on the
+      object.
     type: integer
     value: 0
   VEHICLE_TYPE_SLED:
     member-of: [VehicleType]
-    tooltip: Simple vehicle that bumps along the ground, and likes to move along its
-      local x-axis.\nSee http://wiki.secondlife.com/wiki/VEHICLE_TYPE_SLED
+    tooltip: Vehicle type constant for sliding vehicles that bump along the ground
+      and prefer to move along their local X-axis.
     type: integer
     value: 1
   VEHICLE_VERTICAL_ATTRACTION_EFFICIENCY:
     member-of: [VehicleFloatParam]
-    tooltip: A slider between minimum (0.0 = wobbly) and maximum (1.0 = firm as possible)
-      stability of the vehicle to keep itself upright.
+    tooltip: Vehicle float parameter (range 0.0 to 1.0) controlling vertical
+      attraction stability (0.0 is wobbly/bouncy, 1.0 is critically damped/firm)
+      to keep the vehicle upright.
     type: integer
     value: 36
   VEHICLE_VERTICAL_ATTRACTION_TIMESCALE:
     member-of: [VehicleFloatParam]
-    tooltip: The period of wobble, or timescale for exponential approach, of the vehicle
-      to rotate such that its preferred "up" axis is oriented along the world's "up"
-      axis.
+    tooltip: Vehicle float parameter specifying the exponential timescale (in
+      seconds) for the vehicle to rotate and align its local Z-axis (up) with
+      the world Z-axis (vertical).
     type: integer
     value: 37
   VERTICAL:
     member-of: [CharacterOrientation]
-    tooltip: ''
+    tooltip: Constant indicating that the collision capsule orientation for a
+      pathfinding character is vertical.
     type: integer
     value: 0
   WANDER_PAUSE_AT_WAYPOINTS:
     member-of: [CharacterWanderWithinParam]
-    tooltip: ''
+    tooltip: ""
     type: integer
     value: 0
   WATER_BLUR_MULTIPLIER:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Blur factor.
+    tooltip: Environmental setting specifying the multiplier applied to blur the
+      scene when underwater.
     type: integer
     value: 100
   WATER_FOG:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Fog properties when underwater.
+    tooltip: "Environmental underwater fog parameters: color, density exponent, and
+      modulation."
     type: integer
     value: 101
   WATER_FRESNEL:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Fresnel scattering applied to the surface of the water.
+    tooltip: "Environmental water surface Fresnel scattering parameters: offset and
+      scale."
     type: integer
     value: 102
   WATER_NORMAL_SCALE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Scaling applied to the water normal map.
+    tooltip: Environmental setting specifying the scaling vector applied to the
+      water normal map.
     type: integer
     value: 104
   WATER_NORMAL_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Normal map used for environmental waves.
+    tooltip: Environmental setting containing the inventory name or UUID of the
+      normal map texture used for water waves.
     type: integer
     value: 107
   WATER_REFRACTION:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Refraction factors when looking through the surface of the water.
+    tooltip: "Environmental water surface refraction scale factors: scale_above and
+      scale_below."
     type: integer
     value: 105
   WATER_TEXTURE_DEFAULTS:
     member-of: [EnvironmentParamReadOnly]
-    tooltip: Is the environment using the default wave map.
+    tooltip: Environmental check returning 1 if default water wave maps are used, or
+      0 if a custom texture is set.
     type: integer
     value: 103
   WATER_WAVE_DIRECTION:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
-    tooltip: Vectors for the directions of the waves.
+    tooltip: Environmental wave direction vectors (X is east/west, Y is north/south)
+      specifying speeds and directions for both large and small waves.
     type: integer
     value: 106
   XP_ERROR_EXPERIENCES_DISABLED:
@@ -5849,7 +6454,7 @@ constants:
     value: 8
   XP_ERROR_EXPERIENCE_SUSPENDED:
     member-of: [ExperienceError]
-    tooltip: The experience has been suspended by Linden Customer Support.
+    tooltip: The experience has been suspended by Linden Lab customer support.
     type: integer
     value: 9
   XP_ERROR_INVALID_EXPERIENCE:
@@ -5885,12 +6490,14 @@ constants:
     value: 6
   XP_ERROR_NOT_PERMITTED:
     member-of: [ExperienceError]
-    tooltip: This experience is not allowed to run by the requested agent.
+    tooltip: This experience is not allowed to run by the requested agent, or
+      experience permissions were denied by the user.
     type: integer
     value: 4
   XP_ERROR_NOT_PERMITTED_LAND:
     member-of: [ExperienceError]
-    tooltip: This experience is not allowed to run on the current region.
+    tooltip: The experience is blocked or not enabled for this land, or is not
+      allowed to run in the current region.
     type: integer
     value: 17
   XP_ERROR_NO_EXPERIENCE:
@@ -5900,13 +6507,14 @@ constants:
     value: 5
   XP_ERROR_QUOTA_EXCEEDED:
     member-of: [ExperienceError]
-    tooltip: An attempted write data to the key-value store failed due to the data
+    tooltip: An attempt to write data to the key-value store failed due to the data
       quota being met.
     type: integer
     value: 11
   XP_ERROR_REQUEST_PERM_TIMEOUT:
     member-of: [ExperienceError]
-    tooltip: Request timed out; permissions not modified.
+    tooltip: The request for experience permissions was ignored and the request
+      timed out without modification.
     type: integer
     value: 18
   XP_ERROR_RETRY_UPDATE:
@@ -5916,7 +6524,8 @@ constants:
     value: 15
   XP_ERROR_STORAGE_EXCEPTION:
     member-of: [ExperienceError]
-    tooltip: Unable to communicate with the key-value store.
+    tooltip: Unable to communicate with the key-value store, or attempted to create
+      a key that already exists.
     type: integer
     value: 13
   XP_ERROR_STORE_DISABLED:
@@ -5931,468 +6540,489 @@ constants:
     value: 1
   XP_ERROR_UNKNOWN_ERROR:
     member-of: [ExperienceError]
-    tooltip: Other unknown error.
+    tooltip: An unknown error occurred that is not covered by any of the other
+      predetermined error states.
     type: integer
     value: 10
   ZERO_ROTATION:
-    tooltip: ''
+    tooltip: A rotation constant representing an identity rotation (causes no
+      change). This is the default value for rotation variables.
     type: rotation
     value: <0.0, 0.0, 0.0, 1.0>
   ZERO_VECTOR:
-    tooltip: ''
+    tooltip: A vector constant representing <0.0, 0.0, 0.0>. This is the default
+      value for vector variables.
     type: vector
     value: <0.0, 0.0, 0.0>
 events:
   at_rot_target:
     arguments:
-    - TargetNumber:
-        tooltip: ''
-        type: integer
-    - TargetRotation:
-        tooltip: ''
-        type: rotation
-    - CurrentRotation:
-        tooltip: ''
-        type: rotation
-    tooltip: This event is triggered when a script comes within a defined angle of
-      a target rotation. The range and rotation are set by a call to llRotTarget.
+      - handle:
+          tooltip: The integer handle returned by the llRotTarget call.
+          type: integer
+      - targetrot:
+          tooltip: The target rotation specified in the llRotTarget call.
+          type: rotation
+      - ourrot:
+          tooltip: The current rotation of the object (similar to llGetRot).
+          type: rotation
+    tooltip: Triggered when the script's rotation (ourrot) comes within a defined
+      angle (error) of the target rotation (targetrot) set by a call to
+      llRotTarget (which returns the associated handle).
   at_target:
     arguments:
-    - TargetNumber:
-        tooltip: ''
-        type: integer
-    - TargetPosition:
-        tooltip: ''
-        type: vector
-    - CurrentPosition:
-        tooltip: ''
-        type: vector
-    tooltip: This event is triggered when the scripted object comes within a defined
-      range of the target position, defined by the llTarget function call.
+      - tnum:
+          tooltip: The integer target handle returned by the llTarget call.
+          type: integer
+      - targetpos:
+          tooltip: The target position vector specified in the llTarget call.
+          type: vector
+      - ourpos:
+          tooltip: The current position vector of the object (similar to llGetPos).
+          type: vector
+    tooltip: Triggered when the scripted object's position (ourpos) comes within the
+      defined range of the target position (targetpos) set by llTarget (which
+      returns the associated handle tnum).
   attach:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    tooltip: This event is triggered whenever an object is attached or detached from
-      an avatar. If it is attached, the key of the avatar it is attached to is passed
-      in, otherwise NULL_KEY is.
+      - avatarid:
+          tooltip: ''
+          type: key
+    tooltip: Triggered whenever the object is attached to or detached from an
+      avatar. Passes the UUID key of the avatar (id) if attached, or NULL_KEY if
+      detached.
   changed:
     arguments:
-    - Changed:
-        tooltip: ''
-        type: integer
-    tooltip: Triggered when various events change the object. The change argument
-      will be a bit-field of CHANGED_* constants.
+      - changed:
+          tooltip: ''
+          type: integer
+    tooltip: Triggered when various properties of the object change. The parameter
+      change is a bitfield of CHANGED_* constants.
   collision:
     arguments:
-    - NumberOfCollisions:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of detected colliders (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised while another object, or avatar, is colliding with\
-      \ the object the script is attached to.\n\t\t\tThe number of detected objects\
-      \ is passed to the script. Information on those objects may be gathered via\
-      \ the llDetected* functions."
+    tooltip: Triggered continuously while an avatar or another object is colliding
+      with the object containing the script. Passes num_detected, representing
+      the number of detected collisions.
   collision_end:
     arguments:
-    - NumberOfCollisions:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of detected colliders (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised when another object, or avatar, stops colliding\
-      \ with the object the script is attached to.\n\t\t\tThe number of detected objects\
-      \ is passed to the script. Information on those objects may be gathered via\
-      \ the llDetected* library functions."
+    tooltip: Triggered when an avatar or another object stops colliding with the
+      object containing the script. Passes num_detected, representing the number
+      of detected collisions.
   collision_start:
     arguments:
-    - NumberOfCollisions:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of detected colliders (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised when another object, or avatar, starts colliding\
-      \ with the object the script is attached to.\n\t\t\tThe number of detected objects\
-      \ is passed to the script. Information on those objects may be gathered via\
-      \ the llDetected* library functions."
+    tooltip: Triggered when an avatar or another object first begins colliding with
+      the object containing the script. Passes num_detected, representing the
+      number of detected collisions.
   control:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Levels:
-        tooltip: ''
-        type: integer
-    - Edges:
-        tooltip: ''
-        type: integer
-    tooltip: "Once a script has the ability to grab control inputs from the avatar,\
-      \ this event will be used to pass the commands into the script.\n\t\t\tThe levels\
-      \ and edges are bit-fields of control constants."
+      - avatarid:
+          tooltip: ''
+          type: key
+      - levels:
+          tooltip: ''
+          type: integer
+      - edges:
+          tooltip: ''
+          type: integer
+    tooltip: Triggered to pass captured avatar control inputs into the script. The
+      parameter level indicates held controls, and edge indicates change in
+      controls (both are bitfields of CONTROL_* constants).
   dataserver:
     arguments:
-    - RequestID:
-        tooltip: ''
-        type: key
-    - Data:
-        tooltip: ''
-        type: string
-    tooltip: "This event is triggered when the requested data is returned to the script.\n\
-      \t\t\tData may be requested by the llRequestAgentData, llRequestInventoryData,\
-      \ and llGetNotecardLine function calls, for example."
+      - requestid:
+          tooltip: ''
+          type: key
+      - data:
+          tooltip: The string containing the requested data.
+          type: string
+    tooltip: Triggered when requested data is returned to the script (e.g., from
+      llRequestAgentData, llRequestInventoryData, or llGetNotecardLine).
   email:
     arguments:
-    - Time:
-        tooltip: ''
-        type: string
-    - Address:
-        tooltip: ''
-        type: string
-    - Subject:
-        tooltip: ''
-        type: string
-    - Body:
-        tooltip: ''
-        type: string
-    - NumberRemaining:
-        tooltip: ''
-        type: integer
-    tooltip: "This event is triggered when an email sent to this script arrives.\n\
-      \t\t\tThe number remaining tells how many more emails are known to be still\
-      \ pending."
+      - time:
+          tooltip: The timestamp of when the email was received.
+          type: string
+      - address:
+          tooltip: The email address of the sender.
+          type: string
+      - subject:
+          tooltip: The subject of the email.
+          type: string
+      - body:
+          tooltip: The body text of the email.
+          type: string
+      - numberremaining:
+          tooltip: ''
+          type: integer
+    tooltip: Triggered when an email sent to this script's address arrives. num_left
+      indicates the number of pending emails remaining in the queue.
   experience_permissions:
     arguments:
-    - agent_id:
-        tooltip: ID of the agent approving permission for the Experience.
-        type: key
-    tooltip: Triggered when an agent has approved an experience permissions request.
+      - agent_id:
+          tooltip: The UUID of the avatar approving experience permissions.
+          type: key
+    tooltip: Triggered when the agent specified by agent_id approves an experience
+      permissions request (interactively or automatically if previously
+      approved).
   experience_permissions_denied:
     arguments:
-    - agent_id:
-        tooltip: ID of the agent denying permission for the Experience.
-        type: key
-    - Reason:
-        tooltip: One of the XP_ERROR_... constants describing the reason why the Experience
-          permissions were denied for the agent.
-        type: integer
-    tooltip: Describes why the Experience permissions were denied for the agent.
+      - agent_id:
+          tooltip: The UUID of the avatar who denied or was blocked from granting
+            permissions.
+          type: key
+      - reason:
+          tooltip: The XP_ERROR_* error constant describing why permissions were denied.
+          type: integer
+    tooltip: Triggered when the agent specified by agent_id denies experience
+      permissions, or when permission is blocked for other reasons (specified by
+      the error code reason).
   final_damage:
     arguments:
-    - count:
-        tooltip: The number of damage events queued.
-        type: integer
+      - num_detected:
+          tooltip: The number of damage events applied to the avatar or task.
+          type: integer
     detected-semantics: true
-    tooltip: Triggered as damage is applied to an avatar or task, after all on_damage
-      events have been processed.
+    tooltip: Triggered after all on_damage events across all scripts have completed
+      and damage is actively applied to the avatar or distributed among seated
+      avatars. Collision detected functions (llDetected*) and llDetectedDamage
+      are available.
   game_control:
     arguments:
-    - id:
-        tooltip: UUID of avatar supplying input
-        type: key
-    - buttons:
-        tooltip: 32-bit mask of buttons pressed
-        type: integer
-    - axes:
-        tooltip: Six float values in range [-1, 1]
-        type: list
-        slua-type: "{number}"
-    tooltip: This event is raised when game controller input changes.
+      - id:
+          tooltip: The UUID of the avatar supplying controller input.
+          type: key
+      - button_levels:
+          tooltip: A 32-bit mask representing the buttons currently held down on the
+            controller.
+          type: integer
+      - axes:
+          tooltip: A list of six float values in the range [-1.0, 1.0] representing
+            controller axes.
+          type: list
+          slua-type: "{number}"
+    tooltip: Triggered when a compatible viewer sends game controller input changes
+      for the avatar specified by id. Only triggers for scripts in attachments
+      or seats.
   http_request:
     arguments:
-    - HTTPRequestID:
-        tooltip: ''
-        type: key
-    - HTTPMethod:
-        tooltip: ''
-        type: string
-    - Body:
-        tooltip: ''
-        type: string
-    tooltip: Triggered when task receives an HTTP request.
+      - request_id:
+          tooltip: The unique key identifying the incoming HTTP request (used with
+            llHTTPResponse).
+          type: key
+      - method:
+          tooltip: The HTTP method string ('GET', 'POST', 'PUT', 'DELETE') or URL request
+            status constants.
+          type: string
+      - body:
+          tooltip: The string payload of the incoming request body.
+          type: string
+    tooltip: Triggered when the script's registered URL receives an incoming HTTP
+      request identified by request_id.
   http_response:
     arguments:
-    - HTTPRequestID:
-        tooltip: ''
-        type: key
-    - Status:
-        tooltip: ''
-        type: integer
-    - Metadata:
-        tooltip: ''
-        type: list
-    - Body:
-        tooltip: ''
-        type: string
-    tooltip: This event handler is invoked when an HTTP response is received for a
-      pending llHTTPRequest request or if a pending request fails or times out.
+      - request_id:
+          tooltip: The key matching the handle returned by the initiating llHTTPRequest
+            call.
+          type: key
+      - status:
+          tooltip: The integer HTTP status code returned (such as 200 or 404).
+          type: integer
+      - metadata:
+          tooltip: A list of HTTP_* constants and response headers metadata.
+          type: list
+      - body:
+          tooltip: The string payload of the received response body.
+          type: string
+    tooltip: Triggered when an HTTP response body is received for a pending
+      request_id, or if the request fails or times out.
   land_collision:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
-    tooltip: This event is raised when the object the script is attached to is colliding
-      with the ground.
+      - pos:
+          tooltip: The vector position of collision with the ground.
+          type: vector
+    tooltip: Triggered in the root prim when a physical object or attached avatar is
+      colliding with the ground at position pos.
   land_collision_end:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
-    tooltip: This event is raised when the object the script is attached to stops
-      colliding with the ground.
+      - pos:
+          tooltip: The vector position of the last ground collision.
+          type: vector
+    tooltip: Triggered in the root prim when a physical object or attached avatar
+      stops colliding with the ground at position pos.
   land_collision_start:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
-    tooltip: This event is raised when the object the script is attached to begins
-      to collide with the ground.
+      - pos:
+          tooltip: The vector position of collision with the ground.
+          type: vector
+    tooltip: Triggered in the root prim when a physical object or attached avatar
+      first begins colliding with the ground at position pos.
   link_message:
     arguments:
-    - SendersLink:
-        tooltip: ''
-        type: integer
-    - Value:
-        tooltip: ''
-        type: integer
-    - Text:
-        tooltip: ''
-        type: string
-    - ID:
-        tooltip: ''
-        type: key
-        slua-type: string
-    tooltip: Triggered when object receives a link message via llMessageLinked function
-      call.
+      - sender_num:
+          tooltip: The link index of the prim containing the script that sent the message.
+          type: integer
+      - num:
+          tooltip: An integer value passed from the sending script.
+          type: integer
+      - str:
+          tooltip: A text string value passed from the sending script.
+          type: string
+      - id:
+          tooltip: A key value passed from the sending script.
+          type: key
+          slua-type: string
+    tooltip: Triggered when the script receives a link message from sender_num,
+      containing the parameters num, str, and id sent via llMessageLinked.
   linkset_data:
     arguments:
-    - action:
-        tooltip: ''
-        type: integer
-    - name:
-        tooltip: ''
-        type: string
-    - value:
-        tooltip: ''
-        type: string
-    tooltip: Triggered when a script modifies the linkset datastore.
+      - action:
+          tooltip: An integer constant representing the action taken (e.g.,
+            LINKSETDATA_UPDATE, LINKSETDATA_DELETE, LINKSETDATA_RESET).
+          type: integer
+      - name:
+          tooltip: The key name of the modified key-value pair.
+          type: string
+      - value:
+          tooltip: The new string value of the pair (empty if the pair was deleted or is
+            password-protected).
+          type: string
+    tooltip: Fires in all scripts in the linkset whenever the datastore has been
+      modified via an llLinksetData function. Passes the action taken, the
+      affected key name, and the new value.
   listen:
     arguments:
-    - Channel:
-        tooltip: ''
-        type: integer
-    - Name:
-        tooltip: ''
-        type: string
-    - ID:
-        tooltip: ''
-        type: key
-    - Text:
-        tooltip: ''
-        type: string
-    tooltip: "This event is raised whenever a chat message matching the constraints\
-      \ set in the llListen command is received. The name and ID of the speaker, as\
-      \ well as the message, are passed in as parameters.\n\t\t\tChannel 0 is the\
-      \ public chat channel that all avatars see as chat text. Channels 1 through\
-      \ 2,147,483,648 are private channels that are not sent to avatars but other\
-      \ scripts can listen on those channels."
+      - channel:
+          tooltip: The chat channel where the message appeared.
+          type: integer
+      - name:
+          tooltip: The name of the sending prim or the legacy name of the sending avatar.
+          type: string
+      - id:
+          tooltip: The UUID of the sending avatar or prim.
+          type: key
+      - message:
+          tooltip: The spoken text string.
+          type: string
+    tooltip: Triggered when a chat message matching active llListen filters is
+      received on channel. Passes the sender's name and UUID key id, along with
+      the spoken message string.
   money:
     arguments:
-    - Payer:
-        tooltip: ''
-        type: key
-    - Amount:
-        tooltip: ''
-        type: integer
-    tooltip: This event is triggered when a resident has given an amount of Linden
-      dollars to the object.
+      - id:
+          tooltip: The UUID of the paying resident.
+          type: key
+      - amount:
+          tooltip: The quantity of L$ paid to the prim.
+          type: integer
+    tooltip: Triggered when a resident specified by id pays an amount of Linden
+      dollars (L$) to the prim.
   moving_end:
     arguments: []
-    tooltip: Triggered whenever an object with this script stops moving.
+    tooltip: Triggered whenever the physical or moving object containing the script
+      stops moving.
   moving_start:
     arguments: []
-    tooltip: Triggered whenever an object with this script starts moving.
+    tooltip: Triggered whenever the physical or moving object containing the script
+      starts moving.
   no_sensor:
     arguments: []
-    tooltip: This event is raised when sensors are active, via the llSensor function
-      call, but are not sensing anything.
+    tooltip: Triggered when active sensors (from llSensor or llSensorRepeat)
+      complete a scan without finding any matching targets.
   not_at_rot_target:
     arguments: []
-    tooltip: When a target is set via the llRotTarget function call, but the script
-      is outside the specified angle this event is raised.
+    tooltip: Triggered continuously while the object's rotation is outside the
+      leeway angle of targets set via llRotTarget.
   not_at_target:
     arguments: []
-    tooltip: When a target is set via the llTarget library call, but the script is
-      outside the specified range this event is raised.
+    tooltip: Triggered continuously while the object's position has not yet reached
+      the range of targets set via llTarget.
   object_rez:
     arguments:
-    - RezzedObjectsID:
-        tooltip: ''
-        type: key
-    tooltip: Triggered when an object rezzes another object from its inventory via
-      the llRezObject, or similar, functions. The id is the globally unique key for
-      the object rezzed.
+      - id:
+          tooltip: The UUID of the newly rezzed object.
+          type: key
+    tooltip: Triggered when this object successfully rezzes another object from its
+      inventory. Passes the key (UUID) id of the newly rezzed object.
   on_damage:
     arguments:
-    - count:
-        tooltip: The number of damage events queued.
-        type: integer
+      - num_detected:
+          tooltip: The number of pending damage events.
+          type: integer
     detected-semantics: true
-    tooltip: Triggered when an avatar or object receives damage.
+    tooltip: Triggered when damage has been inflicted on an avatar or task, but
+      before it is applied or distributed. Collision detected functions
+      (llDetected*), llDetectedDamage, and llAdjustDamage are available. Passes
+      num_detected, representing the number of pending damage events.
   on_death:
     arguments: []
-    tooltip: Triggered when an avatar reaches 0 health.
+    tooltip: Triggered on all worn attachments when the wearing avatar's health
+      reaches 0.
   on_rez:
     arguments:
-    - StartParameter:
-        tooltip: ''
-        type: integer
-    tooltip: Triggered whenever an object is rezzed from inventory or by another object.
-      The start parameter is passed in from the llRezObject call, or zero if from
-      inventory.
+      - start_param:
+          tooltip: The integer start parameter passed from the rezzing call.
+          type: integer
+    tooltip: Triggered when the object is rezzed into the world (by a script or
+      user). Passes start_param from the rezzing call (or 0 if rezzed from
+      inventory). Also triggers on attachments during login or when attached
+      from inventory.
   path_update:
     arguments:
-    - Type:
-        tooltip: ''
-        type: integer
-    - Reserved:
-        tooltip: ''
-        type: list
-    tooltip: This event is called to inform the script of changes within the object's
-      path-finding status.
+      - type:
+          tooltip: The path update status or failure code constant (PU_* flag).
+          type: integer
+      - reserved:
+          tooltip: Reserved parameter (currently unused).
+          type: list
+    tooltip: Triggered to inform the script of changes or failures in the
+      pathfinding character's status.
   remote_data:
     arguments:
-    - EventType:
-        tooltip: ''
-        type: integer
-    - ChannelID:
-        tooltip: ''
-        type: key
-    - MessageID:
-        tooltip: ''
-        type: key
-    - Sender:
-        tooltip: ''
-        type: string
-    - IData:
-        tooltip: ''
-        type: integer
-    - SData:
-        tooltip: ''
-        type: string
+      - event_type:
+          tooltip: The integer constant representing the type of XML-RPC event.
+          type: integer
+      - channel:
+          tooltip: The XML-RPC channel ID key.
+          type: key
+      - message_id:
+          tooltip: The XML-RPC message ID key.
+          type: key
+      - sender:
+          tooltip: The XML-RPC sender string.
+          type: string
+      - idata:
+          tooltip: The payload integer data.
+          type: integer
+      - sdata:
+          tooltip: The payload string data.
+          type: string
     deprecated: true
-    tooltip: This event is deprecated.
+    tooltip: Deprecated. Triggered by incoming XML-RPC calls, passing event_type,
+      channel, message_id, sender, idata, and sdata.
   run_time_permissions:
     arguments:
-    - PermissionFlags:
-        tooltip: ''
-        type: integer
-    tooltip: "Scripts need permission from either the owner or the avatar they wish\
-      \ to act on before they may perform certain functions, such as debiting money\
-      \ from their owners account, triggering an animation on an avatar, or capturing\
-      \ control inputs. The llRequestPermissions library function is used to request\
-      \ these permissions and the various permissions integer constants can be supplied.\n\
-      \t\t\tThe integer returned to this event handler contains the current set of\
-      \ permissions flags, so if permissions equal 0 then no permissions are set."
+      - perm:
+          tooltip: The bitfield of currently granted permissions (PERMISSION_* flags).
+          type: integer
+    tooltip: Triggered when an agent grants or denies runtime permissions requested
+      by llRequestPermissions. Passes the active integer permissions bitfield
+      perm (returns 0 if no permissions are currently granted).
   sensor:
     arguments:
-    - NumberDetected:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of detected targets found (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised whenever objects matching the constraints of the\
-      \ llSensor command are detected.\n\t\t\tThe number of detected objects is passed\
-      \ to the script in the parameter. Information on those objects may be gathered\
-      \ via the llDetected* functions."
+    tooltip: Triggered when objects matching constraints of llSensor or
+      llSensorRepeat are successfully detected. Passes num_detected,
+      representing the number of detected targets.
   state_entry:
     arguments: []
-    tooltip: The state_entry event occurs whenever a new state is entered, including
-      at program start, and is always the first event handled.
+    tooltip: Triggered immediately whenever a new state is entered (including at
+      script start). It is always the first event handled.
     slua-removed: true
   state_exit:
     arguments: []
     slua-removed: true
-    tooltip: The state_exit event occurs whenever the state command is used to transition
-      to another state. It is handled before the new states state_entry event.
+    tooltip: Triggered when the state command is used to transition out of the
+      current state. Handled before entering the new state's state_entry.
   timer:
     arguments: []
     slua-deprecated:
       use: LLTimers
-    tooltip: This event is raised at regular intervals set by the llSetTimerEvent
-      library function.
+    tooltip: Triggered at regular periodic intervals configured by llSetTimerEvent.
   touch:
     arguments:
-    - NumberOfTouches:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of touching agents detected (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised while a user is touching the object the script\
-      \ is attached to.\n\t\t\tThe number of touching objects is passed to the script\
-      \ in the parameter.\n\t\t\tInformation on those objects may be gathered via\
-      \ the llDetected* library functions."
+    tooltip: Triggered continuously while an avatar touches the object. Passes
+      num_detected, representing the number of touching agents.
   touch_end:
     arguments:
-    - NumberOfTouches:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of touching agents detected (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised when a user stops touching the object the script\
-      \ is attached to. The number of touches is passed to the script in the parameter.\n\
-      \t\t\tInformation on those objects may be gathered via the llDetected* library\
-      \ functions."
+    tooltip: Triggered when an avatar stops touching the object. Passes
+      num_detected, representing the number of touching agents.
   touch_start:
     arguments:
-    - NumberOfTouches:
-        tooltip: ''
-        type: integer
+      - num_detected:
+          tooltip: The total number of touching agents detected (usable with llDetected*
+            functions).
+          type: integer
     detected-semantics: true
-    tooltip: "This event is raised when a user first touches the object the script\
-      \ is attached to. The number of touches is passed to the script in the parameter.\n\
-      \t\t\tInformation on those objects may be gathered via the llDetected() library\
-      \ functions."
+    tooltip: Triggered when an avatar first touches the object. Passes num_detected,
+      representing the number of touching agents.
   transaction_result:
     arguments:
-    - RequestID:
-        tooltip: ''
-        type: key
-    - Success:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
-    - Message:
-        tooltip: ''
-        type: string
-    tooltip: Triggered by llTransferLindenDollars() function.
+      - id:
+          tooltip: The key matching the handle returned by the initiating llTransfer*
+            function.
+          type: key
+      - success:
+          tooltip: Boolean. TRUE if the L$ transfer succeeded, FALSE otherwise.
+          type: integer
+          bool-semantics: true
+      - data:
+          tooltip: Contains a CSV string of transaction info on success, or an error
+            string on failure.
+          type: string
+    tooltip: Triggered when an asynchronous L$ transfer (such as
+      llTransferLindenDollars) is completed. Passes transaction info id, success
+      status, and CSV or error data.
 functions:
 
-#  <key>: is the LSL name for the function.
-#    energy: Script energy consumed by the function. (When in doubt just use 10.0)
-#    sleep: Additional sleep time imposed by the script after this function completes.
-#    mono-sleep: Sleep in the mono script runtime
-#    return: Return type of the function.
-#    slua-return: More specific return type for slua type-checking.
-#    slua-type: More specific argument type for slua type-checking.
-#    type-arguments: An array of strings naming the type variables used for generic type-checking this slua function.
-#    arguments: An array of maps of maps describing the parameters to this function.
-#    tooltip: A brief description of this function. Map of maps is used to retain ordering.
-#    func-id: The LSO function identifier, (See comment at the top of this file.)
-#    private: Should this function be omitted from the generated documentation.
-#    deprecated: Has this function been deprecated.
-#    slua-deprecated: Has this function or event been deprecated in SLua.
-#    slua-removed: Has this function or event been removed in SLua.
-#    pure: Is the function guaranteed to have no side effects.
-#    must-use: If true or `pure` is true, then the functions return value should not be discarded, as it serves no other purpose
-#    native: If true, this function must use a native implementation for non-LSO VMs.
-#    god-mode: If true, this function can only be executed in god mode.
-#    experience: If true, this function requires an experience to be set for the script to compile.
-#    linden-experience: If true, this function requires a linden-owned experience.
-#    index-semantics: If true then the returned integer from this function represents 0 based index
-#    bool-semantics: If true then the returned integer represents a boolean 1 or 0
-#    asset-semantics: If true this argument represents an inventory item and can accept either name or uuid
-#    detected-semantics: If true, the event or function is involved in the DetectedEvent wrapper in SLua
+  #  <key>: is the LSL name for the function.
+  #    energy: Script energy consumed by the function. (When in doubt just use 10.0)
+  #    sleep: Additional sleep time imposed by the script after this function completes.
+  #    mono-sleep: Sleep in the mono script runtime
+  #    return: Return type of the function.
+  #    slua-return: More specific return type for slua type-checking.
+  #    slua-type: More specific argument type for slua type-checking.
+  #    type-arguments: An array of strings naming the type variables used for generic type-checking this slua function.
+  #    arguments: An array of maps of maps describing the parameters to this function.
+  #    tooltip: A brief description of this function. Map of maps is used to retain ordering.
+  #    func-id: The LSO function identifier, (See comment at the top of this file.)
+  #    private: Should this function be omitted from the generated documentation.
+  #    deprecated: Has this function been deprecated.
+  #    slua-deprecated: Has this function or event been deprecated in SLua.
+  #    slua-removed: Has this function or event been removed in SLua.
+  #    pure: Is the function guaranteed to have no side effects.
+  #    must-use: If true or 'pure' is true, then the functions return value should not be discarded, as it serves no other purpose
+  #    native: If true, this function must use a native implementation for non-LSO VMs.
+  #    god-mode: If true, this function can only be executed in god mode.
+  #    experience: If true, this function requires an experience to be set for the script to compile.
+  #    linden-experience: If true, this function requires a linden-owned experience.
+  #    index-semantics: If true then the returned integer from this function represents 0 based index
+  #    bool-semantics: If true then the returned integer represents a boolean 1 or 0
+  #    asset-semantics: If true this argument represents an inventory item and can accept either name or uuid
+  #    detected-semantics: If true, the event or function is involved in the DetectedEvent wrapper in SLua
   llAbs:
     arguments:
-    - Value:
-        tooltip: An integer value.
-        type: integer
+      - val:
+          tooltip: Any integer value.
+          type: integer
     slua-deprecated:
       use: math.abs
       reason: Double precision; fastcall.
@@ -6403,14 +7033,14 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the absolute (positive) version of Value.
+    tooltip: Returns an integer representing the absolute (positive) value of val.
     categories:
       - math
   llAcos:
     arguments:
-    - Value:
-        tooltip: A floating-point value.
-        type: float
+      - val:
+          tooltip: A floating-point value falling in the range [-1.0, 1.0].
+          type: float
     slua-deprecated:
       use: math.acos
       reason: Double precision; fastcall.
@@ -6421,84 +7051,85 @@ functions:
     must-use: true # not pure because it might trigger a math error
     return: float
     sleep: 0.0
-    tooltip: Returns the arc-cosine of Value, in radians.
+    tooltip: Returns a float representing the arc-cosine of val in radians.
     categories:
       - math
       - math_trig
   llAddToLandBanList:
     arguments:
-    - ID:
-        tooltip: Agent UUID to add to ban-list.
-        type: key
-    - Hours:
-        tooltip: Period, in hours, to ban the avatar for.
-        type: float
+      - avatar:
+          tooltip: The UUID of the avatar to add to the ban list.
+          type: key
+      - hours:
+          tooltip: The duration, in hours, to ban the avatar for (0 for indefinite).
+          type: float
     energy: 10.0
     func-id: 310
     return: void
     sleep: 0.1
-    tooltip: Add avatar ID to the parcel ban list for the specified number of Hours.\nA
-      value of 0 for Hours will add the agent indefinitely.\nThe smallest value that
-      Hours will accept is 0.01; anything smaller will be seen as 0.\nWhen values
-      that small are used, it seems the function bans in approximately 30 second increments
-      (Probably 36 second increments, as 0.01 of an hour is 36 seconds).\nResidents
-      teleporting to a parcel where they are banned will be redirected to a neighbouring
-      parcel.
+    tooltip: Adds the avatar to the parcel ban list for the specified number of
+      hours. A value of 0 hours adds the avatar indefinitely. Banned users
+      teleporting to the parcel are redirected to a neighboring parcel; the
+      minimum accepted duration is 0.01 hours (approximately 36 seconds).
     categories:
       - land_moderation
       - parcel
   llAddToLandPassList:
     arguments:
-    - ID:
-        tooltip: Agent UUID to add to pass-list.
-        type: key
-    - Hours:
-        tooltip: Period, in hours, to allow the avatar for.
-        type: float
+      - avatar:
+          tooltip: The UUID of the avatar to add to the pass list.
+          type: key
+      - hours:
+          tooltip: The duration, in hours, to allow the avatar for (range [0.0, 144.0], 0
+            for indefinite).
+          type: float
     energy: 10.0
     func-id: 240
     return: void
     sleep: 0.1
-    tooltip: Add avatar ID to the land pass list, for a duration of Hours.
+    tooltip: Adds the avatar to the land pass list for the specified number of hours
+      (or indefinitely if hours is 0).
     categories:
       - land_moderation
       - parcel
   llAdjustDamage:
     arguments:
-    - Number:
-        tooltip: Damage event index to modify.
-        type: integer
-        index-semantics: true
-    - Damage:
-        tooltip: New damage amount to apply on this event.
-        type: float
+      - number:
+          tooltip: The index of the damage event to modify.
+          type: integer
+          index-semantics: true
+      - new_damage:
+          tooltip: The new damage value to be applied or distributed after on_damage
+            processing.
+          type: float
     energy: 10.0
     func-id: 555
     return: void
     detected-semantics: true
     sleep: 0.0
-    tooltip: Changes the amount of damage to be delivered by this damage event.
+    tooltip: Modifies the amount of damage applied by the current on_damage event
+      after it completes processing, specified by the damage event index number.
     categories:
       - combat
       - detected
   llAdjustSoundVolume:
     arguments:
-    - Volume:
-        tooltip: The volume to set.
-        type: float
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 207
     return: void
     sleep: 0.1
-    tooltip: Adjusts the volume (0.0 - 1.0) of the currently playing attached sound.\nThis
-      function has no effect on sounds started with llTriggerSound.
+    tooltip: Adjusts the volume of the currently playing attached sound (has no
+      effect on sounds started with llTriggerSound).
     categories:
       - sound
   llAgentInExperience:
     arguments:
-    - AgentID:
-        tooltip: ''
-        type: key
+      - agent:
+          tooltip: The UUID of the avatar in the same region to query.
+          type: key
     energy: 10.0
     experience: true
     func-id: 392
@@ -6506,39 +7137,44 @@ functions:
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: "\n                   Returns TRUE if the agent is in the Experience\
-      \ and the Experience can run in the current location.\n                "
+    tooltip: Returns TRUE if the specified agent is in the experience and the
+      experience can run in the current region/location; returns FALSE
+      otherwise.
     categories:
       - avatar
       - experience
   llAllowInventoryDrop:
     arguments:
-    - Flag:
-        tooltip: Boolean, If TRUE allows anyone to drop inventory on prim, FALSE revokes.
-        type: integer
-        bool-semantics: true
+      - add:
+          tooltip: Boolean. If TRUE, allows anyone to drop inventory items into the prim
+            (even without modify rights). If FALSE, restricts inventory dropping
+            to those with modify permissions.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 176
     return: void
     sleep: 0.0
-    tooltip: If Flag == TRUE, users without object modify permissions can still drop
-      inventory items into the object.
+    tooltip: If add is TRUE, allows users without object modify permissions to drop
+      inventory items into the prim. If FALSE, restricts inventory dropping to
+      users with modify permissions.
     categories:
       - prim_inventory
   llAngleBetween:
     arguments:
-    - Rot1:
-        tooltip: First rotation.
-        type: rotation
-    - Rot2:
-        tooltip: Second rotation.
-        type: rotation
+      - a:
+          tooltip: The starting rotation.
+          type: rotation
+      - b:
+          tooltip: The ending rotation.
+          type: rotation
     energy: 10.0
     func-id: 174
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the angle, in radians, between rotations Rot1 and Rot2.
+    tooltip: Returns a float representing the angle in radians between rotations a
+      and b.
     categories:
       - math
       - math_3d
@@ -6546,48 +7182,49 @@ functions:
       - quaternion
   llApplyImpulse:
     arguments:
-    - Force:
-        tooltip: Amount of impulse force to apply.
-        type: vector
-    - Local:
-        tooltip: Boolean, if TRUE, force is treated as a local directional vector
-          instead of region directional vector.
-        type: integer
-        bool-semantics: true
+      - momentum:
+          tooltip: The linear impulse vector to apply.
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, momentum is treated as a local directional vector; if
+            FALSE, it is treated as a global region vector.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 72
     return: void
     sleep: 0.0
-    tooltip: Applies impulse to the object.\nIf Local == TRUE, apply the Force in
-      local coordinates; otherwise, apply the Force in global coordinates.\nThis function
-      only works on physical objects.
+    tooltip: Applies a linear impulse (momentum) to a physical object. If local is
+      TRUE, the impulse is applied in local coordinates; otherwise, it is
+      applied in global region coordinates.
     categories:
       - movement
       - physics
   llApplyRotationalImpulse:
     arguments:
-    - Force:
-        tooltip: Amount of impulse force to apply.
-        type: vector
-    - Local:
-        tooltip: Boolean, if TRUE, uses local axis, if FALSE, uses region axis.
-        type: integer
-        bool-semantics: true
+      - force:
+          tooltip: The rotational impulse vector to apply.
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, the force is treated as a local directional vector;
+            if FALSE, it is treated as a global region vector.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 73
     return: void
     sleep: 0.0
-    tooltip: Applies rotational impulse to the object.\nIf Local == TRUE, apply the
-      Force in local coordinates; otherwise, apply the Force in global coordinates.\nThis
-      function only works on physical objects.
+    tooltip: Applies a rotational impulse (force) to a physical object. If local is
+      TRUE, the rotational impulse is applied in local coordinates; otherwise,
+      it is applied in global region coordinates.
     categories:
       - movement
       - physics
   llAsin:
     arguments:
-    - Value:
-        tooltip: A floating-point value.
-        type: float
+      - val:
+          tooltip: A floating-point value falling in the range [-1.0, 1.0].
+          type: float
     slua-deprecated:
       use: math.asin
       reason: Double precision; fastcall.
@@ -6598,18 +7235,18 @@ functions:
     must-use: true # not pure because it might trigger a math error
     return: float
     sleep: 0.0
-    tooltip: Returns the arc-sine, in radians, of Value.
+    tooltip: Returns a float representing the arc-sine of val in radians.
     categories:
       - math
       - math_trig
   llAtan2:
     arguments:
-    - y:
-        tooltip: A floating-point value.
-        type: float
-    - x:
-        tooltip: A floating-point value.
-        type: float
+      - y:
+          tooltip: A floating-point value representing the y coordinate.
+          type: float
+      - x:
+          tooltip: A floating-point value representing the x coordinate.
+          type: float
     slua-deprecated:
       use: math.atan2
       reason: Double precision; fastcall.
@@ -6620,57 +7257,60 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the arc-tangent2 of y, x.
+    tooltip: Returns a float representing the arctangent2 of y and x.
     categories:
       - math
       - math_trig
   llAttachToAvatar:
     arguments:
-    - AttachmentPoint:
-        tooltip: ''
-        type: integer
+      - attach_point:
+          tooltip: The ATTACH_* constant or integer value representing the target
+            attachment point.
+          type: integer
     energy: 10.0
     func-id: 113
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_ATTACH
-    tooltip: Attach to avatar at point AttachmentPoint.\nRequires the PERMISSION_ATTACH
-      runtime permission.
+    tooltip: Attaches the object to the avatar who has granted the PERMISSION_ATTACH
+      permission. Takes the object into the user's inventory and attaches it at
+      attach_point.
     categories:
       - attachments
       - avatar
   llAttachToAvatarTemp:
     arguments:
-    - AttachPoint:
-        tooltip: Valid attachment point or ATTACH_* constant.
-        type: integer
+      - attach_point:
+          tooltip: The ATTACH_* constant or integer value representing the target
+            attachment point.
+          type: integer
     energy: 10.0
     func-id: 391
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_ATTACH
-    tooltip: Follows the same convention as llAttachToAvatar, with the exception that
-      the object will not create new inventory for the user, and will disappear on
-      detach or disconnect.\nRequires the PERMISSION_ATTACH runtime permission.
+    tooltip: Attaches the object temporarily to an avatar who has granted the
+      PERMISSION_ATTACH permission. No permanent inventory is created, and the
+      object disappears on detach or disconnect. Can be used on non-owners
+      (changing ownership to the wearer).
     categories:
       - attachments
       - avatar
   llAvatarOnLinkSitTarget:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag.'
-        type: integer
+      - link:
+          tooltip: The index of the prim in the linkset (1 for root, >1 for children), or
+            a LINK_* flag.
+          type: integer
     energy: 10.0
     func-id: 376
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: If an avatar is sitting on the link's sit target, return the avatar's
-      key, NULL_KEY otherwise.\nReturns a key that is the UUID of the user seated
-      on the specified link's prim.
+    tooltip: Returns the UUID of the avatar seated on the specified link's sit
+      target, or NULL_KEY if no avatar is sitting there.
     categories:
       - avatar
       - linkset
@@ -6682,31 +7322,30 @@ functions:
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: If an avatar is seated on the sit target, returns the avatar's key, otherwise
-      NULL_KEY.\nThis only will detect avatars sitting on sit targets defined with
-      llSitTarget.
+    tooltip: Returns the UUID of the avatar seated on the prim's sit target (defined
+      via llSitTarget), or NULL_KEY if no avatar is sitting there or the prim
+      lacks a sit target.
     categories:
       - avatar
       - prim
       - sit
   llAxes2Rot:
     arguments:
-    - Forward:
-        tooltip: Forward/Back part of rotation.
-        type: vector
-    - Left:
-        tooltip: Left/Right part of rotation.
-        type: vector
-    - Up:
-        tooltip: Up/Down part of rotation.
-        type: vector
+      - fwd:
+          tooltip: The forward/back directional vector of the rotation.
+          type: vector
+      - left:
+          tooltip: The left/right directional vector of the rotation.
+          type: vector
+      - up:
+          tooltip: The up/down directional vector of the rotation.
+          type: vector
     energy: 10.0
     func-id: 17
     pure: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation represented by coordinate axes Forward, Left, and
-      Up.
+    tooltip: Returns the rotation defined by the coordinate axes fwd, left, and up.
     categories:
       - math
       - math_3d
@@ -6714,18 +7353,19 @@ functions:
       - quaternion
   llAxisAngle2Rot:
     arguments:
-    - Axis:
-        tooltip: Axis.
-        type: vector
-    - Angle:
-        tooltip: Angle in radians.
-        type: float
+      - axis:
+          tooltip: The axis vector around which the rotation is generated.
+          type: vector
+      - angle:
+          tooltip: The angle of rotation, expressed in radians.
+          type: float
     energy: 10.0
     func-id: 169
     pure: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation that is a generated Angle about Axis.
+    tooltip: Returns the rotation representing a generated angle (in radians) about
+      the specified axis.
     categories:
       - math
       - math_3d
@@ -6733,9 +7373,9 @@ functions:
       - quaternion
   llBase64ToInteger:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - str:
+          tooltip: The Base64-encoded string to decode.
+          type: string
     slua-deprecated:
       reason: Use 'llbase64.decode' and 'string.unpack' or 'buffer.readi32' instead.
       selene-replace: ['string.unpack(">i", llbase64.decode(s))']
@@ -6744,23 +7384,24 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns an integer that is the Text, Base64 decoded as a big endian integer.\nReturns
-      zero if Text is longer then 8 characters. If Text contains fewer then 6 characters,
-      the return value is unpredictable.
+    tooltip: Returns an integer representing the Base64-decoded big-endian value of
+      str. Returns zero if str is longer than 8 characters; the return value is
+      unpredictable if str contains fewer than 6 characters.
     categories:
       - data_conversion
   llBase64ToString:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - str:
+          tooltip: The Base64-encoded string to decode.
+          type: string
     energy: 10.0
     func-id: 261
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Converts a Base64 string to a conventional string.\nIf the conversion
-      creates any unprintable characters, they are converted to question marks.
+    tooltip: Decodes the Base64-encoded string str into a conventional string,
+      interpreting the bytes as a UTF-8 character sequence. Unprintable
+      characters are converted to question marks.
     categories:
       - data_conversion
     slua-deprecated:
@@ -6774,68 +7415,69 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_CHANGE_LINKS
-    tooltip: De-links all prims in the link set.\nRequires the PERMISSION_CHANGE_LINKS
-      runtime permission.
+    tooltip: Delinks all prims in the linkset. Requires the PERMISSION_CHANGE_LINKS
+      runtime permission, which must be requested and granted by the owner.
     categories:
       - linkset
   llBreakLink:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: "The link number (0: unlinked, 1: root prim, >1: child prims and seated
+            avatars) to delink."
+          type: integer
     energy: 10.0
     func-id: 142
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_CHANGE_LINKS
-    tooltip: De-links the prim with the given link number.\nRequires the PERMISSION_CHANGE_LINKS
-      runtime permission.
+    tooltip: Delinks the prim specified by the link number link. Requires the
+      PERMISSION_CHANGE_LINKS runtime permission.
     categories:
       - linkset
   llCSV2List:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The string of comma-separated values to parse.
+          type: string
     energy: 10.0
     func-id: 196
     pure: true
     return: list
     slua-return: '{string}'
     sleep: 0.0
-    tooltip: Create a list from a string of comma separated values specified in Text.
+    tooltip: Parses the comma-separated string src and returns it as a list.
     categories:
       - data_conversion
   llCastRay:
     arguments:
-    - Start:
-        tooltip: ''
-        type: vector
-    - End:
-        tooltip: ''
-        type: vector
-    - Options:
-        tooltip: ''
-        type: list
+      - start:
+          tooltip: The starting location vector of the ray.
+          type: vector
+      - end:
+          tooltip: The ending location vector of the ray.
+          type: vector
+      - options:
+          tooltip: A list of option flags and their parameters to configure the raycast.
+          type: list
     energy: 10.0
     func-id: 363
     must-use: true
     return: list
     sleep: 0.0
-    tooltip: 'Casts a ray into the physics world from ''start'' to ''end'' and returns
-      data according to details in Options.\nReports collision data for intersections
-      with objects.\nReturn value: [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1},
-      UUID_2, {link_number_2}, hit_position_2, {hit_normal_2}, ... , status_code]
-      where {} indicates optional data.'
+    tooltip: Casts a ray into the physics world from start to end and reports
+      collision data for intersections with objects based on options. Returns a
+      list of strided values [UUID_1, {link_number_1}, hit_position_1,
+      {hit_normal_1}, ..., status_code]. A negative status_code indicates an
+      error; otherwise, it represents the number of hits.
     categories:
       - physics
       - sensor
   llCeil:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The float value to round.
+          type: float
     slua-deprecated:
       use: math.ceil
       reason: Fastcall.
@@ -6846,21 +7488,22 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns smallest integer value >= Value.
+    tooltip: Returns the smallest integer value greater than or equal to val
+      (rounded toward positive infinity).
     categories:
       - math
   llChar:
     arguments:
-    - value:
-        tooltip: Unicode value to convert into a string.
-        type: integer
+      - val:
+          tooltip: The Unicode value to convert into a character string.
+          type: integer
     energy: 10.0
     func-id: 526
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns a single character string that is the representation of the unicode
-      value.
+    tooltip: Constructs and returns a single-character string representing the
+      supplied Unicode value val.
     categories:
       - string
   llClearCameraParams:
@@ -6872,73 +7515,74 @@ functions:
     requires-permission:
       - PERMISSION_CONTROL_CAMERA
     tooltip: Resets all camera parameters to default values and turns off scripted
-      camera control.\nRequires the PERMISSION_CONTROL_CAMERA runtime permission
-      (automatically granted to attached or sat on objects).
+      camera control. Requires the PERMISSION_CONTROL_CAMERA runtime permission
+      (automatically granted for attached or sat-on objects).
     categories:
       - avatar
       - camera
       - permissions
   llClearExperience:
     arguments:
-    - AgentID:
-        tooltip: ''
-        type: key
-    - ExperienceID:
-        tooltip: ''
-        type: key
+      - agentid:
+          tooltip: ''
+          type: key
+      - experienceid:
+          tooltip: ''
+          type: key
     deprecated: true
     energy: 10.0
     func-id: 411
     private: true
     return: void
     sleep: 0.0
-    tooltip: ''
+    tooltip: ""
     categories:
       - experience
   llClearExperiencePermissions:
     arguments:
-    - AgentID:
-        tooltip: ''
-        type: key
+      - agentid:
+          tooltip: ''
+          type: key
     deprecated: true
     energy: 10.0
     func-id: 385
     private: true
     return: void
     sleep: 0.0
-    tooltip: ''
+    tooltip: ""
     categories:
       - experience
   llClearLinkMedia:
     arguments:
-    - Link:
-        tooltip: ''
-        type: integer
-    - Face:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: "The link number (0: unlinked, 1: root prim, >1: child prims) or a
+            LINK_* flag representing the target prim."
+          type: integer
+      - face:
+          tooltip: The face number to clear.
+          type: integer
     energy: 10.0
     func-id: 373
     return: integer
     sleep: 0.0
-    tooltip: Clears (deletes) the media and all parameters from the given Face on
-      the linked prim.\nReturns an integer that is a STATUS_* flag, which details
-      the success/failure of the operation.
+    tooltip: Deletes the media and clears all parameters from the given face on the
+      linked prim. Returns an integer STATUS_* flag detailing the success or
+      failure of the operation.
     categories:
       - linkset
       - media
       - prim_media
   llClearPrimMedia:
     arguments:
-    - Face:
-        tooltip: Number of side to clear.
-        type: integer
+      - face:
+          tooltip: The face number (side) to clear.
+          type: integer
     energy: 10.0
     func-id: 352
     return: integer
     sleep: 1.0
-    tooltip: Clears (deletes) the media and all parameters from the given Face.\nReturns
-      an integer that is a STATUS_* flag which details the success/failure of the
+    tooltip: Deletes the media and clears all parameters from the specified face.
+      Returns an integer STATUS_* flag detailing the success or failure of the
       operation.
     categories:
       - media
@@ -6946,109 +7590,118 @@ functions:
       - prim_media
   llCloseRemoteDataChannel:
     arguments:
-    - ChannelID:
-        tooltip: ''
-        type: key
+      - channel:
+          tooltip: The XML-RPC channel ID to close.
+          type: key
     deprecated: true
     energy: 10.0
     func-id: 257
     return: void
     sleep: 1.0
-    tooltip: This function is deprecated.
+    tooltip: Deprecated. Closes the specified XML-RPC channel.
     categories:
       - script_communication
   llCloud:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     deprecated: true
     energy: 10.0
     func-id: 43
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the cloud density at the object's position + Offset.
+    tooltip: Returns a float representing the cloud density at the prim's position
+      offset by the vector offset.
     categories:
       - region
   llCollisionFilter:
     arguments:
-    - ObjectName:
-        tooltip: ''
-        type: string
-    - ObjectID:
-        tooltip: ''
-        type: key
-    - Accept:
-        tooltip: If TRUE, only accept collisions with ObjectName name AND ObjectID
-          (either is optional), otherwise with objects not ObjectName AND ObjectID.
-        type: integer
-        bool-semantics: true
+      - name:
+          tooltip: The specific object name or avatar legacy name to filter for.
+          type: string
+      - id:
+          tooltip: The group, avatar, or object UUID to filter by.
+          type: key
+      - accept:
+          tooltip: Boolean. If TRUE, only collisions matching the name and id filters are
+            processed; if FALSE, matching collisions are excluded.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 110
     return: void
     sleep: 0.0
-    tooltip: Specify an empty string or NULL_KEY for Accept, to not filter on the
-      corresponding parameter.
+    tooltip: Sets the collision filter, either exclusively or inclusively. If accept
+      is TRUE, only collisions matching name and id are processed; if FALSE,
+      matches are excluded. Pass an empty string or NULL_KEY to name or id to
+      skip filtering on that parameter.
     categories:
       - physics
       - sensor
   llCollisionSound:
     arguments:
-    - ImpactSound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - ImpactVolume:
-        tooltip: ''
-        type: float
+      - impact_sound:
+          tooltip: The UUID of a sound, the name of a sound in the prim's inventory, or an
+            empty string to suppress sounds.
+          type: string
+          asset-semantics: true
+      - impact_volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 160
     return: void
     sleep: 0.0
-    tooltip: Suppress default collision sounds, replace default impact sounds with
-      ImpactSound.\nThe ImpactSound must be in the object inventory.\nSupply an empty
-      string to suppress collision sounds.
+    tooltip: Suppresses default collision sounds and replaces default impact sounds
+      with impact_sound at the volume level specified by impact_volume. Supply
+      an empty string to only suppress collision sounds.
     categories:
       - physics
       - sound
   llCollisionSprite:
     arguments:
-    - ImpactSprite:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - impact_sprite:
+          tooltip: The UUID of a texture, the name of a texture in the prim's inventory,
+            or an empty string to suppress sprites.
+          type: string
+          asset-semantics: true
     deprecated: true
     energy: 10.0
     func-id: 161
     return: void
     sleep: 0.0
-    tooltip: Suppress default collision sprites, replace default impact sprite with
-      ImpactSprite; found in the object inventory (empty string to just suppress).
+    tooltip: Suppresses default collision sprites and replaces them with
+      impact_sprite (which must be in the prim's inventory). Supply an empty
+      string to only suppress collision sprites.
     categories:
       - effects
       - sound
   llComputeHash:
     arguments:
-    - Message:
-        tooltip: The message to be hashed.
-        type: string
-    - Algorithm:
-        tooltip: 'The digest algorithm: md5, sha1, sha224, sha256, sha384, sha512.'
-        type: string
+      - message:
+          tooltip: The message string to be hashed.
+          type: string
+      - algorithm:
+          tooltip: The cryptographic digest algorithm to use (e.g., md5, sha1, sha224,
+            sha256, sha384, or sha512).
+          type: string
     energy: 10.0
     func-id: 548
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns hex-encoded Hash string of Message using digest Algorithm.
+    tooltip: Returns a hex-encoded hash digest string of message using the specified
+      cryptographic algorithm.
     categories:
       - cryptography
   llCos:
     arguments:
-    - Theta:
-        tooltip: ''
-        type: float
+      - theta:
+          tooltip: The angle expressed in radians.
+          type: float
     slua-deprecated:
       use: math.cos
       reason: Double precision; fastcall.
@@ -7059,45 +7712,43 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the cosine of Theta (Theta in radians).
+    tooltip: Returns a float representing the cosine of theta.
     categories:
       - math
       - math_trig
   llCreateCharacter:
     arguments:
-    - Options:
-        tooltip: ''
-        type: list
+      - options:
+          tooltip: A list of key-value pairs specifying the character's configuration
+            options.
+          type: list
     energy: 10.0
     func-id: 399
     return: void
     sleep: 0.0
-    tooltip: Convert link-set to AI/Physics character.\nCreates a path-finding entity,
-      known as a "character", from the object containing the script. Required to activate
-      use of path-finding functions.\nOptions is a list of key/value pairs.
+    tooltip: Converts the linkset containing the script into a pathfinding character
+      entity (required to use pathfinding functions) using the specified
+      options.
     categories:
       - pathfinding
   llCreateKeyValue:
     arguments:
-    - Key:
-        tooltip: ''
-        type: string
-    - Value:
-        tooltip: ''
-        type: string
+      - k:
+          tooltip: The unique key name for the key-value pair.
+          type: string
+      - v:
+          tooltip: The value for the key-value pair (maximum 2047 characters, or 4095
+            characters if using Mono).
+          type: string
     energy: 10.0
     experience: true
     func-id: 387
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction to create a key-value\
-      \ pair. Will fail with XP_ERROR_STORAGE_EXCEPTION if the key already exists.\
-      \ The dataserver callback will be executed with the key returned from this call\
-      \ and a string describing the result. The result is a two element commma-delimited\
-      \ list. The first item is an integer specifying if the transaction succeeded\
-      \ (1) or not (0). In the failure case, the second item will be an integer corresponding\
-      \ to one of the XP_ERROR_... constants. In the success case the second item\
-      \ will be the value passed to the function.\n                "
+    tooltip: Starts an asynchronous transaction to create a key-value pair (k and v)
+      associated with the script's experience. Returns a key query handle for
+      the dataserver event. Fails with XP_ERROR_STORAGE_EXCEPTION if the key
+      already exists.
     categories:
       - data_storage
       - dataserver
@@ -7105,40 +7756,43 @@ functions:
       - experience_data
   llCreateLink:
     arguments:
-    - TargetPrim:
-        tooltip: Object UUID that is in the same region.
-        type: key
-    - Parent:
-        tooltip: If FALSE, then TargetPrim becomes the root. If TRUE, then the script's
-          object becomes the root.
-        type: integer
-        bool-semantics: true
+      - target:
+          tooltip: The UUID of the target prim/object in the same region.
+          type: key
+      - parent:
+          tooltip: Boolean. If TRUE, the script's object becomes the root prim; if FALSE,
+            target becomes the root.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 141
     return: void
     sleep: 0.1
     requires-permission:
       - PERMISSION_CHANGE_LINKS
-    tooltip: Attempt to link the object the script is in, to target.\nRequires the
-      PERMISSION_CHANGE_LINKS runtime permission.
+    tooltip: Attempts to link the object containing the script with target. Requires
+      the PERMISSION_CHANGE_LINKS runtime permission.
     categories:
       - linkset
   llDamage:
     arguments:
-    - target:
-        tooltip: Agent or task to receive damage.
-        type: key
-    - damage:
-        tooltip: Damage amount to inflict on this target.
-        type: float
-    - type:
-        tooltip: Damage type to inflict on this target.
-        type: integer
+      - target:
+          tooltip: The key of the target avatar or task to receive damage.
+          type: key
+      - damage:
+          tooltip: The amount of damage to inflict (can exceed 100, unlike collision-based
+            damage).
+          type: float
+      - damage_type:
+          tooltip: The type of damage to deliver to the target (can correspond to a
+            DAMAGE_TYPE_* constant).
+          type: integer
     energy: 10.0
     func-id: 671
     return: void
     sleep: 0.0
-    tooltip: Generates a damage event on the targeted agent or task.
+    tooltip: Generates a damage event delivering the specified amount of damage and
+      damage_type to the targeted avatar or task in the same region.
     categories:
       - combat
   llDataSizeKeyValue:
@@ -7148,15 +7802,9 @@ functions:
     func-id: 600
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction the request the\
-      \ used and total amount of data allocated for the Experience. The dataserver\
-      \ callback will be executed with the key returned from this call and a string\
-      \ describing the result. The result is commma-delimited list. The first item\
-      \ is an integer specifying if the transaction succeeded (1) or not (0). In the\
-      \ failure case, the second item will be an integer corresponding to one of the\
-      \ XP_ERROR_... constants. In the success case the second item will be the the\
-      \ amount in use and the third item will be the total available.\n          \
-      \      "
+    tooltip: Starts an asynchronous transaction to request the used and total data
+      storage allocated for the experience. Returns a key query handle for the
+      dataserver event.
     categories:
       - data_storage
       - dataserver
@@ -7168,28 +7816,23 @@ functions:
     func-id: 405
     return: void
     sleep: 0.0
-    tooltip: Convert link-set from AI/Physics character to Physics object.\nConvert
-      the current link-set back to a standard object, removing all path-finding properties.
+    tooltip: Converts the linkset back to a standard physical object, removing all
+      pathfinding properties.
     categories:
       - pathfinding
   llDeleteKeyValue:
     arguments:
-    - Key:
-        tooltip: ''
-        type: string
+      - k:
+          tooltip: The key of the key-value pair to delete.
+          type: string
     energy: 10.0
     experience: true
     func-id: 390
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction to delete a key-value\
-      \ pair. The dataserver callback will be executed with the key returned from\
-      \ this call and a string describing the result. The result is a two element\
-      \ commma-delimited list. The first item is an integer specifying if the transaction\
-      \ succeeded (1) or not (0). In the failure case, the second item will be an\
-      \ integer corresponding to one of the XP_ERROR_... constants. In the success\
-      \ case the second item will be the value associated with the key.\n        \
-      \        "
+    tooltip: Starts an asynchronous transaction to delete the key-value pair
+      associated with key k in the experience. Returns a key query handle for
+      the dataserver event.
     categories:
       - data_storage
       - dataserver
@@ -7198,18 +7841,18 @@ functions:
   llDeleteSubList:
     type-arguments: [T]
     arguments:
-    - Source:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list to copy and modify.
+          type: list
+          slua-type: '{T}'
+      - start:
+          tooltip: The starting index of the slice to remove (inclusive).
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The ending index of the slice to remove (inclusive).
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: table.remove
       reason: Unnecessary table copying.
@@ -7221,54 +7864,52 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Removes the slice from start to end and returns the remainder of the
-      list.\nRemove a slice from the list and return the remainder, start and end
-      are inclusive.\nUsing negative numbers for start and/or end causes the index
-      to count backwards from the length of the list, so 0, -1 would delete the entire
-      list.\nIf Start is larger than End the list deleted is the exclusion of the
-      entries; so 6, 4 would delete the entire list except for the 5th list entry.
+    tooltip: Returns a copy of the list src with the slice from start to end
+      (inclusive) removed. Negative indices count backward from the end of the
+      list. If start is greater than end, the deletion excludes the specified
+      range.
     categories:
       - list
   llDeleteSubString:
     arguments:
-    - Source:
-        tooltip: ''
-        type: string
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source string to modify.
+          type: string
+      - start:
+          tooltip: The starting index of the substring to remove (inclusive).
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The ending index of the substring to remove (inclusive).
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 95
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Removes the indicated sub-string and returns the result.\nStart and End
-      are inclusive.\nUsing negative numbers for Start and/or End causes the index
-      to count backwards from the length of the string, so 0, -1 would delete the
-      entire string.\nIf Start is larger than End, the sub-string is the exclusion
-      of the entries; so 6, 4 would delete the entire string except for the 5th character.
+    tooltip: Returns a copy of the string src with the characters from start to end
+      (inclusive) removed. Negative indices count backward from the end of the
+      string. If start is greater than end, the deletion excludes the specified
+      range.
     categories:
       - string
   llDerezObject:
     arguments:
-    - ID:
-        tooltip: The ID of an object in the region.
-        type: key
-    - flags:
-        tooltip: Flags for derez behavior.
-        type: integer
+      - id:
+          tooltip: The UUID of the object in the region to derez.
+          type: key
+      - flag:
+          tooltip: Derez behavior flags matching DEREZ_* constants.
+          type: integer
     energy: 10.0
     func-id: 509
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Derezzes an object previously rezzed by a script in this region. Returns
-      TRUE on success or FALSE if the object could not be derezzed.
+    tooltip: Derezzes (deletes or returns) a targeted object in the region
+      previously rezzed by a script in this linkset, returning TRUE on success
+      or FALSE on failure.
     categories:
       - prim_inventory
       - rez
@@ -7280,51 +7921,55 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_ATTACH
-    tooltip: Remove the object containing the script from the avatar.\nRequires the
-      PERMISSION_ATTACH runtime permission (automatically granted to attached objects).
+    tooltip: Detaches the object containing the script from the avatar. Requires the
+      PERMISSION_ATTACH runtime permission (automatically granted to attached
+      objects). Note that the detached object is completely removed from the
+      region and not dropped on the ground.
     categories:
       - attachments
       - avatar
   llDetectedDamage:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 554
     must-use: true
     return: list
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns a list containing the current damage for the event, the damage
-      type and the original damage delivered.
+    tooltip: Returns a list containing pending damage information for the event
+      specified by number, including the current damage, the damage type, and
+      the original damage delivered.
     categories:
       - combat
       - detected
   llDetectedGrab:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 37
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the grab offset of a user touching the object.\nReturns <0.0,
-      0.0, 0.0> if Number is not a valid object.
+    tooltip: Returns a vector representing the grab offset of the user touching the
+      object. Only works in touch events and returns <0.0, 0.0, 0.0> if number
+      is not a valid index.
     categories:
       - detected
       - touch
   llDetectedGroup:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 39
     must-use: true
@@ -7332,34 +7977,34 @@ functions:
     bool-semantics: true
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if detected object or agent Number has the same user group
-      active as this object.\nIt will return FALSE if the object or agent is in the
-      group, but the group is not active.
+    tooltip: Returns TRUE if the detected object or avatar specified by number has
+      the same active group as the prim containing the script. Returns FALSE if
+      the group is not active or if they are not in the group.
     categories:
       - detected
   llDetectedKey:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 32
     must-use: true
     return: key
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the key of detected object or avatar number.\nReturns NULL_KEY
-      if Number is not a valid index.
+    tooltip: Returns the key (UUID) of the detected object or avatar specified by
+      number, or NULL_KEY if number is not a valid index.
     categories:
       - detected
       - uuid
   llDetectedLinkNumber:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 40
     # Note that the return does NOT have index semantics, link numbers are already one-indexed (sort of)
@@ -7367,115 +8012,119 @@ functions:
     return: integer
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the link position of the triggered event for touches and collisions
-      only.\n0 for a non-linked object, 1 for the root of a linked object, 2 for the
-      first child, etc.
+    tooltip: Returns the link number (integer) of the triggered event (touches and
+      collisions only) specified by number. Returns 0 for non-linked objects, 1
+      for the root prim, and 2+ for child prims. Returns 0 if not supported by
+      the event.
     categories:
       - detected
   llDetectedName:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - item:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 31
     must-use: true
     return: string
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the name of detected object or avatar number.\nReturns the name
-      of detected object number.\nReturns empty string if Number is not a valid index.
+    tooltip: Returns a string representing the name of the detected object or avatar
+      specified by item. Returns an empty string if item is not a valid index.
     categories:
       - detected
   llDetectedOwner:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 33
     must-use: true
     return: key
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the key of detected object's owner.\nReturns invalid key if Number
-      is not a valid index.
+    tooltip: Returns the key (UUID) of the owner of the detected object specified by
+      number. Returns an invalid key if number is not a valid index.
     categories:
       - avatar
       - detected
   llDetectedPos:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 35
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the position of detected object or avatar number.\nReturns <0.0,
-      0.0, 0.0> if Number is not a valid index.
+    tooltip: Returns the vector position (in region coordinates) of the detected
+      object or avatar specified by number, or <0.0, 0.0, 0.0> if number is not
+      a valid index.
     categories:
       - detected
   llDetectedRezzer:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 553
     must-use: true
     return: key
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the key for the rezzer of the detected object.
+    tooltip: Returns the key (UUID) of the object or avatar that rezzed the detected
+      object specified by number.
     categories:
       - detected
   llDetectedRot:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 38
     must-use: true
     return: rotation
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the rotation of detected object or avatar number.\nReturns <0.0,
-      0.0, 0.0, 1.0> if Number is not a valid offset.
+    tooltip: Returns the rotation of the detected object or avatar specified by
+      number, or <0.0, 0.0, 0.0, 1.0> if number is not a valid offset index.
     categories:
       - detected
   llDetectedTouchBinormal:
     arguments:
-    - Index:
-        tooltip: Index of detection information
-        type: integer
-        index-semantics: true
+      - index:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 341
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the surface bi-normal for a triggered touch event.\nReturns a
-      vector that is the surface bi-normal (tangent to the surface) where the touch
-      event was triggered.
+    tooltip: Returns the surface binormal vector (tangent to the surface, pointing
+      along the positive T (V) direction of tangent space) at the touched
+      location specified by index. Can be used with llDetectedTouchNormal to
+      determine the tangent space.
     categories:
       - detected
       - touch
   llDetectedTouchFace:
     arguments:
-    - Index:
-        tooltip: Index of detection information
-        type: integer
-        index-semantics: true
+      - index:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 338
     # NOTE: We can't change face number indexing easily because it's part of the viewer, so no index semantics for ret...
@@ -7483,153 +8132,142 @@ functions:
     return: integer
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the index of the face where the avatar clicked in a triggered
-      touch event.
+    tooltip: Returns the integer index of the face clicked by the avatar in the
+      touch event specified by index.
     categories:
       - detected
       - touch
   llDetectedTouchNormal:
     arguments:
-    - Index:
-        tooltip: Index of detection information
-        type: integer
-        index-semantics: true
+      - index:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 340
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the surface normal for a triggered touch event.\nReturns a vector
-      that is the surface normal (perpendicular to the surface) where the touch event
-      was triggered.
+    tooltip: Returns the surface normal vector (perpendicular to the surface) at the
+      touched location specified by index. Can be used with
+      llDetectedTouchBinormal to determine the tangent space.
     categories:
       - detected
       - touch
   llDetectedTouchPos:
     arguments:
-    - Index:
-        tooltip: Index of detected information
-        type: integer
-        index-semantics: true
+      - index:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 339
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the position, in region coordinates, where the object was touched
-      in a triggered touch event.\nUnless it is a HUD, in which case it returns the
-      position relative to the attach point.
+    tooltip: Returns the vector position where the object was touched (specified by
+      index) in region coordinates, or in screen-space coordinates if the object
+      is attached as a HUD.
     categories:
       - detected
       - touch
   llDetectedTouchST:
     arguments:
-    - Index:
-        tooltip: Index of detection information
-        type: integer
-        index-semantics: true
+      - index:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 342
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns a vector that is the surface coordinates where the prim was touched.\nThe
-      X and Y vector positions contain the horizontal (S) and vertical (T) face coordinates
-      respectively.\nEach component is in the interval [0.0, 1.0].\nTOUCH_INVALID_TEXCOORD
-      is returned if the surface coordinates cannot be determined (e.g. when the viewer
-      does not support this function).
+    tooltip: Returns the surface coordinates (<s, t, 0.0>) where the prim was
+      touched, specified by index. X and Y contain the horizontal (s) and
+      vertical (t) face coordinates, typically in the interval [0.0, 1.0].
+      Returns TOUCH_INVALID_TEXCOORD if coordinates cannot be determined.
     categories:
       - detected
       - touch
   llDetectedTouchUV:
     arguments:
-    - Index:
-        tooltip: Index of detection information
-        type: integer
-        index-semantics: true
+      - index:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 337
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns a vector that is the texture coordinates for where the prim was
-      touched.\nThe X and Y vector positions contain the U and V face coordinates
-      respectively.\nTOUCH_INVALID_TEXCOORD is returned if the touch UV coordinates
-      cannot be determined (e.g. when the viewer does not support this function).
+    tooltip: Returns the texture coordinates (<u, v, 0.0>) where the prim was
+      touched, specified by index. X and Y contain the horizontal (u) and
+      vertical (v) texture coordinates, typically in the interval [0.0, 1.0]
+      (affected by repeats and rotation). Returns TOUCH_INVALID_TEXCOORD if
+      coordinates cannot be determined.
     categories:
       - detected
       - touch
   llDetectedType:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 34
     must-use: true
     return: integer
     detected-semantics: true
     sleep: 0.0
-    tooltip: "Returns the type (AGENT, ACTIVE, PASSIVE, SCRIPTED) of detected object.\\\
-      nReturns 0 if number is not a valid index.\\nNote that number is a bit-field,\
-      \ so comparisons need to be a bitwise checked. e.g.:\\ninteger iType = llDetectedType(0);\\\
-      n{\\n\t// ...do stuff with the agent\\n}"
+    tooltip: Returns an integer bitfield representing the types (AGENT, ACTIVE,
+      PASSIVE, or SCRIPTED) of the detected object or avatar specified by
+      number. Returns 0 if number is not a valid index.
     categories:
       - detected
   llDetectedVel:
     arguments:
-    - Number:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - number:
+          tooltip: The index of the detection information.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 36
     must-use: true
     return: vector
     detected-semantics: true
     sleep: 0.0
-    tooltip: Returns the velocity of the detected object Number.\nReturns<0.0, 0.0,
-      0.0> if Number is not a valid offset.
+    tooltip: Returns the vector velocity of the detected object or avatar specified
+      by number, or <0.0, 0.0, 0.0> if number is not a valid offset index.
     categories:
       - detected
   llDialog:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Text:
-        tooltip: ''
-        type: string
-    - Buttons:
-        tooltip: ''
-        type: list
-        slua-type: "{string}"
-    - Channel:
-        tooltip: ''
-        type: integer
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
+      - message:
+          tooltip: The text message to display in the dialog box.
+          type: string
+      - buttons:
+          tooltip: A list of up to 12 strings representing button labels.
+          type: list
+          slua-type: "{string}"
+      - channel:
+          tooltip: The output chat channel (any integer value) where button clicks are
+            chatted.
+          type: integer
     energy: 10.0
     func-id: 247
     return: void
     sleep: 1.0
-    tooltip: "Shows a dialog box on the avatar's screen with the message.\\n\n   \
-      \                 Up to 12 strings in the list form buttons.\\n\n          \
-      \          If a button is clicked, the name is chatted on Channel.\\nOpens a\
-      \ \"notify box\" in the given avatars screen displaying the message.\\n\n  \
-      \              Up to twelve buttons can be specified in a list of strings. When\
-      \ the user clicks a button, the name of the button is said on the specified\
-      \ channel.\\n\n                Channels work just like llSay(), so channel 0\
-      \ can be heard by everyone.\\n\n                The chat originates at the object's\
-      \ position, not the avatar's position, even though it is said as the avatar\
-      \ (uses avatar's UUID and Name etc.).\\n\n                Examples:\\n\n   \
-      \             llDialog(who, \"Are you a boy or a girl?\", [ \"Boy\", \"Girl\"\
-      \ ], -4913);\\n\n                llDialog(who, \"This shows only an OK button.\"\
-      , [], -192);\\n\n                llDialog(who, \"This chats so you can 'hear'\
-      \ it.\", [\"Hooray\"], 0);"
+    tooltip: Shows a dialog box on the screen of the avatar specified by avatar,
+      displaying message along with up to 12 choice buttons. Clicking a button
+      chats its label on channel.
     categories:
       - avatar_communication
       - chat
@@ -7640,153 +8278,151 @@ functions:
     func-id: 41
     return: void
     sleep: 0.0
-    tooltip: Delete the object which holds the script.
+    tooltip: Deletes the entire object containing the script (the object does not go
+      to inventory). Use llBreakLink first to delete only a single prim.
     categories:
       - rez
   llDumpList2String:
     arguments:
-    - Source:
-        tooltip: ''
-        type: list
-    - Separator:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The source list to convert.
+          type: list
+      - separator:
+          tooltip: The separator string to place between list entries.
+          type: string
     energy: 10.0
     func-id: 245
     native: true
-    must-use: true  # not pure, because the C++ impl looks at the running script type, which requires context
+    must-use: true # not pure, because the C++ impl looks at the running script type, which requires context
     return: string
     sleep: 0.0
-    tooltip: Returns the list as a single string, using Separator between the entries.\nWrite
-      the list out as a single string, using Separator between values.
+    tooltip: Returns a string that is the list src converted to a single string,
+      with separator placed between each entry.
     categories:
       - data_conversion
   llEdgeOfWorld:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
-    - Direction:
-        tooltip: ''
-        type: vector
+      - pos:
+          tooltip: The position vector in region coordinates.
+          type: vector
+      - dir:
+          tooltip: The direction vector.
+          type: vector
     energy: 10.0
     func-id: 205
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Checks to see whether the border hit by Direction from Position is the
-      edge of the world (has no neighboring region).\nReturns TRUE if the line along
-      Direction from Position hits the edge of the world in the current simulator,
-      returns FALSE if that edge crosses into another simulator.
+    tooltip: Checks if the border reached along the vector dir from the vector pos
+      is the edge of the world (i.e., has no neighboring simulator). Returns
+      TRUE if it hits the edge of the world, or FALSE if there is a neighboring
+      simulator.
     categories:
       - region
   llEjectFromLand:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 213
     return: void
     sleep: 0.0
-    tooltip: Ejects AvatarID from land that you own.\nEjects AvatarID from land that
-      the object owner (group or resident) owns.
+    tooltip: Ejects the specified avatar from land/parcels owned by the object's
+      owner (group or resident).
     categories:
       - land_moderation
       - parcel
   llEmail:
     arguments:
-    - Address:
-        tooltip: ''
-        type: string
-    - Subject:
-        tooltip: ''
-        type: string
-    - Text:
-        tooltip: ''
-        type: string
+      - address:
+          tooltip: The destination email address.
+          type: string
+      - subject:
+          tooltip: The subject of the email.
+          type: string
+      - message:
+          tooltip: The message body of the email.
+          type: string
     energy: 10.0
     func-id: 119
     return: void
     sleep: 20.0
-    tooltip: Sends email to Address with Subject and Message.\nSends an email to Address
-      with Subject and Message.
+    tooltip: Sends an email to address with subject and message.
     categories:
       - avatar_communication
   llEscapeURL:
     arguments:
-    - URL:
-        tooltip: ''
-        type: string
+      - url:
+          tooltip: The unescaped URL string to escape.
+          type: string
     energy: 10.0
     func-id: 307
     pure: true
     return: string
     sleep: 0.0
-    tooltip: "Returns an escaped/encoded version of url, replacing spaces with %20\
-      \ etc.\\nReturns the string that is the URL-escaped version of URL (replacing\
-      \ spaces with %20, etc.).\\n\n                This function returns the UTF-8\
-      \ encoded escape codes for selected characters."
+    tooltip: Returns a string representing the escaped/encoded version of url,
+      replacing spaces with '%20' and non-alphanumeric characters with their
+      '%xx' hexadecimal UTF-8 equivalent.
     categories:
       - web
   llEuler2Rot:
     arguments:
-    - Vector:
-        tooltip: ''
-        type: vector
+      - v:
+          tooltip: The vector of Euler angles to convert.
+          type: vector
     energy: 10.0
     func-id: 16
     pure: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation representation of the Euler angles.\nReturns the
-      rotation represented by the Euler Angle.
+    tooltip: Returns the rotation representation of the Euler angles vector v.
     categories:
       - math
       - math_3d
       - quaternion
   llEvade:
     arguments:
-    - TargetID:
-        tooltip: Agent or object to evade.
-        type: key
-    - Options:
-        tooltip: No options yet.
-        type: list
+      - target:
+          tooltip: The UUID of the group, avatar, or object to evade.
+          type: key
+      - options:
+          tooltip: No options currently available (should be empty list).
+          type: list
     energy: 10.0
     func-id: 407
     return: void
     sleep: 0.0
-    tooltip: Evade a specified target.\nCharacters will (roughly) try to hide from
-      their pursuers if there is a good hiding spot along their fleeing path. Hiding
-      means no direct line of sight from the head of the character (centre of the
-      top of its physics bounding box) to the head of its pursuer and no direct path
-      between the two on the navigation-mesh.
+    tooltip: Directs a pathfinding character to evade target, attempting to hide
+      from its pursuer if a hiding spot is available (i.e., no line of sight
+      from the character's head to the pursuer's head, and no direct path on the
+      navmesh).
     categories:
       - pathfinding
   llExecCharacterCmd:
     arguments:
-    - Command:
-        tooltip: Command to send.
-        type: integer
-    - Options:
-        tooltip: Height for CHARACTER_CMD_JUMP.
-        type: list
+      - command:
+          tooltip: The pathfinding command to execute.
+          type: integer
+      - options:
+          tooltip: A list of options for the command (e.g., jump height for
+            CHARACTER_CMD_JUMP).
+          type: list
     energy: 10.0
     func-id: 404
     return: void
     sleep: 0.0
-    tooltip: Execute a character command.\nSend a command to the path system.\nCurrently
-      only supports stopping the current path-finding operation or causing the character
-      to jump.
+    tooltip: Sends a command (specified by command) to the pathing system with
+      options. Currently only supports stopping pathfinding or making the
+      character jump.
     categories:
       - pathfinding
   llFabs:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The float value to convert.
+          type: float
     slua-deprecated:
       use: math.abs
       reason: Double precision; fastcall.
@@ -7797,56 +8433,55 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the positive version of Value.\nReturns the absolute value of
-      Value.
+    tooltip: Returns a float representing the absolute (positive) value of val.
     categories:
       - math
   llFindNotecardTextCount:
     arguments:
-    - NotecardName:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Pattern:
-        tooltip: Regex pattern to find in the notecard text.
-        type: string
-    - Options:
-        tooltip: A list of options to control the search. Included for future expansion,
-          should be []
-        type: list
+      - notecardname:
+          tooltip: ''
+          type: string
+          asset-semantics: true
+      - pattern:
+          tooltip: Regex pattern to find in the notecard text.
+          type: string
+      - options:
+          tooltip: A list of options to control the search. Included for future expansion,
+            should be []
+          type: list
     energy: 10.0
     func-id: 507
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: "Searches the text of a cached notecard for lines containing the given\
-      \ pattern and returns the \n            number of matches found through a dataserver\
-      \ event.\n            "
+    tooltip: Searches the text of a cached notecard for lines containing the given
+      pattern and returns the number of matches found through a dataserver
+      event.
     categories:
       - data_storage
       - dataserver
       - notecard
   llFindNotecardTextSync:
     arguments:
-    - NotecardName:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Pattern:
-        tooltip: Regex pattern to find in the notecard text.
-        type: string
-    - StartMatch:
-        tooltip: Index of the first match to return.
-        type: integer
-        index-semantics: true
-    - Count:
-        tooltip: The maximum number of matches to return. If 0 this function will
-          return the first 64 matches found.
-        type: integer
-    - Options:
-        tooltip: A list of options to control the search. Included for future expansion,
-          should be []
-        type: list
+      - name:
+          tooltip: The name of a notecard in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - pattern:
+          tooltip: The regular expression pattern to search for.
+          type: string
+      - start:
+          tooltip: The number of match results to skip before returning (0 to start at the
+            first match).
+          type: integer
+          index-semantics: true
+      - count:
+          tooltip: The maximum number of matches to return (if 0, returns the first 64
+            matches).
+          type: integer
+      - options:
+          tooltip: A list of options for future expansion (unused, should be []).
+          type: list
     energy: 10.0
     func-id: 508
     must-use: true
@@ -7854,38 +8489,37 @@ functions:
     # There are list indices in the return value!
     index-semantics: true
     sleep: 0.0
-    tooltip: "Searches the text of a cached notecard for lines containing the given\
-      \ pattern. \n            Returns a list of line numbers and column where a match\
-      \ is found. If the notecard is not in\n            the cache it returns a list\
-      \ containing a single entry of NAK. If no matches are found an\n           \
-      \ empty list is returned."
+    tooltip: Synchronously searches a cached notecard name for lines containing
+      pattern, returning a list of line and column numbers. Returns a list
+      containing 'NAK' if the notecard is not cached, or an empty list if no
+      matches are found.
     categories:
       - data_storage
       - notecard
   llFleeFrom:
     arguments:
-    - Source:
-        tooltip: Global coordinate from which to flee.
-        type: vector
-    - Distance:
-        tooltip: Distance in meters to flee from the source.
-        type: float
-    - Options:
-        tooltip: No options available at this time.
-        type: list
+      - position:
+          tooltip: The position vector in region coordinates from which to flee.
+          type: vector
+      - distance:
+          tooltip: The distance in meters to keep from the position.
+          type: float
+      - options:
+          tooltip: No options currently available (should be empty list).
+          type: list
     energy: 10.0
     func-id: 402
     return: void
     sleep: 0.0
-    tooltip: Flee from a point.\nDirects a character (llCreateCharacter) to keep away
-      from a defined position in the region or adjacent regions.
+    tooltip: Directs a pathfinding character to keep the specified distance from the
+      target position vector (within the region or adjacent regions).
     categories:
       - pathfinding
   llFloor:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The float value to round.
+          type: float
     slua-deprecated:
       use: math.floor
       reason: Fastcall.
@@ -7896,43 +8530,41 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns largest integer value <= Value.
+    tooltip: Returns the largest integer value less than or equal to val (rounded
+      toward negative infinity).
     categories:
       - math
   llForceMouselook:
     arguments:
-    - Enable:
-        tooltip: Boolean, if TRUE when an avatar sits on the prim, the avatar will
-          be forced into mouse-look mode.\nFALSE is the default setting and will undo
-          a previously set TRUE or do nothing.
-        type: integer
-        bool-semantics: true
+      - mouselook:
+          tooltip: Boolean. If TRUE, forces a sitting avatar into mouselook; if FALSE,
+            allows them to keep their current camera mode.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 294
     return: void
     sleep: 0.0
-    tooltip: If Enable is TRUE any avatar that sits on this object is forced into
-      mouse-look mode.\nAfter calling this function with Enable set to TRUE, any agent
-      sitting down on the prim will be forced into mouse-look.\nJust like llSitTarget,
-      this changes a permanent property of the prim (not the object) and needs to
-      be reset by calling this function with Enable set to FALSE in order to disable
-      it.
+    tooltip: Sets whether any avatar sitting on this prim is forced into mouselook
+      mode. Setting mouselook to TRUE forces the mode; FALSE (default) allows
+      the avatar to keep their current camera mode.
     categories:
       - avatar
       - camera
       - permissions
   llFrand:
     arguments:
-    - Magnitude:
-        tooltip: ''
-        type: float
+      - mag:
+          tooltip: The float magnitude of the random range.
+          type: float
     energy: 10.0
     func-id: 8
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns a pseudo random number in the range [0, Magnitude] or [Magnitude,
-      0].\nReturns a pseudo-random number between [0, Magnitude].
+    tooltip: Returns a pseudo-random float in the range [0.0, mag) or (mag, 0.0]
+      depending on the sign of mag. The value is inclusive of 0.0 but exclusive
+      of mag.
     categories:
       - math
   llGenerateKey:
@@ -7942,11 +8574,10 @@ functions:
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Generates a key (SHA-1 hash) using UUID generation to create a unique
-      key.\nAs the UUID produced is versioned, it should never return a value of NULL_KEY.\nThe
-      specific UUID version is an implementation detail that has changed in the past
-      and may change again in the future. Do not depend upon the UUID that is returned
-      to be version 5 SHA-1 hash.
+    tooltip: Generates and returns a unique versioned UUID key (utilizing SHA-1
+      hashing). Due to being versioned, it will not return NULL_KEY; however,
+      the exact UUID version is an implementation detail that should not be
+      relied upon.
     categories:
       - uuid
   llGetAccel:
@@ -7956,91 +8587,87 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the acceleration of the object relative to the region's axes.\nGets
-      the acceleration of the object.
+    tooltip: Returns a vector representing the acceleration of the object in the
+      region's frame of reference.
     categories:
       - physics
   llGetAgentInfo:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 206
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: "Returns an integer bit-field containing the agent information about\
-      \ id.\\n\n                    Returns AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SCRIPTED,\
-      \ AGENT_SITTING, AGENT_ON_OBJECT, AGENT_MOUSELOOK, AGENT_AWAY, AGENT_BUSY, AGENT_TYPING,\
-      \ AGENT_CROUCHING, AGENT_ALWAYS_RUN, AGENT_WALKING, AGENT_IN_AIR and/or AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT.\\\
-      nReturns information about the given agent ID as a bit-field of agent info constants."
+    tooltip: Returns an integer bitfield containing status information about the
+      agent specified by id (such as AGENT_FLYING, AGENT_ATTACHMENTS,
+      AGENT_SITTING, etc.).
     categories:
       - avatar
   llGetAgentLanguage:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 336
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the language code of the preferred interface language of the
-      avatar.\nReturns a string that is the language code of the preferred interface
-      language of the resident.
+    tooltip: Returns a string representing the language code of the preferred
+      interface language set by the avatar.
     categories:
       - avatar
   llGetAgentList:
     arguments:
-    - Scope:
-        tooltip: The scope (region, parcel, parcel same owner) to return agents for.
-        type: integer
-    - Options:
-        tooltip: List of options to apply. Current unused.
-        type: list
+      - scope:
+          tooltip: The integer scope (region, parcel, or same-owner parcels) to limit the
+            returned agents.
+          type: integer
+      - options:
+          tooltip: A list of options to apply (currently unused).
+          type: list
     energy: 10.0
     func-id: 412
     must-use: true
     return: list
     slua-return: "{uuid}"
     sleep: 0.0
-    tooltip: Requests a list of agents currently in the region, limited by the scope
-      parameter.\nReturns a list [key UUID-0, key UUID-1, ..., key UUID-n] or [string
-      error_msg] - returns avatar keys for all agents in the region limited to the
-      area(s) specified by scope
+    tooltip: Requests a list of avatar UUID keys for agents currently in the region,
+      limited by scope. Returns a list of keys or a list containing an error
+      message string.
     categories:
       - avatar
       - parcel
       - region
   llGetAgentSize:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 218
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: If the avatar is in the same region, returns the size of the bounding
-      box of the requested avatar by id, otherwise returns ZERO_VECTOR.\nIf the agent
-      is in the same region as the object, returns the size of the avatar.
+    tooltip: Returns a vector representing the estimated bounding box size of the
+      specified avatar, or ZERO_VECTOR if they are not in the same region.
     categories:
       - avatar
   llGetAlpha:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 50
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the alpha value of Face.\nReturns the 'alpha' of the given face.
-      If face is ALL_SIDES the value returned is the mean average of all faces.
+    tooltip: Returns a float representing the Blinn-Phong alpha (transparency) of
+      face. If face is ALL_SIDES, returns the mean average of all faces.
     categories:
       - prim
       - prim_appearance
@@ -8051,49 +8678,48 @@ functions:
     return: float
     slua-removed: true
     sleep: 0.0
-    tooltip: Returns the script time in seconds and then resets the script timer to
-      zero.\nGets the time in seconds since starting and resets the time to zero.
+    tooltip: Returns the elapsed script time in seconds as a float, then resets the
+      script timer to zero.
     categories:
       - script
   llGetAnimation:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 162
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the name of the currently playing locomotion animation for the
-      avatar id.\nReturns the currently playing animation for the specified avatar
-      ID.
+    tooltip: Returns a string representing the name of the currently playing
+      locomotion animation for the avatar specified by id.
     categories:
       - avatar
       - avatar_animation
       - permissions
   llGetAnimationList:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 266
     must-use: true
     return: list
     slua-return: "{uuid}"
     sleep: 0.0
-    tooltip: Returns a list of keys of playing animations for an avatar.\nReturns
-      a list of keys of all playing animations for the specified avatar ID.
+    tooltip: Returns a list of keys (UUIDs) representing all active animations
+      currently playing on the specified avatar.
     categories:
       - avatar
       - avatar_animation
       - permissions
   llGetAnimationOverride:
     arguments:
-    - AnimationState:
-        tooltip: ''
-        type: string
+      - anim_state:
+          tooltip: The animation state string to query.
+          type: string
     energy: 10.0
     func-id: 500
     must-use: true
@@ -8102,9 +8728,10 @@ functions:
     requires-permission:
       - PERMISSION_OVERRIDE_ANIMATIONS
       - PERMISSION_TRIGGER_ANIMATION
-    tooltip: Returns a string that is the name of the animation that is used for the
-      specified animation state.\nRequires the PERMISSION_OVERRIDE_ANIMATIONS or
-      PERMISSION_TRIGGER_ANIMATION runtime permission (automatically granted to attached objects).
+    tooltip: Returns a string representing the name of the animation currently
+      overriding the specified anim_state. Requires the
+      PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION runtime
+      permission.
     categories:
       - avatar
       - avatar_animation
@@ -8116,57 +8743,61 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the object's attachment point, or 0 if not attached.
+    tooltip: Returns the integer attachment point (an ATTACH_* constant) that the
+      object is attached to, or 0 if it is unattached or pending detachment.
     categories:
       - attachments
   llGetAttachedList:
     arguments:
-    - ID:
-        tooltip: Avatar to get attachments
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     energy: 10.0
     func-id: 523
     must-use: true
     return: list
     slua-return: '{uuid} | {string}'
     sleep: 0.0
-    tooltip: Returns a list of keys of all visible (not HUD) attachments on the avatar
-      identified by the ID argument, or a list containing 1 string on error.
+    tooltip: Returns a list of object keys (UUIDs) corresponding to public, visible
+      (non-HUD) attachments worn by the specified avatar, in the order they were
+      attached. Returns a list with an error message string on failure.
     categories:
       - attachments
       - avatar
   llGetAttachedListFiltered:
     arguments:
-    - AgentID:
-        tooltip: An agent in the region.
-        type: key
-    - Options:
-        tooltip: A list of option for inventory transfer.
-        type: list
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
+      - options:
+          tooltip: A list of options to filter the returned attachments.
+          type: list
     energy: 10.0
     func-id: 518
     must-use: true
     return: list
     slua-return: '{uuid} | {string}'
     sleep: 0.0
-    tooltip: Retrieves a list of attachments on an avatar, or a list containing 1 string on error.
+    tooltip: Retrieves a list of attachment object keys worn by avatar in the order
+      they were attached, filtered by options. Returns a list containing an
+      error message string on failure.
     categories:
       - attachments
       - avatar
   llGetBoundingBox:
     arguments:
-    - ID:
-        tooltip: ''
-        type: key
+      - object:
+          tooltip: The UUID of the avatar or prim in the same region.
+          type: key
     energy: 10.0
     func-id: 277
     must-use: true
     return: list
     slua-return: '{vector}'
     sleep: 0.0
-    tooltip: Returns the bounding box around the object (including any linked prims)
-      relative to its root prim, as a list in the format [ (vector) min_corner, (vector)
-      max_corner ].
+    tooltip: Returns the bounding box of object (including any linked prims)
+      relative to its root prim in local coordinates, formatted as [ (vector)
+      min_corner, (vector) max_corner ].
     categories:
       - object
   llGetCameraAspect:
@@ -8178,9 +8809,9 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRACK_CAMERA
-    tooltip: 'Returns the current camera aspect ratio (width / height) of the agent
-      who has granted the scripted object PERMISSION_TRACK_CAMERA permissions. If
-      no permissions have been granted: it returns zero.'
+    tooltip: Returns a float representing the camera's current aspect ratio
+      (width/height) of the agent who granted PERMISSION_TRACK_CAMERA. Returns
+      0.0 if permissions are not granted.
     categories:
       - avatar
       - camera
@@ -8194,9 +8825,9 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRACK_CAMERA
-    tooltip: 'Returns the current camera field of view of the agent who has granted
-      the scripted object PERMISSION_TRACK_CAMERA permissions. If no permissions have
-      been granted: it returns zero.'
+    tooltip: Returns a float representing the camera's current field of view (FOV)
+      in radians of the agent who granted PERMISSION_TRACK_CAMERA. Returns 0.0
+      if permissions are not granted.
     categories:
       - avatar
       - camera
@@ -8210,9 +8841,9 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRACK_CAMERA
-    tooltip: Returns the current camera position for the agent the task has permissions
-      for.\nReturns the position of the camera, of the user that granted the script
-      PERMISSION_TRACK_CAMERA. If no user has granted the permission, it returns ZERO_VECTOR.
+    tooltip: Returns a vector representing the camera's current position in region
+      coordinates of the agent who granted PERMISSION_TRACK_CAMERA. Returns
+      ZERO_VECTOR if permissions are not granted.
     categories:
       - avatar
       - camera
@@ -8226,9 +8857,9 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRACK_CAMERA
-    tooltip: Returns the current camera orientation for the agent the task has permissions
-      for. If no user has granted the PERMISSION_TRACK_CAMERA permission, returns
-      ZERO_ROTATION.
+    tooltip: Returns a rotation representing the camera's current orientation of the
+      agent who granted PERMISSION_TRACK_CAMERA. Returns ZERO_ROTATION if
+      permissions are not granted.
     categories:
       - avatar
       - camera
@@ -8240,44 +8871,43 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the prim's centre of mass (unless called from the root prim,
-      where it returns the object's centre of mass).
+    tooltip: Returns the vector position (in region coordinates) of the center of
+      mass. Returns the individual child prim's center of mass if called from a
+      child, or the entire linkset's center of mass if called from the root.
     categories:
       - object
       - physics
   llGetClosestNavPoint:
     arguments:
-    - Point:
-        tooltip: A point in region-local space.
-        type: vector
-    - Options:
-        tooltip: No options at this time.
-        type: list
+      - point:
+          tooltip: The position vector in region-local coordinates.
+          type: vector
+      - options:
+          tooltip: A list of GCNP_* flags and parameters to configure the search limits.
+          type: list
     energy: 10.0
     func-id: 408
     must-use: true
     return: list
     slua-return: "{vector}"
     sleep: 0.0
-    tooltip: Get the closest navigable point to the point provided.\nThe function
-      accepts a point in region-local space (like all the other path-finding methods)
-      and returns either an empty list or a list containing a single vector which
-      is the closest point on the navigation-mesh to the point provided.
+    tooltip: Returns a list containing the closest vector position on the navigation
+      mesh (navmesh) to the specified point (expressed in region-local space),
+      or an empty list if none is found. Configured using options.
     categories:
       - pathfinding
   llGetColor:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 52
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the color on Face.\nReturns the color of Face as a vector of
-      red, green, and blue values between 0 and 1. If face is ALL_SIDES the color
-      returned is the mean average of each channel.
+    tooltip: Returns the Blinn-Phong RGB color vector of face (values between 0.0
+      and 1.0). If face is ALL_SIDES, returns the mean average of all faces.
     categories:
       - prim
       - prim_appearance
@@ -8288,8 +8918,7 @@ functions:
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns a key for the creator of the prim.\nReturns the key of the object's
-      original creator. Similar to llGetOwner.
+    tooltip: Returns the key (UUID) of the prim's original creator.
     categories:
       - prim
   llGetDate:
@@ -8299,8 +8928,8 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the current date in the UTC time zone in the format YYYY-MM-DD.\nReturns
-      the current UTC date as YYYY-MM-DD. Equivilant to os.date("%Y-%m-%d") in lua.
+    tooltip: Returns a string representing the current date in the UTC time zone in
+      the format 'YYYY-MM-DD'.
     categories:
       - time
   llGetDayLength:
@@ -8310,7 +8939,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of seconds in a day on this parcel.
+    tooltip: Returns an integer representing the number of seconds in the
+      environmental day cycle applied to the current parcel.
     categories:
       - time
   llGetDayOffset:
@@ -8320,24 +8950,24 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of seconds in a day is offset from midnight in this
-      parcel.
+    tooltip: Returns an integer representing the offset duration (in seconds) added
+      to calculate the current environmental time on this parcel.
     categories:
       - time
   llGetDisplayName:
     arguments:
-    - AvatarID:
-        tooltip: Avatar UUID that is in the same region, or is otherwise known to
-          the region.
-        type: key
+      - id:
+          tooltip: The UUID of the avatar in the same region or otherwise known to the
+            region.
+          type: key
     energy: 10.0
     func-id: 360
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the display name of an avatar, if the avatar is connected to
-      the current region, or if the name has been cached.  Otherwise, returns an empty
-      string. Use llRequestDisplayName if the avatar may be absent from the region.
+    tooltip: Returns the display name string of the avatar specified by id if they
+      are in the region or cached; returns an empty string otherwise (use
+      llRequestDisplayName if the avatar is absent).
     categories:
       - avatar
   llGetEnergy:
@@ -8347,32 +8977,34 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns how much energy is in the object as a percentage of maximum.
+    tooltip: Returns a float representing the remaining physics energy of the object
+      as a percentage (0.0 to 1.0) of its maximum capacity.
     categories:
       - script
   llGetEnv:
     arguments:
-    - DataRequest:
-        tooltip: The type of data to request. Any other string will cause an empty
-          string to be returned.
-        type: string
+      - name:
+          tooltip: The name of the regional data to request (unrecognized strings return
+            an empty string).
+          type: string
     energy: 10.0
     func-id: 362
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string with the requested data about the region.
+    tooltip: Returns a string containing the requested regional data specified by name.
     categories:
       - region
   llGetEnvironment:
     arguments:
-    - Position:
-        tooltip: Location within the region.
-        type: vector
-    - EnvParams:
-        tooltip: List of environment settings requested for the specified parcel location.
-        type: list
-        slua-type: "{number}"
+      - pos:
+          tooltip: The position vector in region coordinates (X/Y determine the parcel, or
+            region if X/Y are -1; Z determines the sky track altitude).
+          type: vector
+      - params:
+          tooltip: A list of environmental attributes to retrieve.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 711
     must-use: true
@@ -8380,49 +9012,48 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns a string with the requested data about the region.
+    tooltip: Returns a list containing the current environment parameters for the
+      parcel or region at pos, retrieved in the order specified by params.
     categories:
       - parcel
       - parcel_appearance
   llGetExperienceDetails:
     arguments:
-    - ExperienceID:
-        tooltip: May be NULL_KEY to retrieve the details for the script's Experience
-        type: key
+      - experience_id:
+          tooltip: The UUID of the experience to query (can be NULL_KEY to retrieve
+            details for the script's own experience).
+          type: key
     energy: 10.0
     experience: true
     func-id: 409
     must-use: true
     return: list
     sleep: 0.0
-    tooltip: "\n                   Returns a list with the following Experience properties:\
-      \ [Experience Name, Owner ID, Group ID, Experience ID, State, State Message].\
-      \ State is an integer corresponding to one of the constants XP_ERROR_... and\
-      \ State Message is the string returned by llGetExperienceErrorMessage for that\
-      \ integer.\n                "
+    tooltip: Returns a list of details for the specified experience_id, formatted as
+      [string experience_name, key owner_id, key experience_id, integer state,
+      string state_message, key group_id].
     categories:
       - experience
   llGetExperienceErrorMessage:
     arguments:
-    - Error:
-        tooltip: An Experience error code to translate.
-        type: integer
+      - error:
+          tooltip: The XP_ERROR_* error code constant to translate.
+          type: integer
     energy: 10.0
     experience: true
     func-id: 603
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: "\n                   Returns a string describing the error code passed\
-      \ or the string corresponding with XP_ERROR_UNKNOWN_ERROR if the value is not\
-      \ a valid Experience error code.\n                "
+    tooltip: Returns a text description of the specified experience error code, or a
+      description of XP_ERROR_UNKNOWN_ERROR if the error is invalid.
     categories:
       - experience
   llGetExperienceList:
     arguments:
-    - AgentID:
-        tooltip: ''
-        type: key
+      - agentid:
+          tooltip: ''
+          type: key
     deprecated: true
     energy: 10.0
     func-id: 410
@@ -8431,7 +9062,7 @@ functions:
     return: list
     slua-return: '{uuid}'
     sleep: 0.0
-    tooltip: ''
+    tooltip: ""
     categories:
       - experience
   llGetForce:
@@ -8441,8 +9072,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the force (if the script is physical).\nReturns the current force
-      if the script is physical.
+    tooltip: Returns a vector representing the constant force currently applied to
+      the object (if the object is physical).
     categories:
       - physics
   llGetFreeMemory:
@@ -8452,8 +9083,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of free bytes of memory the script can use.\nReturns
-      the available free space for the current script. This is inaccurate with LSO.
+    tooltip: Returns an integer representing the number of free bytes of memory
+      currently available to the script.
     categories:
       - script
   llGetFreeURLs:
@@ -8463,8 +9094,9 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of available URLs for the current script.\nReturns
-      an integer that is the number of available URLs.
+    tooltip: Returns an integer representing the number of available HTTP URLs
+      (remaining for the owner if the object is attached, or for the region if
+      unattached).
     categories:
       - script
       - web
@@ -8475,8 +9107,8 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the time in seconds since midnight GMT.\nGets the time in seconds
-      since midnight in GMT/UTC.
+    tooltip: Returns a float representing the time in seconds since midnight GMT
+      (truncated to whole seconds).
     categories:
       - time
   llGetGeometricCenter:
@@ -8486,161 +9118,157 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the vector that is the geometric center of the object relative
-      to the root prim.
+    tooltip: Returns a vector representing the geometric center of the object
+      relative to its root prim.
     categories:
       - physics
   llGetHTTPHeader:
     arguments:
-    - HTTPRequestID:
-        tooltip: A valid HTTP request key
-        type: key
-    - Header:
-        tooltip: Header value name
-        type: string
+      - request_id:
+          tooltip: The unique key of the HTTP request.
+          type: key
+      - header:
+          tooltip: The lowercase name of the HTTP header to retrieve.
+          type: string
     energy: 10.0
     func-id: 349
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the value for header for request_id.\nReturns a string that is
-      the value of the Header for HTTPRequestID.
+    tooltip: Returns a string representing the value of the specified header
+      associated with the HTTP request_id.
     categories:
       - web
   llGetHealth:
     arguments:
-    - ID:
-        tooltip: The ID of an agent or object in the region.
-        type: key
+      - id:
+          tooltip: The UUID of the agent or object to query.
+          type: key
     energy: 10.0
     func-id: 552
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the current health of an avatar or object in the region.
+    tooltip: Returns a float representing the current health of the avatar or object
+      specified by id.
     categories:
       - combat
   llGetInventoryAcquireTime:
     arguments:
-    - InventoryItem:
-        tooltip: Name of item in prim inventory.
-        type: string
+      - item:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 529
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the time at which the item was placed into this prim's inventory
-      as a timestamp.
+    tooltip: Returns a string containing the UTC timestamp (YYYY-MM-DDThh:mm:ssZ)
+      representing when the inventory item was placed inside the prim.
     categories:
       - prim_inventory
   llGetInventoryCreator:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - item:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 291
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns a key for the creator of the inventory item.\nThis function returns
-      the UUID of the creator of item. If item is not found in inventory, the object
-      says "No item named 'name'".
+    tooltip: Returns the key (UUID) of the creator of the specified inventory item.
     categories:
       - prim_inventory
   llGetInventoryDesc:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - item:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 543
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the item description of the item in inventory. If item is not
-      found in inventory, the object says "No item named 'name'" to the debug channel
-      and returns an empty string.
+    tooltip: Returns a string containing the description of the specified inventory
+      item.
     categories:
       - prim_inventory
   llGetInventoryKey:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - name:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 175
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the key that is the UUID of the inventory named.\nReturns the
-      key of the inventory named.
+    tooltip: Returns the key (UUID) of the specified inventory name.
     categories:
       - prim_inventory
   llGetInventoryName:
     arguments:
-    - InventoryType:
-        tooltip: Inventory item type
-        type: integer
-    - Index:
-        tooltip: Index number of inventory item.
-        type: integer
-        index-semantics: true
+      - type:
+          tooltip: The INVENTORY_* type constant of the item.
+          type: integer
+      - number:
+          tooltip: The index number of the item of that type, starting from 0.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 147
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the name of the inventory item of a given type, specified by
-      index number.\nUse the inventory constants INVENTORY_* to specify the type.
+    tooltip: Returns the name of the inventory item of the specified type
+      (INVENTORY_*) at the index number.
     categories:
       - prim_inventory
   llGetInventoryNumber:
     arguments:
-    - InventoryType:
-        tooltip: Inventory item type
-        type: integer
+      - type:
+          tooltip: The INVENTORY_* type constant to count.
+          type: integer
     energy: 10.0
     func-id: 146
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the quantity of items of a given type (INVENTORY_* flag) in the
-      prim's inventory.\nUse the inventory constants INVENTORY_* to specify the type.
+    tooltip: Returns an integer representing the quantity of items of the specified
+      type (INVENTORY_*) in the prim's inventory.
     categories:
       - prim_inventory
   llGetInventoryPermMask:
     arguments:
-    - InventoryItem:
-        tooltip: Inventory item name.
-        type: string
-    - BitMask:
-        tooltip: MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE or MASK_NEXT
-        type: integer
+      - item:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
+      - category:
+          tooltip: The MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, MASK_GROUP,
+            MASK_EVERYONE, or MASK_NEXT).
+          type: integer
     energy: 10.0
     func-id: 289
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the requested permission mask for the inventory item.\nReturns
-      the requested permission mask for the inventory item defined by InventoryItem.
-      If item is not in the object's inventory, llGetInventoryPermMask returns FALSE
-      and causes the object to say "No item named '<item>'", where "<item>" is item.
+    tooltip: Returns an integer bitfield representing the permission category mask
+      of the specified inventory item.
     categories:
       - prim_inventory
   llGetInventoryType:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - name:
+          tooltip: The name of the inventory item.
+          type: string
     energy: 10.0
     func-id: 301
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the type of the named inventory item.\nLike all inventory functions,
-      llGetInventoryType is case-sensitive.
+    tooltip: Returns an integer representing the INVENTORY_* type of the named
+      inventory item.
     categories:
       - prim_inventory
   llGetKey:
@@ -8650,53 +9278,50 @@ functions:
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the key of the prim the script is attached to.\nGet the key for
-      the object which has this script.
+    tooltip: Returns the key (UUID) of the prim containing the script.
     categories:
       - prim
       - uuid
   llGetLandOwnerAt:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
+      - pos:
+          tooltip: The position vector in region coordinates.
+          type: vector
     energy: 10.0
     func-id: 216
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the key of the land owner, returns NULL_KEY if public.\nReturns
-      the key of the land owner at Position, or NULL_KEY if public.
+    tooltip: Returns the key (UUID) of the land owner at the vector pos, or NULL_KEY
+      if the land is public.
     categories:
       - parcel
   llGetLinkKey:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
     energy: 10.0
     func-id: 144
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the key of the linked prim LinkNumber.\nReturns the key of LinkNumber
-      in the link set.
+    tooltip: Returns the key (UUID) of the linked prim or avatar specified by link.
     categories:
       - linkset
       - uuid
   llGetLinkMedia:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - Face:
-        tooltip: The prim's side number
-        type: integer
-    - Parameters:
-        tooltip: A list of PRIM_MEDIA_* property constants to return values of.
-        type: list
-        slua-type: "{number}"
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - face:
+          tooltip: The face number (side) of the prim.
+          type: integer
+      - params:
+          tooltip: A list of PRIM_MEDIA_* property constants to retrieve values for.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 372
     must-use: true
@@ -8704,25 +9329,23 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 0.0
-    tooltip: "Get the media parameters for a particular face on linked prim, given\
-      \ the desired list of parameter names. Returns a list of values in the order\
-      \ requested.\tReturns an empty list if no media exists on the face."
+    tooltip: Returns a list containing the media parameters of the specified face on
+      the linked prim link, retrieved in the order requested by params.
     categories:
       - linkset
       - media
       - prim_media
   llGetLinkName:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
     energy: 10.0
     func-id: 145
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the name of LinkNumber in a link set.\nReturns the name of LinkNumber
-      the link set.
+    tooltip: Returns a string containing the name of the linked prim specified by link.
     categories:
       - linkset
   llGetLinkNumber:
@@ -8732,38 +9355,35 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the link number of the prim containing the script (0 means not
-      linked, 1 the prim is the root, 2 the prim is the first child, etc.).\nReturns
-      the link number of the prim containing the script. 0 means no link, 1 the root,
-      2 for first child, etc.
+    tooltip: Returns the integer link number of the prim containing the script (0
+      for unlinked, 1 for the root, and 2+ for children).
     categories:
       - prim
   llGetLinkNumberOfSides:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag.'
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
     energy: 10.0
     func-id: 357
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of sides of the specified linked prim.\nReturns an
-      integer that is the number of faces (or sides) of the prim link.
+    tooltip: Returns an integer representing the number of sides (faces) of the
+      linked prim specified by link.
     categories:
       - linkset
       - prim_appearance
   llGetLinkPrimitiveParams:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag.'
-        type: integer
-    - Parameters:
-        tooltip: PRIM_* flags.
-        type: list
-        slua-type: "{number}"
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag to
+            retrieve parameters from.
+          type: integer
+      - params:
+          tooltip: A list of PRIM_* flags specifying the attributes to retrieve.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 354
     must-use: true
@@ -8771,38 +9391,35 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns the list of primitive attributes requested in the Parameters
-      list for LinkNumber.\nPRIM_* flags can be broken into three categories, face
-      flags, prim flags, and object flags.\n* Supplying a prim or object flag will
-      return that flag's attributes.\n* Face flags require the user to also supply
-      a face index parameter.
+    tooltip: Returns a list of primitive parameters requested in params for the
+      linked prim specified by link (equivalent to llGetPrimitiveParams).
     categories:
       - linkset
       - prim_appearance
   llGetLinkSitFlags:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag.'
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
     energy: 10.0
     func-id: 551
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the sit flags set on the specified prim in a linkset.
+    tooltip: Returns an integer representing the active sit flags currently set on
+      the linked prim specified by link.
     categories:
       - linkset
       - sit
   llGetListEntryType:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: typeof
       selene-replace: ["typeof(%1[%2])"]
@@ -8812,16 +9429,15 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the type of the index entry in the list (TYPE_INTEGER, TYPE_FLOAT,
-      TYPE_STRING, TYPE_KEY, TYPE_VECTOR, TYPE_ROTATION, or TYPE_INVALID if index
-      is off list).\nReturns the type of the variable at Index in ListVariable.
+    tooltip: Returns an integer representing the variable type (TYPE_*) of the list
+      entry at index in the list src.
     categories:
       - list
   llGetListLength:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
+      - src:
+          tooltip: The list to measure.
+          type: list
     slua-deprecated:
       reason: "Use '#' or 'rawlen' instead. Metatable support."
       selene-replace: ["#%1", "rawlen(%1)"]
@@ -8831,8 +9447,8 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of elements in the list.\nReturns the number of elements
-      in ListVariable.
+    tooltip: Returns an integer representing the total number of elements in the
+      list src.
     categories:
       - list
   llGetLocalPos:
@@ -8842,8 +9458,9 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the position relative to the root.\nReturns the local position
-      of a child object relative to the root.
+    tooltip: Returns a position vector relative to the root prim. If called from the
+      root prim, it returns the global region position (or the position relative
+      to the attachment point if attached).
     categories:
       - prim
   llGetLocalRot:
@@ -8853,8 +9470,9 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation local to the root.\nReturns the local rotation of
-      a child object relative to the root.
+    tooltip: Returns a rotation representing the local orientation of a child prim
+      relative to the root prim, or the object's overall rotation if called from
+      the root.
     categories:
       - prim
   llGetMass:
@@ -8864,11 +9482,10 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the mass of object that the script is attached to.\nReturns the
-      scripted object's mass. When called from a script in a link-set, the parent
-      will return the sum of the link-set weights, while a child will return just
-      its own mass. When called from a script inside an attachment, this function
-      will return the mass of the avatar it's attached to, not its own.
+    tooltip: Returns a float representing the mass of the object (in lindograms).
+      Returns the total linkset mass if called from the root, or the individual
+      prim's mass if called from a child prim. Returns the wearer's mass if
+      inside an attachment.
     categories:
       - linkset
       - physics
@@ -8879,8 +9496,8 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Acts as llGetMass(), except that the units of the value returned are
-      Kg.
+    tooltip: Returns a float representing the mass of the object in kilograms.
+      Functionally identical to llGetMass except for using MKS (metric) units.
     categories:
       - linkset
       - physics
@@ -8891,9 +9508,9 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the largest multiplicative uniform scale factor that can be successfully
-      applied (via llScaleByFactor()) to the object without violating prim size or
-      linkability rules.
+    tooltip: Returns a float representing the maximum scale factor that can be
+      applied to the object via llScaleByFactor without violating size or
+      linkability limits.
     categories:
       - linkset
       - prim_appearance
@@ -8904,7 +9521,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Get the maximum memory a script can use, in bytes.
+    tooltip: Returns an integer representing the maximum memory limit (in bytes)
+      that the script is allowed to allocate.
     categories:
       - script
   llGetMinScaleFactor:
@@ -8914,9 +9532,8 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the smallest multiplicative uniform scale factor that can be
-      successfully applied (via llScaleByFactor()) to the object without violating
-      prim size or linkability rules.
+    tooltip: Returns a float representing the minimum scale factor that can be
+      applied to the object via llScaleByFactor without violating size limits.
     categories:
       - linkset
       - prim_appearance
@@ -8927,8 +9544,9 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns a normalized vector of the direction of the moon in the parcel.\nReturns
-      the moon's direction on the simulator in the parcel.
+    tooltip: Returns a normalized vector representing the current direction of the
+      parcel's moon, taking altitude into account. Falls back to the region's
+      moon direction if no custom parcel environment is set.
     categories:
       - parcel
       - parcel_appearance
@@ -8939,85 +9557,82 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation applied to the moon in the parcel.
+    tooltip: Returns a rotation representing the orientation applied to the moon on
+      the current parcel and altitude track. Falls back to the region's moon
+      rotation if no custom parcel environment is set.
     categories:
       - parcel
       - parcel_appearance
   llGetNextEmail:
     arguments:
-    - Address:
-        tooltip: ''
-        type: string
-    - Subject:
-        tooltip: ''
-        type: string
+      - address:
+          tooltip: The sender email address filter.
+          type: string
+      - subject:
+          tooltip: The email subject filter.
+          type: string
     energy: 10.0
     func-id: 120
     return: void
     sleep: 0.0
-    tooltip: Fetch the next queued email with that matches the given address and/or
-      subject, via the email event.\nIf the parameters are blank, they are not used
-      for filtering.
+    tooltip: Requests the next queued email matching the specified sender address
+      and subject filters via the email event.
     categories:
       - script_communication
   llGetNotecardLine:
     arguments:
-    - NotecardName:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - LineNumber:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - name:
+          tooltip: The name of the notecard in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - line:
+          tooltip: The zero-based line number to request.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 217
     return: key
     sleep: 0.1
-    tooltip: Returns LineNumber from NotecardName via the dataserver event. The line
-      index starts at zero in LSL, one in Lua.\nIf the requested line is passed the
-      end of the note-card the dataserver event will return the constant EOF string.\nThe
-      key returned by this function is a unique identifier which will be supplied
-      to the dataserver event in the requested parameter.
+    tooltip: Asynchronously requests the line index line of the notecard name from
+      the dataserver. Returns a key query handle for the dataserver event, which
+      will return 'EOF' when reaching past the end of the notecard.
     categories:
       - data_storage
       - dataserver
       - notecard
   llGetNotecardLineSync:
     arguments:
-    - NotecardName:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - LineNumber:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - name:
+          tooltip: The name of the notecard in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - line:
+          tooltip: The zero-based line number to request.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 549
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns LineNumber from NotecardName. The line index starts at zero in
-      LSL, one in Lua.\nIf the requested line is past the end of the note-card the
-      return value will be set to the constant EOF string.\nIf the note-card is not
-      cached on the simulator the return value is the NAK string.
+    tooltip: Synchronously reads the line index line of the notecard name from the
+      region's cache, immediately returning its text without raising a
+      dataserver event. Returns 'NAK' if not cached or 'EOF' if out of bounds.
     categories:
       - data_storage
       - notecard
   llGetNumberOfNotecardLines:
     arguments:
-    - NotecardName:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - name:
+          tooltip: The name of the notecard in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
     energy: 10.0
     func-id: 276
     return: key
     sleep: 0.1
-    tooltip: Returns the number of lines contained within a notecard via the dataserver
-      event.\nThe key returned by this function is a query ID for identifying the
-      dataserver reply.
+    tooltip: Asynchronously requests the total line count of the notecard name.
+      Returns a key query handle for the dataserver event.
     categories:
       - data_storage
       - dataserver
@@ -9029,8 +9644,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of prims in a link set the script is attached to.\nReturns
-      the number of prims in (and avatars seated on) the object the script is in.
+    tooltip: Returns an integer representing the total number of prims and seated
+      avatars in the linkset containing the script.
     categories:
       - linkset
   llGetNumberOfSides:
@@ -9040,8 +9655,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of faces (or sides) of the prim.\nReturns the number
-      of sides of the prim which has the script.
+    tooltip: Returns an integer representing the total number of sides (faces) of
+      the prim containing the script.
     categories:
       - prim
       - prim_appearance
@@ -9054,8 +9669,8 @@ functions:
     slua-return: "{string}"
     asset-semantics: true
     sleep: 0.0
-    tooltip: Returns a list of names of playing animations for an object.\nReturns
-      a list of names of all playing animations for the current object.
+    tooltip: Returns a list of strings representing the names of all active
+      animations currently playing on the object.
     categories:
       - object_animation
   llGetObjectDesc:
@@ -9065,21 +9680,21 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the description of the prim the script is attached to.\nReturns
-      the description of the scripted object/prim. You can set the description using
-      llSetObjectDesc.
+    tooltip: Returns a string containing the description of the specific prim
+      containing the script.
     categories:
       - prim
       - prim_properties
   llGetObjectDetails:
     arguments:
-    - ID:
-        tooltip: Prim or avatar UUID that is in the same region.
-        type: key
-    - Parameters:
-        tooltip: List of OBJECT_* flags.
-        type: list
-        slua-type: "{number}"
+      - id:
+          tooltip: The UUID of the avatar or prim (in the same or adjacent regions) to
+            query.
+          type: key
+      - params:
+          tooltip: A list of OBJECT_* flags specifying the attributes to retrieve.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 332
     must-use: true
@@ -9087,42 +9702,41 @@ functions:
     sleep: 0.0
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
-    tooltip: Returns a list of object details specified in the Parameters list for
-      the object or avatar in the region with key ID.\nParameters are specified by
-      the OBJECT_* constants.
+    tooltip: Returns a list containing the requested parameters of the specified
+      avatar or object id, retrieved in the order requested by params.
     categories:
       - object
       - prim_properties
   llGetObjectLinkKey:
     arguments:
-    - id:
-        tooltip: UUID of prim
-        type: key
-    - link_no:
-        tooltip: Link number to retrieve
-        type: integer
+      - link:
+          tooltip: The UUID of the target prim or linkset.
+          type: key
+      - link_no:
+          tooltip: The link number (index) of the prim within the linkset to retrieve.
+          type: integer
     energy: 10.0
     func-id: 532
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the key of the linked prim link_no in a linkset.\nReturns the
-      key of link_no in the link set specified by id.
+    tooltip: Returns the key (UUID) of the child prim link_no within the target
+      linkset specified by link.
     categories:
       - object
       - uuid
   llGetObjectMass:
     arguments:
-    - ID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the avatar or object to query.
+          type: key
     energy: 10.0
     func-id: 295
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the mass of the avatar or object in the region.\nGets the mass
-      of the object or avatar corresponding to ID.
+    tooltip: Returns a float representing the mass of the avatar or object specified
+      by id.
     categories:
       - object
       - physics
@@ -9133,38 +9747,39 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the name of the prim which the script is attached to.\nReturns
-      the name of the prim (not object) which contains the script.
+    tooltip: Returns a string containing the name of the specific prim containing
+      the script.
     categories:
       - prim
       - prim_properties
   llGetObjectPermMask:
     arguments:
-    - Category:
-        tooltip: Category is one of MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE,
-          or MASK_NEXT
-        type: integer
+      - category:
+          tooltip: The MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, MASK_GROUP,
+            MASK_EVERYONE, or MASK_NEXT).
+          type: integer
     energy: 10.0
     func-id: 287
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the permission mask of the requested category for the object.
+    tooltip: Returns an integer bitfield representing the permission mask of the
+      specified category for the object containing the script.
     categories:
       - asset_permissions
       - linkset
   llGetObjectPrimCount:
     arguments:
-    - ObjectID:
-        tooltip: ''
-        type: key
+      - prim:
+          tooltip: The UUID of the prim in the same region.
+          type: key
     energy: 10.0
     func-id: 323
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the total number of prims for an object in the region.\nReturns
-      the prim count for any object id in the same region.
+    tooltip: Returns an integer representing the total number of prims in the object
+      containing the specified prim.
     categories:
       - object
   llGetOmega:
@@ -9174,8 +9789,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the rotation velocity in radians per second.\nReturns a vector
-      that is the rotation velocity of the object in radians per second.
+    tooltip: Returns a vector representing the physical rotation (angular velocity)
+      of the object in radians per second.
     categories:
       - movement
       - physics
@@ -9186,35 +9801,34 @@ functions:
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the object owner's UUID.\nReturns the key for the owner of the
-      object.
+    tooltip: Returns the key (UUID) of the object's current owner.
     categories:
       - linkset
       - uuid
   llGetOwnerKey:
     arguments:
-    - ObjectID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the prim in the same region.
+          type: key
     energy: 10.0
     func-id: 182
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the owner of ObjectID.\nReturns the key for the owner of object
-      ObjectID.
+    tooltip: Returns the key (UUID) of the owner of the prim specified by id.
     categories:
       - object
       - uuid
   llGetParcelDetails:
     arguments:
-    - Position:
-        tooltip: Location within the region.
-        type: vector
-    - ParcelDetails:
-        tooltip: List of details requested for the specified parcel location.
-        type: list
-        slua-type: "{number}"
+      - pos:
+          tooltip: The position vector in region coordinates (only the X and Y components
+            are used).
+          type: vector
+      - params:
+          tooltip: A list of PARCEL_DETAILS_* flags specifying the attributes to retrieve.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 327
     must-use: true
@@ -9222,47 +9836,43 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 0.0
-    tooltip: 'Returns a list of parcel details specified in the ParcelDetails list
-      for the parcel at Position.\nParameters is one or more of: PARCEL_DETAILS_NAME,
-      _DESC, _OWNER, _GROUP, _AREA, _ID, _SEE_AVATARS.\nReturns a list that is the
-      parcel details specified in ParcelDetails (in the same order) for the parcel
-      at Position.'
+    tooltip: Returns a list containing the requested parcel details specified by
+      params (retrieved in the same order) for the parcel at the vector pos.
     categories:
       - parcel
   llGetParcelFlags:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
+      - pos:
+          tooltip: The position vector in region coordinates (the Z component is ignored).
+          type: vector
     energy: 10.0
     func-id: 317
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns a mask of the parcel flags (PARCEL_FLAG_*) for the parcel that
-      includes the point Position.\nReturns a bit-field specifying the parcel flags
-      (PARCEL_FLAG_*) for the parcel at Position.
+    tooltip: Returns an integer bitfield of parcel flags (PARCEL_FLAG_*) for the
+      parcel at the position pos.
     categories:
       - parcel
   llGetParcelMaxPrims:
     arguments:
-    - Position:
-        tooltip: Region coordinates (z is ignored) of parcel.
-        type: vector
-    - SimWide:
-        tooltip: Boolean. If FALSE then the return is the maximum prims supported
-          by the parcel. If TRUE then it is the combined number of prims on all parcels
-          in the region owned by the specified parcel's owner.
-        type: integer
-        bool-semantics: true
+      - pos:
+          tooltip: The position vector in region coordinates (the Z component is ignored).
+          type: vector
+      - sim_wide:
+          tooltip: Boolean. If TRUE, returns the combined land impact limit for all
+            parcels owned by the parcel owner in the region; if FALSE, returns
+            only the limit for the specified parcel.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 326
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the maximum number of prims allowed on the parcel at Position
-      for a given scope.\nThe scope may be set to an individual parcel or the combined
-      resources of all parcels with the same ownership in the region.
+    tooltip: Returns an integer representing the maximum combined land impact (prim
+      limit) allowed for objects on the parcel at pos, determined either for the
+      single parcel or sim-wide based on sim_wide.
     categories:
       - parcel
   llGetParcelMusicURL:
@@ -9272,53 +9882,50 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Gets the streaming audio URL for the parcel object is on.\nThe object
-      owner, avatar or group, must also be the land owner.
+    tooltip: Returns a string containing the parcel's streaming music (audio) URL.
+      The object owner must also be the land owner (or share the same group
+      deeding).
     categories:
       - parcel
   llGetParcelPrimCount:
     arguments:
-    - Position:
-        tooltip: Region coordinates of parcel to query.
-        type: vector
-    - Category:
-        tooltip: A PARCEL_COUNT_* flag.
-        type: integer
-    - SimWide:
-        tooltip: Boolean. If FALSE then the return is the maximum prims supported
-          by the parcel. If TRUE then it is the combined number of prims on all parcels
-          in the region owned by the specified parcel's owner.
-        type: integer
-        bool-semantics: true
+      - pos:
+          tooltip: The position vector in region coordinates (the Z component is ignored).
+          type: vector
+      - category:
+          tooltip: The PARCEL_COUNT_* category flag.
+          type: integer
+      - sim_wide:
+          tooltip: Boolean. If TRUE, searches all parcels in the region owned by the
+            targeted parcel's owner; if FALSE, searches only the specified
+            parcel.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 325
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: 'Returns the number of prims on the parcel at Position of the given category.\nCategories:
-      PARCEL_COUNT_TOTAL, _OWNER, _GROUP, _OTHER, _SELECTED, _TEMP.\nReturns the number
-      of prims used on the parcel at Position which are in Category.\nIf SimWide is
-      TRUE, it returns the total number of objects for all parcels with matching ownership
-      in the category specified.\nIf SimWide is FALSE, it returns the number of objects
-      on this specific parcel in the category specified'
+    tooltip: Returns an integer representing the total land impact of objects on the
+      parcel at pos in the specified category. If sim_wide is TRUE, returns
+      combined usage for all regional parcels owned by the parcel owner; if
+      FALSE, returns usage for only the specified parcel.
     categories:
       - parcel
   llGetParcelPrimOwners:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
+      - pos:
+          tooltip: The position vector in region coordinates.
+          type: vector
     energy: 10.0
     func-id: 324
     must-use: true
     return: list
     sleep: 2.0
-    tooltip: Returns a list of up to 100 residents who own objects on the parcel at
-      Position, with per-owner land impact totals.\nRequires owner-like permissions
-      for the parcel, and for the script owner to be present in the region.\nThe list
-      is formatted as [ key agentKey1, integer agentLI1, key agentKey2, integer agentLI2,
-      ... ], sorted by agent key.\nThe integers are the combined land impacts of the
-      objects owned by the corresponding agents.
+    tooltip: Returns a list of up to 100 strides (formatted as [key owner, integer
+      land_impact]) representing owners of objects on the parcel at pos, sorted
+      by owner key. Requires owner-like permissions for the parcel and the
+      script owner's presence in the region.
     categories:
       - parcel
   llGetPermissions:
@@ -9328,9 +9935,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns an integer bitmask of the permissions that have been granted
-      to the script.  Individual permissions can be determined using a bit-wise "and"
-      operation against the PERMISSION_* constants
+    tooltip: Returns an integer bitfield representing the permissions (PERMISSION_*)
+      currently granted to the script.
     categories:
       - permissions
   llGetPermissionsKey:
@@ -9340,8 +9946,9 @@ functions:
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Returns the key of the avatar that last granted or declined permissions
-      to the script.\nReturns NULL_KEY if permissions were never granted or declined.
+    tooltip: Returns the key (UUID) of the avatar that last granted or declined
+      permissions to the script, or NULL_KEY if the permissions request was
+      ignored or cancelled.
     categories:
       - avatar
       - permissions
@@ -9353,8 +9960,9 @@ functions:
     return: list
     slua-return: "{number}"
     sleep: 0.0
-    tooltip: Returns a list of the form [float gravity_multiplier, float restitution,
-      float friction, float density].
+    tooltip: Returns a list of the format [float gravity_multiplier, float
+      restitution, float friction, float density] detailing the physical
+      characteristics of the object.
     categories:
       - physics
       - prim
@@ -9365,19 +9973,19 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the position of the task in region coordinates.\nReturns the
-      vector position of the task in region coordinates.
+    tooltip: Returns a vector representing the current position of the object in
+      region coordinates.
     categories:
       - prim
   llGetPrimMediaParams:
     arguments:
-    - Face:
-        tooltip: face number
-        type: integer
-    - Parameters:
-        tooltip: A list of PRIM_MEDIA_* property constants to return values of.
-        type: list
-        slua-type: "{number}"
+      - face:
+          tooltip: The face number (side) of the prim.
+          type: integer
+      - params:
+          tooltip: A list of PRIM_MEDIA_* property constants to retrieve values for.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 351
     must-use: true
@@ -9385,19 +9993,19 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 1.0
-    tooltip: Returns the media parameters for a particular face on an object, given
-      the desired list of parameter names, in the order requested. Returns an empty
-      list if no media exists on the face.
+    tooltip: Returns a list containing the media parameters of the specified face,
+      retrieved in the order requested by params. Returns an empty list if no
+      media exists on the face.
     categories:
       - media
       - prim
       - prim_media
   llGetPrimitiveParams:
     arguments:
-    - Parameters:
-        tooltip: PRIM_* flags and face parameters
-        type: list
-        slua-type: "{number}"
+      - params:
+          tooltip: A list of PRIM_* flags specifying the attributes to retrieve.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 279
     must-use: true
@@ -9405,8 +10013,8 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 0.2
-    tooltip: Returns the primitive parameters specified in the parameters list.\nReturns
-      primitive parameters specified in the Parameters list.
+    tooltip: Returns a list of primitive attribute values matching the requested
+      params list.
     categories:
       - prim
       - prim_appearance
@@ -9418,8 +10026,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of avatars in the region.\nReturns an integer that
-      is the number of avatars in the region.
+    tooltip: Returns an integer representing the current number of avatars in the
+      region.
     categories:
       - region
   llGetRegionCorner:
@@ -9429,10 +10037,9 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns a vector, in meters, that is the global location of the south-west
-      corner of the region which the object is in.\nReturns the Region-Corner of the
-      simulator containing the task. The region-corner is a vector (values in meters)
-      representing distance from the first region.
+    tooltip: Returns a vector (in meters) representing the global grid coordinates
+      of the south-west corner of the current region (Z component is always
+      0.0).
     categories:
       - region
   llGetRegionDayLength:
@@ -9442,7 +10049,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of seconds in a day in this region.
+    tooltip: Returns an integer representing the total number of seconds in the
+      region-wide day cycle.
     categories:
       - region
       - time
@@ -9453,8 +10061,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of seconds in a day is offset from midnight in this
-      parcel.
+    tooltip: Returns an integer representing the offset duration (in seconds) added
+      to calculate the current environmental time for the region.
     categories:
       - region
       - time
@@ -9465,7 +10073,8 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the mean region frames per second.
+    tooltip: Returns a float representing the average region simulator frames per
+      second (FPS).
     categories:
       - region
   llGetRegionFlags:
@@ -9475,9 +10084,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the region flags (REGION_FLAG_*) for the region the object is
-      in.\nReturns a bit-field specifying the region flags (REGION_FLAG_*) for the
-      region the object is in.
+    tooltip: Returns an integer bitfield representing the region flags
+      (REGION_FLAG_*) currently enabled for the region containing the object.
     categories:
       - region
   llGetRegionMoonDirection:
@@ -9487,8 +10095,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns a normalized vector of the direction of the moon in the region.\nReturns
-      the moon's direction on the simulator.
+    tooltip: Returns a normalized vector representing the current direction of the
+      region's moon, taking altitude into account.
     categories:
       - region
       - region_appearance
@@ -9499,7 +10107,8 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation applied to the moon in the region.
+    tooltip: Returns a rotation representing the orientation applied to the moon at
+      the region level, taking altitude track into account.
     categories:
       - region
       - region_appearance
@@ -9510,7 +10119,7 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the current region name.
+    tooltip: Returns a string containing the name of the current region.
     categories:
       - region
   llGetRegionSunDirection:
@@ -9520,8 +10129,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns a normalized vector of the direction of the sun in the region.\nReturns
-      the sun's direction on the simulator.
+    tooltip: Returns a normalized vector representing the current direction of the
+      region's sun, taking altitude into account.
     categories:
       - region
       - region_appearance
@@ -9532,7 +10141,8 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation applied to the sun in the region.
+    tooltip: Returns a rotation representing the orientation applied to the sun at
+      the region level, taking altitude track into account.
     categories:
       - region
       - region_appearance
@@ -9543,9 +10153,9 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the current time dilation as a float between 0.0 (full dilation)
-      and 1.0 (no dilation).\nReturns the current time dilation as a float between
-      0.0 and 1.0.
+    tooltip: Returns a float representing the current physics time dilation of the
+      region, ranging from 0.0 (full dilation / slow) to 1.0 (no dilation /
+      real-world speed).
     categories:
       - region
   llGetRegionTimeOfDay:
@@ -9555,25 +10165,26 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the time in seconds since environmental midnight for the entire
-      region.
+    tooltip: Returns a float with subsecond precision representing the elapsed
+      seconds since region environmental midnight or region uptime (whichever is
+      smaller). If the region's sun position is fixed, returns region uptime.
     categories:
       - region
       - time
   llGetRenderMaterial:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 760
     must-use: true
     return: string
     asset-semantics: true
     sleep: 0.0
-    tooltip: Returns a string that is the render material on face (the inventory name
-      if it is a material in the prim's inventory, otherwise the key).\nReturns the
-      render material of a face, if it is found in object inventory, its key otherwise.
+    tooltip: Returns a string representing the render material on face (returns the
+      inventory name if it is in the prim's inventory, or its key UUID
+      otherwise).
     categories:
       - prim
       - prim_appearance
@@ -9584,9 +10195,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the position (in region coordinates) of the root prim of the
-      object which the script is attached to.\nThis is used to allow a child prim
-      to determine where the root is.
+    tooltip: Returns a vector representing the position (in region coordinates) of
+      the root prim of the linkset containing the script.
     categories:
       - linkset
   llGetRootRotation:
@@ -9596,9 +10206,8 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation (relative to the region) of the root prim of the
-      object which the script is attached to.\nGets the global rotation of the root
-      object of the object script is attached to.
+    tooltip: Returns a rotation representing the orientation (relative to the
+      region) of the root prim of the linkset containing the script.
     categories:
       - linkset
   llGetRot:
@@ -9608,7 +10217,8 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation relative to the region's axes.\nReturns the rotation.
+    tooltip: Returns a rotation representing the prim's orientation relative to the
+      region's axes.
     categories:
       - prim
   llGetSPMaxMemory:
@@ -9618,9 +10228,9 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the maximum used memory for the current script. Only valid after
-      using PROFILE_SCRIPT_MEMORY. Non-mono scripts always use 16k.\nReturns the integer
-      of the most bytes used while llScriptProfiler was last active.
+    tooltip: Returns an integer representing the maximum memory (in bytes) used by
+      the script while the memory profiler was last active (only valid after
+      using PROFILE_SCRIPT_MEMORY).
     categories:
       - script
   llGetScale:
@@ -9630,8 +10240,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the scale of the prim.\nReturns a vector that is the scale (dimensions)
-      of the prim.
+    tooltip: Returns a vector representing the physical scale (dimensions in meters)
+      of the prim containing the script.
     categories:
       - prim
   llGetScriptName:
@@ -9641,38 +10251,39 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the name of the script that this function is used in.\nReturns
-      the name of this script.
+    tooltip: Returns a string containing the name of the script calling this function.
     categories:
       - prim_inventory
       - script
   llGetScriptState:
     arguments:
-    - ScriptName:
-        tooltip: ''
-        type: string
+      - script:
+          tooltip: The name of the script in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 250
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if the script named is running.\nReturns TRUE if ScriptName
-      is running.
+    tooltip: Returns a boolean integer indicating whether the specified script in
+      the prim's inventory is running (returns TRUE if running, FALSE
+      otherwise).
     categories:
       - prim_inventory
       - script
   llGetSimStats:
     arguments:
-    - StatType:
-        tooltip: Statistic type.
-        type: integer
+      - stat_type:
+          tooltip: The SIM_STAT_* flag of the statistic to retrieve.
+          type: integer
     energy: 10.0
     func-id: 415
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns a float that is the requested statistic.
+    tooltip: Returns a float containing the value of the requested region statistic
+      specified by stat_type.
     categories:
       - region
   llGetSimulatorHostname:
@@ -9682,8 +10293,8 @@ functions:
     must-use: true
     return: string
     sleep: 10.0
-    tooltip: Returns the host-name of the machine which the script is running on.\nFor
-      example, "sim225.agni.lindenlab.com".
+    tooltip: Returns a string containing the hostname of the server machine running
+      the script (e.g., 'sim225.agni.lindenlab.com').
     categories:
       - region
   llGetStartParameter:
@@ -9693,8 +10304,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns an integer that is the script rez parameter.\nIf the object was
-      rezzed by an agent, this function returns 0.
+    tooltip: Returns an integer representing the start/rez parameter passed to the
+      object on creation (returns 0 if rezzed by an agent).
     categories:
       - rez
       - script
@@ -9705,76 +10316,76 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string that is the value passed to llRezObjectWithParams with
-      REZ_PARAM_STRING.\nIf the object was rezzed by an agent, this function returns
-      an empty string.
+    tooltip: Returns the initialization string passed to the object's root prim on
+      rez with llRezObjectWithParams (via REZ_PARAM_STRING; returns an empty
+      string if rezzed by an agent).
     categories:
       - rez
       - script
   llGetStaticPath:
     arguments:
-    - Start:
-        tooltip: Starting position.
-        type: vector
-    - End:
-        tooltip: Ending position.
-        type: vector
-    - Radius:
-        tooltip: Radius of the character that the path is for, between 0.125m and
-          5.0m.
-        type: float
-    - Parameters:
-        tooltip: Currently only accepts the parameter CHARACTER_TYPE; the options
-          are identical to those used for llCreateCharacter. The default value is
-          CHARACTER_TYPE_NONE.
-        type: list
+      - start:
+          tooltip: The starting position vector.
+          type: vector
+      - end:
+          tooltip: The target end position vector.
+          type: vector
+      - radius:
+          tooltip: The radius of the character path, between 0.125m and 5.0m.
+          type: float
+      - params:
+          tooltip: A list specifying the CHARACTER_TYPE parameter (defaults to
+            CHARACTER_TYPE_NONE).
+          type: list
     energy: 10.0
     func-id: 413
     must-use: true
     return: list
     sleep: 0.0
-    tooltip: ''
+    tooltip: Returns a list of position vectors representing pathfinding waypoints
+      between start and end on the static navmesh for a character of the
+      specified radius. Ignores movable obstacles and can be used in any region
+      regardless of dynamic pathfinding status.
     categories:
       - pathfinding
   llGetStatus:
     arguments:
-    - StatusFlag:
-        tooltip: A STATUS_* flag
-        type: integer
+      - status:
+          tooltip: The single STATUS_* flag to check.
+          type: integer
     energy: 10.0
     func-id: 46
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns boolean value of the specified status (e.g. STATUS_PHANTOM) of
-      the object the script is attached to.
+    tooltip: Returns a boolean integer indicating whether the specified status flag
+      status is enabled for the object.
     categories:
       - linkset
       - physics
   llGetSubString:
     arguments:
-    - String:
-        tooltip: ''
-        type: string
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source string to slice.
+          type: string
+      - start:
+          tooltip: The zero-based start index (inclusive).
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The zero-based end index (inclusive).
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 94
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns a sub-string from String, in a range specified by the Start and
-      End indices (inclusive).\nUsing negative numbers for Start and/or End causes
-      the index to count backwards from the length of the string, so 0, -1 would capture
-      the entire string.\nIf Start is greater than End, the sub string is the exclusion
-      of the entries.
+    tooltip: Returns a copy of the substring from src within the inclusive range
+      specified by the start and end indices. Negative indices count backward
+      from the end. If start is greater than end, the substring is the excluded
+      range.
     categories:
       - string
   llGetSunDirection:
@@ -9784,8 +10395,9 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns a normalized vector of the direction of the sun in the parcel.\nReturns
-      the sun's direction on the simulator in the parcel.
+    tooltip: Returns a normalized vector representing the current direction of the
+      parcel's sun, taking altitude into account. Falls back to the region's sun
+      direction if no custom parcel environment is set.
     categories:
       - parcel
       - parcel_appearance
@@ -9796,67 +10408,71 @@ functions:
     must-use: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation applied to the sun in the parcel.
+    tooltip: Returns a rotation representing the orientation applied to the sun on
+      the current parcel and altitude track. Falls back to the region's sun
+      rotation if no custom parcel environment is set.
     categories:
       - parcel
       - parcel_appearance
   llGetTexture:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 57
     must-use: true
     return: string
     asset-semantics: true
     sleep: 0.0
-    tooltip: Returns a string that is the texture on face (the inventory name if it
-      is a texture in the prim's inventory, otherwise the key).\nReturns the texture
-      of a face, if it is found in object inventory, its key otherwise.
+    tooltip: Returns a string representing the Blinn-Phong diffuse texture on face
+      (returns the inventory name if it is a texture in the prim's inventory, or
+      its key UUID otherwise).
     categories:
       - prim
       - prim_appearance
   llGetTextureOffset:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 178
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the texture offset of face in the x and y components of a vector.
+    tooltip: Returns a vector containing the texture offsets of face in the X
+      (horizontal U) and Y (vertical V) components (Z is unused).
     categories:
       - prim
       - prim_appearance
   llGetTextureRot:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 180
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the texture rotation of side.
+    tooltip: Returns a float representing the texture rotation angle (in radians) on
+      face.
     categories:
       - prim
       - prim_appearance
   llGetTextureScale:
     arguments:
-    - Face:
-        tooltip: ''
-        type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 179
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the texture scale of side in the x and y components of a vector.\nReturns
-      the texture scale of a side in the x and y components of a vector.
+    tooltip: Returns a vector containing the texture scales of face in the X and Y
+      components (Z is unused).
     categories:
       - prim
       - prim_appearance
@@ -9867,9 +10483,9 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the time in seconds since the last region reset, script reset,
-      or call to either llResetTime or llGetAndResetTime. Has a resolution of 0.022s
-      (1 server frame), and is 6-11x faster to look up than lua's os.clock
+    tooltip: Returns a float representing the elapsed script time in seconds with
+      subsecond precision (since the script started, was reset, or since the
+      last call to llResetTime or llGetAndResetTime).
     categories:
       - script
   llGetTimeOfDay:
@@ -9879,7 +10495,9 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the time in seconds since environmental midnight on the parcel.
+    tooltip: Returns a float with subsecond precision representing the elapsed
+      seconds since parcel environmental midnight or region uptime (whichever is
+      smaller). If the parcel's sun position is fixed, returns region uptime.
     categories:
       - time
   llGetTimestamp:
@@ -9889,8 +10507,8 @@ functions:
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: 'Returns a time-stamp (UTC time zone) in the format: YYYY-MM-DDThh:mm:ss.ff..fZ.\n
-      Almost equivilant to os.date("%Y-%m-%dT%XZ") in lua, except for the milliseconds'
+    tooltip: Returns a string containing the current date and time in the UTC time
+      zone formatted as an ISO 8601 timestamp ('YYYY-MM-DDThh:mm:ss.ff..fZ').
     categories:
       - time
   llGetTorque:
@@ -9900,8 +10518,8 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the torque (if the script is physical).\nReturns a vector that
-      is the torque (if the script is physical).
+    tooltip: Returns a vector representing the physical torque force currently
+      acting on the object (if the object is physical).
     categories:
       - movement
       - physics
@@ -9915,8 +10533,8 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of seconds elapsed since 00:00 hours, Jan 1, 1970
-      UTC from the system clock.
+    tooltip: Returns an integer representing the current Unix timestamp (the number
+      of seconds elapsed since 00:00:00 Jan 1, 1970 UTC).
     categories:
       - time
   llGetUsedMemory:
@@ -9926,24 +10544,25 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the current used memory for the current script. Non-mono scripts
-      always use 16K.\nReturns the integer of the number of bytes of memory currently
-      in use by the script. Non-mono scripts always use 16K.
+    tooltip: Returns an integer representing the total number of bytes of memory
+      currently used by the script (non-Mono scripts always return 16,384
+      bytes).
     categories:
       - script
   llGetUsername:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the avatar in the same region or otherwise known to the
+            region.
+          type: key
     energy: 10.0
     func-id: 358
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the username of an avatar, if the avatar is connected to the
-      current region, or if the name has been cached.  Otherwise, returns an empty
-      string. Use llRequestUsername if the avatar may be absent from the region.
+    tooltip: Returns a string representing the unique username of the avatar
+      specified by id if they are connected to the region or cached; returns an
+      empty string otherwise (use llRequestUsername if the avatar is absent).
     categories:
       - avatar
   llGetVel:
@@ -9953,27 +10572,29 @@ functions:
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the velocity of the object.\nReturns a vector that is the velocity
-      of the object.
+    tooltip: Returns a vector representing the velocity of the object (in meters per
+      second) relative to the global region coordinates. For physical objects,
+      returns the velocity of its center of mass.
     categories:
       - movement
       - physics
   llGetVisualParams:
     arguments:
-    - ID:
-        tooltip: Avatar UUID in the same region.
-        type: key
-    - Parameters:
-        tooltip: List of visual parameter IDs.
-        type: list
-        slua-type: "{number | string}"
+      - agentid:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
+      - params:
+          tooltip: A list of visual parameter IDs or names to retrieve values for.
+          type: list
+          slua-type: "{number | string}"
     energy: 10.0
     func-id: 530
     must-use: true
     return: list
     slua-return: '{number | ""}'
     sleep: 0.0
-    tooltip: Returns a list of the current value for each requested visual parameter.
+    tooltip: Returns a list containing the values of the visual parameters requested
+      in params for the agent specified by agentid.
     categories:
       - avatar
   llGetWallclock:
@@ -9983,252 +10604,263 @@ functions:
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the time in seconds since midnight California Pacific time (PST/PDT).\nReturns
-      the time in seconds since simulator's time-zone midnight (Pacific Time).
+    tooltip: Returns a float representing the time in seconds since midnight Pacific
+      Time (PST/PDT), which is equivalent to Second Life Time (SLT) truncated to
+      whole seconds.
     categories:
       - time
   llGiveAgentInventory:
     arguments:
-    - AgentID:
-        tooltip: An agent in the region.
-        type: key
-    - FolderName:
-        tooltip: Folder name to give to the agent.
-        type: string
-    - InventoryItems:
-        tooltip: Inventory items to give to the agent.
-        type: list
-        slua-type: "{string}"
-    - Options:
-        tooltip: A list of option for inventory transfer.
-        type: list
+      - agent:
+          tooltip: The UUID of the receiving agent in the region.
+          type: key
+      - folder:
+          tooltip: The name of the destination folder to be created in the agent's
+            inventory.
+          type: string
+      - inventory:
+          tooltip: A list of inventory items to transfer.
+          type: list
+          slua-type: "{string}"
+      - options:
+          tooltip: A list of options to configure the inventory transfer.
+          type: list
     energy: 10.0
     func-id: 517
     return: integer
     sleep: 3.0
-    tooltip: Give InventoryItems to the specified agent as a new folder of items,
-      as permitted by the permissions system. The target must be an agent.
+    tooltip: Gives the specified inventory items to the agent as a new folder named
+      folder, as permitted by the permissions system. Customizes the transfer
+      using options.
     categories:
       - avatar_inventory
   llGiveInventory:
     arguments:
-    - TargetID:
-        tooltip: ''
-        type: key
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - destination:
+          tooltip: The UUID of the destination avatar or prim.
+          type: key
+      - inventory:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 150
     return: void
     sleep: 0.0
-    tooltip: Give InventoryItem to destination represented by TargetID, as permitted
-      by the permissions system.\nTargetID may be any agent or an object in the same
-      region.
+    tooltip: Gives the specified inventory item to the destination, as permitted by
+      the permissions system. The destination can be any agent, or an object
+      located in the same region.
     categories:
       - avatar_inventory
       - prim_inventory
   llGiveInventoryList:
     arguments:
-    - TargetID:
-        tooltip: ''
-        type: key
-    - FolderName:
-        tooltip: ''
-        type: string
-    - InventoryItems:
-        tooltip: ''
-        type: list
-        slua-type: "{string}"
+      - target:
+          tooltip: The UUID of the target avatar or prim in the same region.
+          type: key
+      - folder:
+          tooltip: The name of the destination folder to be created (ignored if the target
+            is an object).
+          type: string
+      - inventory:
+          tooltip: A list of names representing items in the prim's inventory.
+          type: list
+          slua-type: "{string}"
     energy: 10.0
     func-id: 231
     return: void
     sleep: 3.0
-    tooltip: Give InventoryItems to destination (represented by TargetID) as a new
-      folder of items, as permitted by the permissions system.\nTargetID may be any
-      agent or an object in the same region. If TargetID is an object, the items are
-      passed directly to the object inventory (no folder is created).
+    tooltip: Gives the list of inventory items to target as a new folder named
+      folder. If target is an object, the items are passed directly into its
+      inventory and no folder is created. The target must be an agent or an
+      object in the same region.
     categories:
       - avatar_inventory
       - prim_inventory
   llGiveMoney:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Amount:
-        tooltip: ''
-        type: integer
+      - destination:
+          tooltip: The UUID of the destination avatar.
+          type: key
+      - amount:
+          tooltip: The number of L$ to transfer (must be greater than 0).
+          type: integer
     energy: 10.0
     func-id: 99
     return: integer
     sleep: 0.0
     requires-permission:
       - PERMISSION_DEBIT
-    tooltip: Transfers Amount of L$ from script owner to AvatarID.\nThis call will
-      silently fail if PERMISSION_DEBIT has not been granted.
+    tooltip: Transfers the specified amount of L$ from the script owner to the
+      destination avatar. Silently fails if the PERMISSION_DEBIT permission has
+      not been granted. Returns 0 (use llTransferLindenDollars to match
+      transactions to transaction_result events).
     categories:
       - avatar
       - money
       - permissions
   llGodLikeRezObject:
     arguments:
-    - InventoryItemID:
-        tooltip: ''
-        type: key
-    - Position:
-        tooltip: ''
-        type: vector
+      - inventory:
+          tooltip: The asset UUID of the object to rez.
+          type: key
+      - pos:
+          tooltip: The position vector in region coordinates where the object will be
+            rezzed.
+          type: vector
     energy: 10.0
     func-id: 135
     god-mode: true
     return: void
     sleep: 0.0
-    tooltip: Rez directly off of a UUID if owner has god-bit set.
+    tooltip: Rezzes an object directly from a UUID specified by inventory at the
+      position pos, provided the owner has the god-bit set.
     categories:
       - prim_inventory
       - rez
   llGround:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     energy: 10.0
     func-id: 42
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the ground height at the object position + offset.\nReturns the
-      ground height at the object's position + Offset.
+    tooltip: Returns a float representing the ground height directly below the
+      prim's position offset by the vector offset.
     categories:
       - region
   llGroundContour:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     energy: 10.0
     func-id: 223
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the ground contour direction below the object position + Offset.\nReturns
-      the ground contour at the object's position + Offset.
+    tooltip: Returns a vector representing the ground contour direction (the
+      direction with no change in elevation) directly below the prim's position
+      offset by the vector offset.
     categories:
       - region
   llGroundNormal:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     energy: 10.0
     func-id: 222
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the ground normal below the object position + offset.\nReturns
-      the ground contour at the object's position + Offset.
+    tooltip: Returns a vector representing the ground surface normal vector directly
+      below the current position offset by the vector offset.
     categories:
       - region
   llGroundRepel:
     arguments:
-    - Height:
-        tooltip: Distance above the ground.
-        type: float
-    - Water:
-        tooltip: Boolean, if TRUE then hover above water too.
-        type: integer
-        bool-semantics: true
-    - Tau:
-        tooltip: Seconds to critically damp in.
-        type: float
+      - height:
+          tooltip: The target distance in meters above the ground or water.
+          type: float
+      - water:
+          tooltip: Boolean. If TRUE, damp relative to the higher of land and water; if
+            FALSE, damp relative to land only.
+          type: integer
+          bool-semantics: true
+      - tau:
+          tooltip: The timescale in seconds to critically damp the movement.
+          type: float
     energy: 10.0
     func-id: 230
     return: void
     sleep: 0.0
-    tooltip: "Critically damps to height if within height * 0.5 of level (either above\
-      \ ground level or above the higher of land and water if water == TRUE).\\nCritically\
-      \ damps to fHeight if within fHeight * 0.5 of ground or water level.\\n\n  \
-      \                  The height is above ground level if iWater is FALSE or above\
-      \ the higher of land and water if iWater is TRUE.\\n\n                    Do\
-      \ not use with vehicles. Only works in physics-enabled objects."
+    tooltip: Critically damps the object's vertical motion to height (using critical
+      damping timescale tau) if it is within height * 0.5 of the terrain (or
+      water level if water is TRUE). Only works on physics-enabled objects; do
+      not use with vehicles.
     categories:
       - region
   llGroundSlope:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     energy: 10.0
     func-id: 221
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the ground slope below the object position + Offset.\nReturns
-      the ground slope at the object position + Offset.
+    tooltip: Returns a vector representing the ground slope directly below the
+      prim's position offset by the vector offset.
     categories:
       - region
   llHMAC:
     arguments:
-    - Key:
-        tooltip: The PEM-formatted key for the hash digest.
-        type: string
-    - Message:
-        tooltip: The message to be hashed.
-        type: string
-    - Algorithm:
-        tooltip: 'The digest algorithm: md5, sha1, sha224, sha256, sha384, sha512.'
-        type: string
+      - private_key:
+          tooltip: The PEM-formatted secret key to use for the HMAC hash.
+          type: string
+      - msg:
+          tooltip: The message string to be hashed.
+          type: string
+      - algorithm:
+          tooltip: The cryptographic digest algorithm to use.
+          type: string
     energy: 10.0
     func-id: 538
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the base64-encoded hashed message authentication code (HMAC),
-      of Message using PEM-formatted Key and digest Algorithm (md5, sha1, sha224,
-      sha256, sha384, sha512).
+    tooltip: Returns a Base64-encoded HMAC hash of msg using the secret key
+      private_key and the specified digest algorithm (md5, sha1, sha224, sha256,
+      sha384, or sha512).
     categories:
       - cryptography
   llHTTPRequest:
     arguments:
-    - URL:
-        tooltip: A valid HTTP/HTTPS URL.
-        type: string
-    - Parameters:
-        tooltip: Configuration parameters, specified as HTTP_* flag-value pairs.
-        type: list
-    - Body:
-        tooltip: Contents of the request.
-        type: string
+      - url:
+          tooltip: The destination HTTP or HTTPS URL.
+          type: string
+      - parameters:
+          tooltip: A list of HTTP_* configuration flags and value pairs.
+          type: list
+      - body:
+          tooltip: The string contents of the request body.
+          type: string
     energy: 10.0
     func-id: 320
     return: key
     sleep: 0.0
-    tooltip: Sends an HTTP request to the specified URL with the Body of the request
-      and Parameters.\nReturns a key that is a handle identifying the HTTP request
-      made.
+    tooltip: Sends an HTTP request to the specified url containing body and
+      configured via parameters. Raises an http_response event and returns a key
+      query handle identifying the request.
     categories:
       - script_communication
       - web
   llHTTPResponse:
     arguments:
-    - HTTPRequestID:
-        tooltip: A valid HTTP request key.
-        type: key
-    - Status:
-        tooltip: HTTP Status (200, 400, 404, etc.).
-        type: integer
-    - Body:
-        tooltip: Contents of the response.
-        type: string
+      - request_id:
+          tooltip: The unique key identifying the incoming HTTP request.
+          type: key
+      - status:
+          tooltip: The integer HTTP status code (such as 200, 400, or 404) to respond
+            with.
+          type: integer
+      - body:
+          tooltip: The string contents of the response body.
+          type: string
     energy: 10.0
     func-id: 348
     return: void
     sleep: 0.0
-    tooltip: Responds to an incoming HTTP request which was triggerd by an http_request
-      event within the script. HTTPRequestID specifies the request to respond to (this
-      ID is supplied in the http_request event handler).  Status and Body specify
-      the status code and message to respond with.
+    tooltip: Responds to the incoming HTTP request identified by request_id with the
+      HTTP status code status and the payload body.
     categories:
       - media
       - prim_media
@@ -10236,106 +10868,109 @@ functions:
       - web
   llHash:
     arguments:
-    - value:
-        tooltip: ''
-        type: string
+      - val:
+          tooltip: The string to hash.
+          type: string
     energy: 10.0
     func-id: 528
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Calculates the 32bit hash value for the provided string.
+    tooltip: Returns an integer representing the 32-bit hash value of the string val
+      (returns 0 if the string is empty).
     categories:
       - cryptography
   llInsertString:
     arguments:
-    - TargetVariable:
-        tooltip: ''
-        type: string
-    - Position:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - SourceVariable:
-        tooltip: ''
-        type: string
+      - dst:
+          tooltip: The target destination string.
+          type: string
+      - pos:
+          tooltip: The zero-based position index where insertion starts.
+          type: integer
+          index-semantics: true
+      - src:
+          tooltip: The source string to insert.
+          type: string
     energy: 10.0
     func-id: 96
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Inserts SourceVariable into TargetVariable at Position, and returns the
-      result.\nInserts SourceVariable into TargetVariable at Position and returns
-      the result. Note this does not alter TargetVariable.
+    tooltip: Returns a new string representing dst with src inserted starting at the
+      zero-based index pos. Note that this operation does not modify dst itself.
     categories:
       - string
   llInstantMessage:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Text:
-        tooltip: ''
-        type: string
+      - user:
+          tooltip: The UUID of the destination user.
+          type: key
+      - message:
+          tooltip: The text message string to send.
+          type: string
     energy: 10.0
     func-id: 118
     return: void
     sleep: 2.0
-    tooltip: IMs Text to the user identified.\nSend Text to the user as an instant
-      message.
+    tooltip: Sends an instant message containing message to the user identified by
+      their key.
     categories:
       - avatar_communication
   llIntegerToBase64:
     arguments:
-    - Value:
-        tooltip: ''
-        type: integer
+      - number:
+          tooltip: The integer number to encode.
+          type: integer
     energy: 10.0
     func-id: 280
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string that is a Base64 big endian encode of Value.\nEncodes
-      the Value as an 8-character Base64 string.
+    tooltip: Returns an 8-character Base64 string representing the big-endian
+      encoded value of number.
     categories:
       - data_conversion
   llIsFriend:
     arguments:
-    - agent_id:
-        tooltip: Agent ID of another agent in the region.
-        type: key
+      - agent_id:
+          tooltip: The UUID of the agent to check.
+          type: key
     energy: 10.0
     func-id: 542
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if avatar ID is a friend of the script owner.
+    tooltip: Returns TRUE if agent_id and the owner of the script are friends, and
+      FALSE otherwise.
     categories:
       - avatar
   llIsLinkGLTFMaterial:
     arguments:
-    - link:
-        tooltip: Link number to check.
-        type: integer
-    - face:
-        tooltip: Side to check for a PBR material. Use ALL_SIDES to check for all.
-        type: integer
+      - link:
+          tooltip: The link number (or LINK_* flag) of the prim to inspect.
+          type: integer
+      - face:
+          tooltip: The face number (or ALL_SIDES) of the prim to inspect.
+          type: integer
     energy: 10.0
     func-id: 559
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Checks the face for a PBR render material.
+    tooltip: Checks the specified face on the linked prim link. Returns TRUE if the
+      face material is a PBR render material, or FALSE if it uses Blinn-Phong
+      diffuse textures.
     categories:
       - linkset
       - prim_appearance
   llJson2List:
     arguments:
-    - JSON:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The JSON string to parse.
+          type: string
     slua-deprecated:
       use: lljson.decode
     energy: 10.0
@@ -10343,21 +10978,23 @@ functions:
     pure: true
     return: list
     sleep: 0.0
-    tooltip: Converts the top level of the JSON string to a list.
+    tooltip: Parses the JSON string src and returns a list representing its
+      top-level elements.
     categories:
       - data_conversion
       - json
   llJsonGetValue:
     arguments:
-    - JSON:
-        tooltip: ''
-        type: string
-    - Specifiers:
-        tooltip: ''
-          # TODO: The specifiers can contain integers, which should be array indices
-          # But we don't support that in the bindgen yet.
-          # index-semantics: true
-        type: list
+      - json:
+          tooltip: The JSON string to query.
+          type: string
+      - specifiers:
+          tooltip: A list of key names or array indices specifying the path to the desired
+            value.
+            # TODO: The specifiers can contain integers, which should be array indices
+            # But we don't support that in the bindgen yet.
+            # index-semantics: true
+          type: list
     slua-deprecated:
       use: lljson.decode
       reason: Also, the indices are zero-based.
@@ -10366,24 +11003,27 @@ functions:
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Gets the value indicated by Specifiers from the JSON string.
+    tooltip: Parses the JSON string json and returns the value found by traversing
+      the specified path of specifiers as a string.
     categories:
       - data_conversion
       - json
   llJsonSetValue:
     arguments:
-    - JSON:
-        tooltip: ''
-        type: string
-    - Specifiers:
-        tooltip: ''
-        type: list
-          # TODO: The specifiers can contain integers, which should be array indices
-          # But we don't support that in the bindgen yet.
-          # index-semantics: true
-    - Value:
-        tooltip: ''
-        type: string
+      - json:
+          tooltip: The source JSON string to modify.
+          type: string
+      - specifiers:
+          tooltip: A list of key names or array indices specifying the path to add,
+            update, or delete.
+          type: list
+            # TODO: The specifiers can contain integers, which should be array indices
+            # But we don't support that in the bindgen yet.
+            # index-semantics: true
+      - value:
+          tooltip: The new value to set, or the JSON_DELETE constant to delete the
+            targeted element.
+          type: string
     slua-deprecated:
       use: lljson.encode
       reason: Also, the indices are zero-based.
@@ -10392,47 +11032,50 @@ functions:
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns a new JSON string that is the JSON given with the Value indicated
-      by Specifiers set to Value.
+    tooltip: Returns a new JSON string representing json with the target located at
+      specifiers set to value. Supports JSON_APPEND to append elements. Writing
+      JSON_DELETE deletes the target. Overwriting array bounds or setting
+      non-array levels with array indices returns JSON_INVALID.
     categories:
       - data_conversion
       - json
   llJsonValueType:
     arguments:
-    - JSON:
-        tooltip: ''
-        type: string
-    - Specifiers:
-        tooltip: ''
-          # TODO: The specifiers can contain integers, which should be array indices
-          # But we don't support that in the bindgen yet.
-          # index-semantics: true
-        type: list
+      - json:
+          tooltip: The JSON string containing the value to query.
+          type: string
+      - specifiers:
+          tooltip: A list of key names or array indices specifying the path to the value.
+            # TODO: The specifiers can contain integers, which should be array indices
+            # But we don't support that in the bindgen yet.
+            # index-semantics: true
+          type: list
     slua-deprecated:
-      reason: Use 'lljson.decode' and 'typeof' instead. Also, the indices are zero-based.
+      reason: Use 'lljson.decode' and 'typeof' instead. Also, the indices are
+        zero-based.
     energy: 10.0
     func-id: 512
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns the type constant (JSON_*) for the value in JSON indicated by
-      Specifiers.
+    tooltip: Parses the JSON string json and returns the JSON type constant (JSON_*)
+      representing the value found at specifiers.
     categories:
       - data_conversion
       - json
   llKey2Name:
     arguments:
-    - ID:
-        tooltip: Avatar or rezzed prim UUID.
-        type: key
+      - id:
+          tooltip: The UUID of the target avatar or prim in the same region.
+          type: key
     energy: 10.0
     func-id: 210
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the name of the prim or avatar specified by ID. The ID must be
-      a valid rezzed prim or avatar key in the current simulator, otherwise an empty
-      string is returned.\nFor avatars, the returned name is the legacy name
+    tooltip: Returns a string containing the name of the prim or avatar specified by
+      id. The target must be a valid, rezzed entity in the current region,
+      otherwise an empty string is returned. Avatars return their legacy name.
     categories:
       - object
   llKeyCountKeyValue:
@@ -10442,14 +11085,9 @@ functions:
     func-id: 601
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction the request the\
-      \ number of keys in the data store. The dataserver callback will be executed\
-      \ with the key returned from this call and a string describing the result. The\
-      \ result is commma-delimited list. The first item is an integer specifying if\
-      \ the transaction succeeded (1) or not (0). In the failure case, the second\
-      \ item will be an integer corresponding to one of the XP_ERROR_... constants.\
-      \ In the success case the second item will the the number of keys in the system.\n\
-      \                "
+    tooltip: Starts an asynchronous transaction requesting the total count of keys
+      in the experience data store. Returns a key query handle for the
+      dataserver event.
     categories:
       - data_storage
       - dataserver
@@ -10457,32 +11095,22 @@ functions:
       - experience_data
   llKeysKeyValue:
     arguments:
-    - First:
-        tooltip: Index of the first key to return.
-        type: integer
-        index-semantics: true
-    - Count:
-        tooltip: The number of keys to return.
-        type: integer
+      - first:
+          tooltip: The zero-based start index of the keys to retrieve.
+          type: integer
+          index-semantics: true
+      - count:
+          tooltip: The number of keys to retrieve.
+          type: integer
     energy: 10.0
     experience: true
     func-id: 602
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction the request a\
-      \ number of keys from the data store. The dataserver callback will be executed\
-      \ with the key returned from this call and a string describing the result. The\
-      \ result is commma-delimited list. The first item is an integer specifying if\
-      \ the transaction succeeded (1) or not (0). In the failure case, the second\
-      \ item will be an integer corresponding to one of the XP_ERROR_... constants.\
-      \ The error XP_ERROR_KEY_NOT_FOUND is returned if First is greater than or equal\
-      \ to the number of keys in the data store. In the success case the subsequent\
-      \ items will be the keys requested. The number of keys returned may be less\
-      \ than requested if the return value is too large or if there is not enough\
-      \ keys remaining. The order keys are returned is not guaranteed but is stable\
-      \ between subsequent calls as long as no keys are added or removed. Because\
-      \ the keys are returned in a comma-delimited list it is not recommended to use\
-      \ commas in key names if this function is used.\n                "
+    tooltip: Starts an asynchronous transaction to retrieve count keys from the
+      experience data store starting at the zero-based index first. Returns a
+      key query handle for the dataserver event. Fails with
+      XP_ERROR_KEY_NOT_FOUND if out of bounds.
     categories:
       - data_storage
       - dataserver
@@ -10490,153 +11118,145 @@ functions:
       - experience_data
   llLinear2sRGB:
     arguments:
-    - color:
-        tooltip: A color in the linear colorspace.
-        type: vector
+      - color:
+          tooltip: The RGB color vector in linear space to convert.
+          type: vector
     energy: 10.0
     func-id: 715
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Converts a color from the linear colorspace to sRGB.
+    tooltip: Returns a vector representing the conversion of color from the linear
+      RGB colorspace into the sRGB colorspace.
     categories:
       - data_conversion
       - math
       - prim_appearance
   llLinkAdjustSoundVolume:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - Volume:
-        tooltip: The volume to set.
-        type: float
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: integer
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 535
     return: void
     sleep: 0.0
-    tooltip: Adjusts the volume (0.0 - 1.0) of the currently playing sound attached
-      to the link.\nThis function has no effect on sounds started with llTriggerSound.
+    tooltip: Adjusts the volume of the currently playing sound attached to the
+      linked prim link (has no effect on sounds started with llTriggerSound).
     categories:
       - sound
   llLinkParticleSystem:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - Rules:
-        tooltip: Particle system rules list in the format [ rule1, data1, rule2, data2
-          . . . ruleN, dataN ]
-        type: list
+      - rules:
+          tooltip: A list of particle system rules and data pairs [rule1, data1, ...].
+          type: integer
+      - rules:
+          tooltip: A list of particle system rules and data pairs [rule1, data1, ...].
+          type: list
     energy: 10.0
     func-id: 355
     return: void
     sleep: 0.0
-    tooltip: Creates a particle system in prim LinkNumber based on Rules. An empty
-      list removes a particle system from object.\nList format is [ rule-1, data-1,
-      rule-2, data-2 ... rule-n, data-n ].\nThis is identical to llParticleSystem
-      except that it applies to a specified linked prim and not just the prim the
-      script is in.
+    tooltip: Creates or updates a particle system on the linked prim link based on
+      the list of rules. An empty list removes the particle system.
     categories:
       - effects
       - particles
   llLinkPlaySound:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
-    - Flags:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
+      - flags:
+          tooltip: Bitwise flags (combination of SOUND_*) controlling the sound playback.
+          type: integer
     energy: 10.0
     func-id: 533
     return: void
     sleep: 0.0
-    tooltip: Plays Sound, once or looping, at Volume (0.0 - 1.0). The sound may be
-      attached to the link or triggered at its location.\nOnly one sound may be attached
-      to an object at a time, and attaching a new sound or calling llStopSound will
-      stop the previously attached sound.
+    tooltip: Plays the specified sound on the linked prim link (once or looping) at
+      volume. Only one sound can be attached to a prim at a time; new
+      attachments or calling llStopSound stops previous playback. Controlled by
+      flags.
     categories:
       - sound
   llLinkSetSoundQueueing:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - QueueEnable:
-        tooltip: 'Boolean, sound queuing for the linked prim: TRUE enables, FALSE
-          disables (default).'
-        type: integer
-        bool-semantics: true
+      - queue:
+          tooltip: Boolean. If TRUE, sound queuing is enabled; if FALSE, it is disabled.
+          type: integer
+      - queueenable:
+          tooltip: 'Boolean, sound queuing for the linked prim: TRUE enables, FALSE
+            disables (default).'
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 537
     return: void
     sleep: 0.0
-    tooltip: Limits radius for audibility of scripted sounds (both attached and triggered)
-      to distance Radius around the link.
+    tooltip: Enables or disables sound queuing on the linked prim link. When set to
+      TRUE, sounds will queue and play in sequence.
     categories:
       - sound
   llLinkSetSoundRadius:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - radius:
-        tooltip: Maximum distance that sounds can be heard.
-        type: float
+      - linknumber:
+          tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
+            flag'
+          type: integer
+      - radius:
+          tooltip: The maximum distance in meters at which the sounds can be heard.
+          type: float
     energy: 10.0
     func-id: 536
     return: void
     sleep: 0.0
-    tooltip: Limits radius for audibility of scripted sounds (both attached and triggered)
-      to distance Radius around the link.
+    tooltip: Limits the audibility radius of attached and triggered scripted sounds
+      to distance radius (in meters) around the linked prim link.
     categories:
       - sound
   llLinkSitTarget:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag of the prim.'
-        type: integer
-    - Offset:
-        tooltip: Position for the sit target, relative to the prim's position.
-        type: vector
-    - Rotation:
-        tooltip: Rotation (relative to the prim's rotation) for the avatar.
-        type: rotation
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - offset:
+          tooltip: The offset position vector in local prim coordinates.
+          type: vector
+      - rot:
+          tooltip: The rotation relative to the prim's rotation.
+          type: rotation
     energy: 10.0
     func-id: 375
     return: void
     sleep: 0.0
-    tooltip: Set the sit location for the linked prim(s). If Offset == <0,0,0> clear
-      it.\nSet the sit location for the linked prim(s). The sit location is relative
-      to the prim's position and rotation.
+    tooltip: Sets the sit target position (offset) and orientation (rot) for the
+      linked prim link, relative to the prim's own position and rotation. Clear
+      by setting offset to <0.0, 0.0, 0.0>.
     categories:
       - linkset
       - sit
   llLinkStopSound:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
     energy: 10.0
     func-id: 534
     return: void
     sleep: 0.0
-    tooltip: Stops playback of the currently attached sound on a link.
+    tooltip: Stops the playback of any currently playing attached sound on the
+      linked prim link.
     categories:
       - sound
   llLinksetDataAvailable:
@@ -10646,23 +11266,24 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of bytes remaining in the linkset's datastore.
+    tooltip: Returns an integer representing the number of bytes available/remaining
+      in the linkset's datastore.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataCountFound:
     arguments:
-    - search:
-        tooltip: A regex search string to match against keys in the datastore.
-        type: string
+      - pattern:
+          tooltip: A regular expression (regex) search string used to match keys.
+          type: string
     energy: 10.0
     func-id: 661
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of keys matching the regular expression passed in
-      the search parameter.
+    tooltip: Returns the total count of keys in the linkset datastore that match the
+      regular expression pattern.
     categories:
       - data_storage
       - linkset
@@ -10674,135 +11295,144 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the number of keys in the linkset's datastore.
+    tooltip: Returns an integer representing the total number of unique keys stored
+      in the linkset's datastore.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataDelete:
     arguments:
-    - name:
-        tooltip: Key to delete from the linkset's datastore.
-        type: string
+      - name:
+          tooltip: The key name of the key-value pair to delete.
+          type: string
     energy: 10.0
     func-id: 652
     return: integer
     sleep: 0.0
-    tooltip: Deletes a name:value pair from the linkset's datastore.
+    tooltip: Deletes the unprotected key-value pair specified by name from the
+      linkset's datastore.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataDeleteFound:
     arguments:
-    - search:
-        tooltip: A regex search string to match against keys in the datastore.
-        type: string
-    - pass:
-        tooltip: The pass phrase used to protect key value pairs in the linkset data
-        type: string
+      - pattern:
+          tooltip: A regular expression (regex) specifying which keys to delete.
+          type: string
+      - pass:
+          tooltip: The optional passphrase required to delete matching protected keys.
+          type: string
     energy: 10.0
     func-id: 662
     return: list
     slua-return: "{number}"
     sleep: 0.0
-    tooltip: 'Deletes all key value pairs in the linkset data where the key matches
-      the regular expression in search. Returns a list consisting of [ #deleted, #not
-      deleted ].'
+    tooltip: Deletes all keys in the datastore matching the regular expression
+      pattern. Returns a list [num_deleted, num_failed_protected]. Decrypts and
+      deletes protected keys if matching pass is provided.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataDeleteProtected:
     arguments:
-    - name:
-        tooltip: Key to delete from the linkset's datastore.
-        type: string
-    - pass:
-        tooltip: Pass phrase to access protected data.
-        type: string
+      - name:
+          tooltip: The key name of the protected key-value pair to delete.
+          type: string
+      - pass:
+          tooltip: The passphrase required to delete the protected key.
+          type: string
     energy: 10.0
     func-id: 660
     return: integer
     sleep: 0.0
-    tooltip: Deletes a name:value pair from the linkset's datastore.
+    tooltip: Deletes the protected key-value pair specified by name from the
+      linkset's datastore using the passphrase pass.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataFindKeys:
     arguments:
-    - search:
-        tooltip: A regex search string to match against keys in the datastore.
-        type: string
-    - start:
-        tooltip: Index of the first entry to return.
-        type: integer
-        index-semantics: true
-    - count:
-        tooltip: Number of entries to return. Less than 1 for all keys.
-        type: integer
+      - pattern:
+          tooltip: A regular expression (regex) describing which keys to search for.
+          type: string
+      - start:
+          tooltip: The zero-based start index of the matching keys to return.
+          type: integer
+          index-semantics: true
+      - count:
+          tooltip: The maximum number of keys to return (or less than 1 to retrieve all
+            matching keys).
+          type: integer
     energy: 10.0
     func-id: 657
     must-use: true
     return: list
     slua-return: "{string}"
     sleep: 0.0
-    tooltip: Returns a list of keys from the linkset's data store matching the search
-      parameter.
+    tooltip: Returns an alphabetically sorted list of up to count keys from the
+      datastore that match the regular expression pattern, starting at index
+      start (returns all matching keys if count < 1).
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataListKeys:
     arguments:
-    - start:
-        tooltip: First entry to return. 0 for start of list.
-        type: integer
-        index-semantics: true
-    - count:
-        tooltip: Number of entries to return. Less than 1 for all keys.
-        type: integer
+      - start:
+          tooltip: The zero-based start index of the keys to return.
+          type: integer
+          index-semantics: true
+      - count:
+          tooltip: The maximum number of keys to return (or less than 1 to retrieve all
+            keys).
+          type: integer
     energy: 10.0
     func-id: 656
     must-use: true
     return: list
     slua-return: "{string}"
     sleep: 0.0
-    tooltip: Returns a list of all keys in the linkset datastore.
+    tooltip: Returns an alphabetically sorted list of up to count keys from the
+      datastore, starting at index start (returns all keys if count < 1).
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataRead:
     arguments:
-    - name:
-        tooltip: Key to retrieve from the linkset's datastore.
-        type: string
+      - name:
+          tooltip: The key of the key-value pair to read.
+          type: string
     energy: 10.0
     func-id: 651
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the value stored for a key in the linkset.
+    tooltip: Reads and returns the string value corresponding to key name from the
+      linkset's datastore.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataReadProtected:
     arguments:
-    - name:
-        tooltip: Key to retrieve from the linkset's datastore.
-        type: string
-    - pass:
-        tooltip: Pass phrase to access protected data.
-        type: string
+      - name:
+          tooltip: The key of the protected key-value pair to read.
+          type: string
+      - pass:
+          tooltip: The passphrase required to read the protected key.
+          type: string
     energy: 10.0
     func-id: 659
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the value stored for a key in the linkset.
+    tooltip: Reads and returns the string value of the protected key name from the
+      linkset's datastore using the passphrase pass.
     categories:
       - data_storage
       - linkset
@@ -10813,72 +11443,77 @@ functions:
     func-id: 655
     return: void
     sleep: 0.0
-    tooltip: Resets the linkset's data store, erasing all key-value pairs.
+    tooltip: Erases all key-value pairs stored in the linkset's datastore,
+      triggering a linkset_data event (with LINKSETDATA_RESET) in all scripts in
+      the linkset.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataWrite:
     arguments:
-    - name:
-        tooltip: key for the name:value pair.
-        type: string
-    - value:
-        tooltip: value to store in the linkset's datastore.
-        type: string
+      - name:
+          tooltip: The key name of the key-value pair.
+          type: string
+      - value:
+          tooltip: The string value to write to the datastore.
+          type: string
     energy: 10.0
     func-id: 650
     return: integer
     sleep: 0.0
-    tooltip: Sets a name:value pair in the linkset's datastore
+    tooltip: Creates or updates an unprotected key-value pair (name and value) in
+      the linkset's datastore. Returns an integer success or failure code.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llLinksetDataWriteProtected:
     arguments:
-    - name:
-        tooltip: key for the name:value pair.
-        type: string
-    - value:
-        tooltip: value to store in the linkset's datastore.
-        type: string
-    - pass:
-        tooltip: Pass phrase to access protected data.
-        type: string
+      - name:
+          tooltip: The key name of the protected key-value pair.
+          type: string
+      - value:
+          tooltip: The string value to write to the datastore.
+          type: string
+      - pass:
+          tooltip: The passphrase used to protect or update the key.
+          type: string
     energy: 10.0
     func-id: 658
     return: integer
     sleep: 0.0
-    tooltip: Sets a name:value pair in the linkset's datastore
+    tooltip: Creates or updates a protected key-value pair (name and value) in the
+      linkset's datastore using the passphrase pass. Returns an integer success
+      or failure code.
     categories:
       - data_storage
       - linkset
       - linkset_data
   llList2CSV:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
+      - src:
+          tooltip: The source list to convert.
+          type: list
     energy: 10.0
     func-id: 195
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Creates a string of comma separated values from the list.\nCreate a string
-      of comma separated values from the specified list.
+    tooltip: Returns a string of comma-separated values taken in order from the list
+      src.
     categories:
       - data_conversion
       - list
   llList2Float:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       reason: Use '[]' and 'tonumber' instead.
       selene-replace: ["tonumber(%1[%2]) or 0"]
@@ -10888,21 +11523,20 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Copies the float at Index in the list.\nReturns the value at Index in
-      the specified list. If Index describes a location not in the list, or the value
-      cannot be type-cast to a float, then zero is returned.
+    tooltip: Returns the float value at index in the list src. Returns 0.0 if the
+      index is out of bounds or if the value cannot be type-cast.
     categories:
       - data_conversion
       - list
   llList2Integer:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       reason: Use '[]', 'tonumber', and 'math.modf' instead.
       selene-replace: ["math.modf(tonumber(%1[%2]) or 0)"]
@@ -10912,20 +11546,19 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Copies the integer at Index in the list.\nReturns the value at Index
-      in the specified list. If Index describes a location not in the list, or the
-      value cannot be type-cast to an integer, then zero is returned.
+    tooltip: Returns the integer value at index in the list src. Returns 0 if the
+      index is out of bounds or if the value cannot be type-cast.
     categories:
       - data_conversion
       - list
   llList2Json:
     arguments:
-    - JsonType:
-        tooltip: Type is JSON_ARRAY or JSON_OBJECT.
-        type: string
-    - Values:
-        tooltip: List of values to convert.
-        type: list
+      - type:
+          tooltip: The JSON target type (JSON_ARRAY or JSON_OBJECT).
+          type: string
+      - values:
+          tooltip: The list of values to serialize.
+          type: list
     slua-deprecated:
       use: lljson.encode
       selene-replace: ["lljson.encode(%2)"]
@@ -10934,21 +11567,22 @@ functions:
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Converts either a strided list of key:value pairs to a JSON_OBJECT, or
-      a list of values to a JSON_ARRAY.
+    tooltip: Converts the list values into a JSON string of the specified type
+      (either a JSON_ARRAY or a JSON_OBJECT). Returns JSON_INVALID if an error
+      is encountered.
     categories:
       - data_conversion
       - json
       - list
   llList2Key:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       reason: Use '[]' and 'touuid' instead.
       selene-replace: ["touuid(%1[%2]) or NULL_KEY"]
@@ -10958,29 +11592,30 @@ functions:
     pure: true
     return: key
     sleep: 0.0
-    tooltip: Copies the key at Index in the list.\nReturns the value at Index in the
-      specified list. If Index describes a location not in the list, or the value
-      cannot be type-cast to a key, then null string is returned.
+    tooltip: Returns the key (UUID) value at index in the list src. Returns a null
+      string/key if the index is out of bounds or if the value cannot be
+      type-cast.
     categories:
       - data_conversion
       - list
   llList2List:
     type-arguments: [T]
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list to slice.
+          type: list
+          slua-type: '{T}'
+      - start:
+          tooltip: The zero-based start index (inclusive).
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The zero-based end index (inclusive).
+          type: integer
+          index-semantics: true
     slua-deprecated:
-      reason: Use 'unpack' (fastcall) or 'table.move' instead. Prefer structured tables over strided lists.
+      reason: Use 'unpack' (fastcall) or 'table.move' instead. Prefer structured
+        tables over strided lists.
       selene-replace: ["table.pack(unpack(%...))", "table.move(%..., 1, {})"]
     energy: 10.0
     func-id: 192
@@ -10989,35 +11624,34 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns a subset of entries from ListVariable, in a range specified by
-      the Start and End indicies (inclusive).\nUsing negative numbers for Start and/or
-      End causes the index to count backwards from the length of the string, so 0,
-      -1 would capture the entire string.\nIf Start is greater than End, the sub string
-      is the exclusion of the entries.
+    tooltip: Returns a new list containing the subset of entries from src within the
+      inclusive range specified by the start and end indices. Negative indices
+      count backward from the end.
     categories:
       - list
   llList2ListSlice:
     type-arguments: [T]
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - Stride:
-        tooltip: ''
-        type: integer
-    - slice_index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source strided list.
+          type: list
+          slua-type: '{T}'
+      - start:
+          tooltip: The zero-based start index (inclusive).
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The zero-based end index (inclusive).
+          type: integer
+          index-semantics: true
+      - stride:
+          tooltip: The number of entries per stride (defaults to 1 if less than 1).
+          type: integer
+      - slice_index:
+          tooltip: The zero-based element index within each stride to extract (negatives
+            count backward from the end of the stride).
+          type: integer
+          index-semantics: true
     slua-deprecated:
       reason: Prefer structured tables over strided lists.
     energy: 10.0
@@ -11026,34 +11660,29 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns a subset of entries from ListVariable, in a range specified by
-      Start and End indices (inclusive) return the slice_index element of each stride.\n
-      Using negative numbers for Start and/or End causes the index to count backwards
-      from the length of the list. (e.g. 0, -1 captures entire list)\nIf slice_index
-      is less than 0, it is counted backwards from the end of the stride.\n Stride
-      must be a positive integer > 0 or an empy list is returned.  If slice_index
-      falls outside range of stride, an empty list is returned. slice_index is zero-based.
-      (e.g. A stride of 2 has valid indices 0,1)
+    tooltip: Returns a list containing the slice_index'th element of every stride
+      within the inclusive range from start to end in the strided list src.
+      Stride must be a positive integer.
     categories:
       - list
   llList2ListStrided:
     type-arguments: [T]
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - Stride:
-        tooltip: ''
-        type: integer
+      - src:
+          tooltip: The source strided list.
+          type: list
+          slua-type: '{T}'
+      - start:
+          tooltip: The zero-based start index (inclusive).
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The zero-based end index (inclusive).
+          type: integer
+          index-semantics: true
+      - stride:
+          tooltip: The number of entries per stride (defaults to 1 if less than 1).
+          type: integer
     slua-deprecated:
       reason: Prefer structured tables over strided lists.
     energy: 10.0
@@ -11062,19 +11691,19 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Copies the strided slice of the list from Start to End.\nReturns a copy
-      of the strided slice of the specified list from Start to End.
+    tooltip: Returns a new list containing the first element of every stride in the
+      strided list src within the inclusive range from start to end.
     categories:
       - list
   llList2Rot:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: '[]'
       selene-replace: ["%1[%2]"]
@@ -11084,21 +11713,21 @@ functions:
     pure: true
     return: rotation
     sleep: 0.0
-    tooltip: Copies the rotation at Index in the list.\nReturns the value at Index
-      in the specified list. If Index describes a location not in the list, or the
-      value cannot be type-cast to rotation, thenZERO_ROTATION is returned.
+    tooltip: Returns the rotation value at index in the list src. Returns
+      ZERO_ROTATION if the index is out of bounds or if the value cannot be
+      type-cast.
     categories:
       - data_conversion
       - list
   llList2String:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       reason: Use '[]' and 'tostring' instead.
       selene-replace: ["tostring(%1[%2])"]
@@ -11108,21 +11737,20 @@ functions:
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Copies the string at Index in the list.\nReturns the value at Index in
-      the specified list as a string. If Index describes a location not in the list
-      then null string is returned.
+    tooltip: Returns the string value at index in the list src. Returns an empty
+      string if the index is out of bounds.
     categories:
       - data_conversion
       - list
   llList2Vector:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Index:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The source list containing the element of interest.
+          type: list
+      - index:
+          tooltip: The zero-based index of the entry.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: '[]'
       selene-replace: ["%1[%2]"]
@@ -11132,20 +11760,19 @@ functions:
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Copies the vector at Index in the list.\nReturns the value at Index in
-      the specified list. If Index describes a location not in the list, or the value
-      cannot be type-cast to a vector, then ZERO_VECTOR is returned.
+    tooltip: Returns the vector value at index in the list src. Returns ZERO_VECTOR
+      if the index is out of bounds or if the value cannot be type-cast.
     categories:
       - data_conversion
       - list
   llListFindList:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Find:
-        tooltip: ''
-        type: list
+      - src:
+          tooltip: The list to search within.
+          type: list
+      - test:
+          tooltip: The list elements to search for.
+          type: list
     slua-deprecated:
       use: table.find
       reason: Prefer dictionaries or single-item searches.
@@ -11156,22 +11783,22 @@ functions:
     return: integer
     index-semantics: true
     sleep: 0.0
-    tooltip: Returns the first index where Find appears in ListVariable. Returns
-      -1 if not found.
+    tooltip: Returns the integer index of the first instance of list test within the
+      list src (returns -1 if not found).
     categories:
       - list
   llListFindListNext:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Find:
-        tooltip: ''
-        type: list
-    - Instance:
-        tooltip: Index of the match to return.
-        type: integer
-        index-semantics: true
+      - src:
+          tooltip: The list to search within.
+          type: list
+      - test:
+          tooltip: The list elements to search for.
+          type: list
+      - instance:
+          tooltip: The zero-based occurrence index of the match to find.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: table.find
       reason: Prefer dictionaries or single-item searches.
@@ -11182,29 +11809,29 @@ functions:
     return: integer
     index-semantics: true
     sleep: 0.0
-    tooltip: Returns the nth index where Find appears in ListVariable. Returns
-      -1 if not found.
+    tooltip: Returns the integer index of the specified instance of list test within
+      the list src (returns -1 if not found).
     categories:
       - list
   llListFindStrided:
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-    - Find:
-        tooltip: ''
-        type: list
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - Stride:
-        tooltip: ''
-        type: integer
+      - src:
+          tooltip: The list to search within.
+          type: list
+      - test:
+          tooltip: The list elements to search for.
+          type: list
+      - start:
+          tooltip: The zero-based start index of the range to search.
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The zero-based end index of the range to search.
+          type: integer
+          index-semantics: true
+      - stride:
+          tooltip: The number of entries per stride in the list.
+          type: integer
     slua-deprecated:
       reason: Prefer dictionary lookups over strided list searches.
     energy: 10.0
@@ -11213,31 +11840,32 @@ functions:
     return: integer
     index-semantics: true
     sleep: 0.0
-    tooltip: Returns the first index (where Start <= index <= End) where Find appears in ListVariable. Steps through
-      ListVariable by Stride.  Returns -1 if not found.
+    tooltip: Returns the integer index of the first instance of list test in the
+      strided list src within the range from start to end (stepping through by
+      stride). Returns -1 if not found.
     categories:
       - list
   llListInsertList:
     type-arguments: [T]
     arguments:
-    - Target:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - ListVariable:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Position:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - dest:
+          tooltip: The target destination list.
+          type: list
+          slua-type: '{T}'
+      - src:
+          tooltip: The source list to insert.
+          type: list
+          slua-type: '{T}'
+      - start:
+          tooltip: The zero-based index where insertion begins.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: table.insert
       reason: Unnecessary table copying. Fastcall.
       selene-replace:
-      - "table.insert(%1, %3, %2[1])"
-      - "table.move(%2, 1, #%2, %3, %1)"
+        - "table.insert(%1, %3, %2[1])"
+        - "table.move(%2, 1, #%2, %3, %1)"
     energy: 10.0
     func-id: 200
     native: true
@@ -11245,52 +11873,50 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns a list that contains all the elements from Target but with the
-      elements from ListVariable inserted at Position start.\nReturns a new list,
-      created by inserting ListVariable into the Target list at Position. Note this
-      does not alter the Target.
+    tooltip: Returns a new list containing all elements of dest with the elements of
+      src inserted starting at index start. Does not modify dest itself.
     categories:
       - list
   llListRandomize:
     type-arguments: [T]
     arguments:
-    - ListVariable:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Stride:
-        tooltip: ''
-        type: integer
+      - src:
+          tooltip: The source list to randomize.
+          type: list
+          slua-type: '{T}'
+      - stride:
+          tooltip: The size of each randomized block (defaults to 1 if less than 1).
+          type: integer
     energy: 10.0
     func-id: 197
     must-use: true
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns a version of the input ListVariable which has been randomized
-      by blocks of size Stride.\nIf the remainder from the length of the list, divided
-      by the stride is non-zero, this function does not randomize the list.
+    tooltip: Returns a randomized copy of the list src by blocks of size stride. If
+      the list length is not perfectly divisible by stride, no randomization
+      occurs.
     categories:
       - list
   llListReplaceList:
     type-arguments: [T]
     arguments:
-    - Target:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - ListVariable:
-        tooltip: ''
-        type: list
-        slua-type: '{T}'
-    - Start:
-        tooltip: ''
-        type: integer
-        index-semantics: true
-    - End:
-        tooltip: ''
-        type: integer
-        index-semantics: true
+      - dest:
+          tooltip: The target destination list.
+          type: list
+          slua-type: '{T}'
+      - src:
+          tooltip: The source list to insert.
+          type: list
+          slua-type: '{T}'
+      - start:
+          tooltip: The zero-based start index (inclusive) of the replaced range.
+          type: integer
+          index-semantics: true
+      - end:
+          tooltip: The zero-based end index (inclusive) of the replaced range.
+          type: integer
+          index-semantics: true
     slua-deprecated:
       use: 't[n] = x'
       reason: Unnecessary table copying.
@@ -11302,58 +11928,56 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns a list that is Target with Start through End removed and ListVariable
-      inserted at Start.\nReturns a list replacing the slice of the Target list from
-      Start to End with the specified ListVariable. Start and End are inclusive, so
-      0, 1 would replace the first two entries and 0, 0 would replace only the first
-      list entry.
+    tooltip: Returns a copy of the list dest with the inclusive range from start to
+      end removed, and the elements of src inserted in its place at start.
     categories:
       - list
   llListSort:
     type-arguments: [T]
     arguments:
-    - ListVariable:
-        tooltip: List to sort.
-        type: list
-        slua-type: '{T}'
-    - Stride:
-        tooltip: Stride length.
-        type: integer
-    - Ascending:
-        tooltip: Boolean. TRUE = result in ascending order, FALSE = result in descending
-          order.
-        type: integer
-        bool-semantics: true
+      - src:
+          tooltip: The list to be sorted.
+          type: list
+          slua-type: '{T}'
+      - stride:
+          tooltip: The number of entries per block/stride (defaults to 1 if less than 1).
+          type: integer
+      - ascending:
+          tooltip: Boolean. If TRUE, sorts in ascending order; if FALSE, sorts in
+            descending order.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 184
     must-use: true
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns the specified list, sorted into blocks of stride in ascending
-      order (if Ascending is TRUE, otherwise descending). Note that sort only works
-      if the first entry of each block is the same datatype.
+    tooltip: Returns a copy of the list src, sorted into blocks of stride in
+      ascending order (if ascending is TRUE) or descending order (if FALSE).
+      Only works if the first entry of each block shares the same datatype.
     categories:
       - list
   llListSortStrided:
     type-arguments: [T]
     arguments:
-    - ListVariable:
-        tooltip: List to sort.
-        type: list
-        slua-type: '{T}'
-    - Stride:
-        tooltip: Stride length.
-        type: integer
-    - Sortkey:
-        tooltip: The zero based element within the stride to use as the sort key
-        type: integer
-        index-semantics: true
-    - Ascending:
-        tooltip: Boolean. TRUE = result in ascending order, FALSE = result in descending
-          order.
-        type: integer
-        bool-semantics: true
+      - src:
+          tooltip: The list to be sorted.
+          type: list
+          slua-type: '{T}'
+      - stride:
+          tooltip: The number of entries per block/stride (defaults to 1 if less than 1).
+          type: integer
+      - stride_index:
+          tooltip: The zero-based index of the element within each stride to use as the
+            sort key (negatives count backward from the end of the stride).
+          type: integer
+          index-semantics: true
+      - ascending:
+          tooltip: Boolean. If TRUE, sorts in ascending order; if FALSE, sorts in
+            descending order.
+          type: integer
+          bool-semantics: true
     slua-deprecated:
       use: table.sort
       reason: Prefer structured tables over strided lists.
@@ -11363,123 +11987,119 @@ functions:
     return: list
     slua-return: '{T}'
     sleep: 0.0
-    tooltip: Returns the specified list, sorted by the specified element into blocks
-      of stride in ascending order (if Ascending is TRUE, otherwise descending). Note
-      that sort only works if the first entry of each block is the same datatype.
+    tooltip: Returns a copy of the list src sorted into blocks of stride by the
+      element at stride_index in each block. Sorted in ascending order (if
+      ascending is TRUE) or descending order (if FALSE).
     categories:
       - list
   llListStatistics:
     arguments:
-    - Operation:
-        tooltip: One of LIST_STAT_* values
-        type: integer
-    - ListVariable:
-        tooltip: Variable to analyze.
-        type: list
+      - operation:
+          tooltip: The LIST_STAT_* constant of the statistical operation to perform.
+          type: integer
+      - src:
+          tooltip: The list of floats and integers to analyze.
+          type: list
     energy: 10.0
     func-id: 315
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Performs a statistical aggregate function, specified by a LIST_STAT_*
-      constant, on ListVariables.\nThis function allows a script to perform a statistical
-      operation as defined by operation on a list composed of integers and floats.
+    tooltip: Returns a float representing the result of performing the statistical
+      aggregate function operation (a LIST_STAT_* constant) on the numeric list
+      src.
     categories:
       - list
       - math
   llListen:
     arguments:
-    - Channel:
-        tooltip: ''
-        type: integer
-    - SpeakersName:
-        tooltip: ''
-        type: string
-    - SpeakersID:
-        tooltip: ''
-        type: key
-    - Text:
-        tooltip: ''
-        type: string
+      - channel:
+          tooltip: The input chat channel to listen on (any integer from -2147483648 to
+            2147483647).
+          type: integer
+      - name:
+          tooltip: The specific prim name or avatar legacy name to filter by (or empty
+            string for no filter).
+          type: string
+      - id:
+          tooltip: The specific avatar or prim UUID to filter by (or NULL_KEY for no
+            filter).
+          type: key
+      - msg:
+          tooltip: The specific chat message string to filter by (or empty string for no
+            filter).
+          type: string
     energy: 10.0
     func-id: 25
     return: integer
     sleep: 0.0
-    tooltip: Creates a listen callback for Text on Channel from SpeakersName and SpeakersID
-      (SpeakersName, SpeakersID, and/or Text can be empty) and returns an identifier
-      that can be used to deactivate or remove the listen.\nNon-empty values for SpeakersName,
-      SpeakersID, and Text will filter the results accordingly, while empty strings
-      and NULL_KEY will not filter the results, for string and key parameters respectively.\nPUBLIC_CHANNEL
-      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
-      is the script debug channel, and is also visible to nearby avatars. All other
-      channels are are not sent to avatars, but may be used to communicate with scripts.
+    tooltip: Creates a listener on channel from name and id for msg. Returns an
+      integer listener handle used to control or remove the listener. Empty
+      strings or NULL_KEY filters do not filter on those parameters.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llListenControl:
     arguments:
-    - ChannelHandle:
-        tooltip: ''
-        type: integer
-    - Active:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
+      - handle:
+          tooltip: The integer listener handle returned by llListen.
+          type: integer
+      - active:
+          tooltip: Boolean. If TRUE, activates the listener; if FALSE, deactivates it.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 26
     return: void
     sleep: 0.0
-    tooltip: Makes a listen event callback active or inactive. Pass in the value returned
-      from llListen to the iChannelHandle parameter to specify which listener you
-      are controlling.\nUse boolean values to specify Active
+    tooltip: Enables or disables the listener specified by the integer handle. If
+      active is TRUE, the listener is activated; if FALSE, it is deactivated.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llListenRemove:
     arguments:
-    - ChannelHandle:
-        tooltip: ''
-        type: integer
+      - handle:
+          tooltip: The integer listener handle returned by llListen to remove.
+          type: integer
     energy: 10.0
     func-id: 27
     return: void
     sleep: 0.0
-    tooltip: Removes a listen event callback. Pass in the value returned from llListen
-      to the iChannelHandle parameter to specify which listener to remove.
+    tooltip: Completely removes the listener specified by the integer handle.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llLoadURL:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Text:
-        tooltip: ''
-        type: string
-    - URL:
-        tooltip: ''
-        type: string
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
+      - message:
+          tooltip: The text message to display in the dialog box.
+          type: string
+      - url:
+          tooltip: The web URL to open.
+          type: string
     energy: 10.0
     func-id: 297
     return: void
     sleep: 0.1
-    tooltip: "Shows dialog to avatar AvatarID offering to load web page at URL.\t\
-      If user clicks yes, launches their web browser.\\nllLoadURL displays a dialogue\
-      \ box to the user, offering to load the specified web page using the default\
-      \ web browser."
+    tooltip: Shows a dialog box displaying message to the avatar avatar offering to
+      open the specified url. Clicking yes launches the URL in their default web
+      browser.
     categories:
       - avatar_communication
       - user_interface
       - web
   llLog:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The float value to evaluate.
+          type: float
     slua-deprecated:
       use: math.log
       reason: Double precision; fastcall.
@@ -11490,15 +12110,15 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the natural logarithm of Value. Returns zero if Value <= 0.\nReturns
-      the base e (natural) logarithm of the specified Value.
+    tooltip: Returns a float representing the natural (base e) logarithm of the
+      positive value val (returns 0.0 if val <= 0).
     categories:
       - math
   llLog10:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The float value to evaluate.
+          type: float
     slua-deprecated:
       use: math.log10
       reason: Double precision; fastcall.
@@ -11509,487 +12129,476 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the base 10 logarithm of Value. Returns zero if Value <= 0.\nReturns
-      the base 10 (common) logarithm of the specified Value.
+    tooltip: Returns a float representing the base-10 (common) logarithm of the
+      positive value val (returns 0.0 if val <= 0).
     categories:
       - math
   llLookAt:
     arguments:
-    - Target:
-        tooltip: ''
-        type: vector
-    - Strength:
-        tooltip: ''
-        type: float
-    - Damping:
-        tooltip: ''
-        type: float
+      - target:
+          tooltip: The target position vector in region coordinates to look at.
+          type: vector
+      - strength:
+          tooltip: The force of rotation (0.0 cancels the tracking; values around half the
+            object's mass are typical).
+          type: float
+      - damping:
+          tooltip: The timescale in seconds to critically damp the orientation.
+          type: float
     energy: 10.0
     func-id: 105
     return: void
     sleep: 0.0
-    tooltip: Cause object name to point its forward axis towards Target, at a force
-      controlled by Strength and Damping.\nGood Strength values are around half the
-      mass of the object and good Damping values are less than 1/10th of the Strength.\nAsymmetrical
-      shapes require smaller Damping. A Strength of 0.0 cancels the look at.
+    tooltip: Causes the object to orient its positive Z-axis (up axis) toward the
+      target vector, keeping its positive X-axis (forward axis) below the
+      horizon. Tracks target until llStopLookAt is called or strength is set to
+      0.0.
     categories:
       - movement
       - physics
   llLoopSound:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 87
     return: void
     sleep: 0.0
-    tooltip: Plays specified Sound, looping indefinitely, at Volume (0.0 - 1.0).\nOnly
-      one sound may be attached to an object at a time.\nA second call to llLoopSound
-      with the same key will not restart the sound, but the new volume will be used.
-      This allows control over the volume of already playing sounds.\nSetting the
-      volume to 0 is not the same as calling llStopSound; a sound with 0 volume will
-      continue to loop.\nTo restart the sound from the beginning, call llStopSound
-      before calling llLoopSound again.
+    tooltip: Plays the attached sound looping indefinitely at the specified volume.
+      Only one sound can be attached to a prim at a time; new loops adjust the
+      volume of the currently playing sound without restarting it.
     categories:
       - sound
   llLoopSoundMaster:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 88
     return: void
     sleep: 0.0
-    tooltip: Plays attached Sound, looping at volume (0.0 - 1.0), and declares it
-      a sync master.\nBehaviour is identical to llLoopSound, with the addition of
-      marking the source as a "Sync Master", causing "Slave" sounds to sync to it.
-      If there are multiple masters within a viewers interest area, the most audible
-      one (a function of both distance and volume) will win out as the master.\nThe
-      use of multiple masters within a small area is unlikely to produce the desired
-      effect.
+    tooltip: Plays the attached sound looping indefinitely at the specified volume
+      and declares it a Sync Master, forcing slave sounds to synchronize with
+      it.
     categories:
       - sound
   llLoopSoundSlave:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 89
     return: void
     sleep: 0.0
-    tooltip: Plays attached sound looping at volume (0.0 - 1.0), synced to most audible
-      sync master.\nBehaviour is identical to llLoopSound, unless there is a "Sync
-      Master" present.\nIf a Sync Master is already playing the Slave sound will begin
-      playing from the same point the master is in its loop synchronizing the loop
-      points of both sounds.\nIf a Sync Master is started when the Slave is already
-      playing, the Slave will skip to the correct position to sync with the Master.
+    tooltip: Plays the attached sound looping indefinitely at the specified volume,
+      synchronized to the most audible active Sync Master in range.
     categories:
       - sound
   llMD5String:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
-    - Nonce:
-        tooltip: ''
-        type: integer
+      - src:
+          tooltip: The source string to hash.
+          type: string
+      - nonce:
+          tooltip: The nonce string used as a salt.
+          type: integer
     energy: 10.0
     func-id: 258
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string of 32 hex characters that is an RSA Data Security Inc.,
-      MD5 Message-Digest Algorithm of Text with Nonce used as the salt.\nReturns a
-      32-character hex string. (128-bit in binary.)
+    tooltip: Returns a string of 32 hex characters representing the MD5 checksum of
+      src salted with nonce (formatted as ':' + nonce).
     categories:
       - cryptography
   llMakeExplosion:
     arguments:
-    - Particles:
-        tooltip: ''
-        type: integer
-    - Scale:
-        tooltip: ''
-        type: float
-    - Velocity:
-        tooltip: ''
-        type: float
-    - Lifetime:
-        tooltip: ''
-        type: float
-    - Arc:
-        tooltip: ''
-        type: float
-    - Texture:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Offset:
-        tooltip: ''
-        type: vector
+      - particles:
+          tooltip: ""
+          type: integer
+      - scale:
+          tooltip: ""
+          type: float
+      - vel:
+          tooltip: ""
+          type: float
+      - lifetime:
+          tooltip: ""
+          type: float
+      - arc:
+          tooltip: ""
+          type: float
+      - texture:
+          tooltip: The name of a texture in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - offset:
+          tooltip: The offset relative to the prim's position (expressed in local
+            coordinates; completely ignored by the system).
+          type: vector
     deprecated:
       use: ll.ParticleSystem
     energy: 10.0
     func-id: 100
     return: void
     sleep: 0.1
-    tooltip: 'Make a round explosion of particles. Deprecated: Use llParticleSystem
-      instead.\nMake a round explosion of particles using texture from the objects
-      inventory. Deprecated: Use llParticleSystem instead.'
+    tooltip: Deprecated. Generates a circular explosion of particles. Use
+      llParticleSystem instead.
     categories:
       - effects
   llMakeFire:
     arguments:
-    - Particles:
-        tooltip: ''
-        type: integer
-    - Scale:
-        tooltip: ''
-        type: float
-    - Velocity:
-        tooltip: ''
-        type: float
-    - Lifetime:
-        tooltip: ''
-        type: float
-    - Arc:
-        tooltip: ''
-        type: float
-    - Texture:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Offset:
-        tooltip: ''
-        type: vector
+      - particles:
+          tooltip: ""
+          type: integer
+      - scale:
+          tooltip: ""
+          type: float
+      - vel:
+          tooltip: ""
+          type: float
+      - lifetime:
+          tooltip: ""
+          type: float
+      - arc:
+          tooltip: ""
+          type: float
+      - texture:
+          tooltip: The name of a texture in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - offset:
+          tooltip: The offset relative to the prim's position (expressed in local
+            coordinates; completely ignored by the system).
+          type: vector
     deprecated:
       use: ll.ParticleSystem
     energy: 10.0
     func-id: 103
     return: void
     sleep: 0.1
-    tooltip: 'Make fire like particles. Deprecated: Use llParticleSystem instead.\nMake
-      fire particles using texture from the objects inventory. Deprecated: Use llParticleSystem
-      instead.'
+    tooltip: Deprecated. Generates fire-like particles. Use llParticleSystem instead.
     categories:
       - effects
   llMakeFountain:
     arguments:
-    - Particles:
-        tooltip: ''
-        type: integer
-    - Scale:
-        tooltip: ''
-        type: float
-    - Velocity:
-        tooltip: ''
-        type: float
-    - Lifetime:
-        tooltip: ''
-        type: float
-    - Arc:
-        tooltip: ''
-        type: float
-    - Bounce:
-        tooltip: ''
-        type: integer
-    - Texture:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Offset:
-        tooltip: ''
-        type: vector
-    - Bounce_Offset:
-        tooltip: ''
-        type: float
+      - particles:
+          tooltip: ""
+          type: integer
+      - scale:
+          tooltip: ""
+          type: float
+      - vel:
+          tooltip: ""
+          type: float
+      - lifetime:
+          tooltip: ""
+          type: float
+      - arc:
+          tooltip: ""
+          type: float
+      - bounce:
+          tooltip: ""
+          type: integer
+      - texture:
+          tooltip: The name of a texture in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - offset:
+          tooltip: The offset relative to the prim's position (expressed in local
+            coordinates; completely ignored by the system).
+          type: vector
+      - bounce_offset:
+          tooltip: ""
+          type: float
     deprecated:
       use: ll.ParticleSystem
     energy: 10.0
     func-id: 101
     return: void
     sleep: 0.1
-    tooltip: 'Make a fountain of particles. Deprecated: Use llParticleSystem instead.\nMake
-      a fountain of particles using texture from the objects inventory. Deprecated:
-      Use llParticleSystem instead.'
+    tooltip: Deprecated. Generates a fountain of particles. Use llParticleSystem
+      instead.
     categories:
       - effects
   llMakeSmoke:
     arguments:
-    - Particles:
-        tooltip: ''
-        type: integer
-    - Scale:
-        tooltip: ''
-        type: float
-    - Velocity:
-        tooltip: ''
-        type: float
-    - Lifetime:
-        tooltip: ''
-        type: float
-    - Arc:
-        tooltip: ''
-        type: float
-    - Texture:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Offset:
-        tooltip: ''
-        type: vector
+      - particles:
+          tooltip: ""
+          type: integer
+      - scale:
+          tooltip: ""
+          type: float
+      - vel:
+          tooltip: ""
+          type: float
+      - lifetime:
+          tooltip: ""
+          type: float
+      - arc:
+          tooltip: ""
+          type: float
+      - texture:
+          tooltip: The name of a texture in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - offset:
+          tooltip: The offset relative to the prim's position (expressed in local
+            coordinates; completely ignored by the system).
+          type: vector
     deprecated:
       use: ll.ParticleSystem
     energy: 10.0
     func-id: 102
     return: void
     sleep: 0.1
-    tooltip: 'Make smoke like particles. Deprecated: Use llParticleSystem instead.\nMake
-      smoky particles using texture from the objects inventory. Deprecated: Use llParticleSystem
-      instead.'
+    tooltip: Deprecated. Generates smoke-like particles. Use llParticleSystem instead.
     categories:
       - effects
   llManageEstateAccess:
     arguments:
-    - Action:
-        tooltip: One of the ESTATE_ACCESS_ALLOWED_* actions.
-        type: integer
-    - AvatarID:
-        tooltip: UUID of the avatar or group to act upon.
-        type: key
+      - action:
+          tooltip: An ESTATE_ACCESS_* action flag specifying the operation to perform.
+          type: integer
+      - avatar:
+          tooltip: The UUID of the avatar or group to add or remove.
+          type: key
     energy: 10.0
     func-id: 393
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Adds or removes agents from the estate's agent access or ban lists, or
-      groups to the estate's group access list. Action is one of the ESTATE_ACCESS_ALLOWED_*
-      operations to perform.\nReturns an integer representing a boolean, TRUE if the
-      call was successful; FALSE if throttled, invalid action, invalid or null id
-      or object owner is not allowed to manage the estate.\nThe object owner is notified
-      of any changes, unless PERMISSION_SILENT_ESTATE_MANAGEMENT has been granted
-      to the script.
+    tooltip: Adds or removes agents from the estate's access or ban lists, or groups
+      from the estate's group access list, specified by the action. Returns TRUE
+      if successful, or FALSE if throttled, if the action/ID is invalid, or if
+      the script owner lacks estate management rights.
     categories:
       - land_moderation
   llMapBeacon:
     arguments:
-    - RegionName:
-        tooltip: Region in which to show the beacon.
-        type: string
-    - Position:
-        tooltip: Position within region to show the beacon.
-        type: vector
-    - Options:
-        tooltip: Options
-        type: list
+      - region_name:
+          tooltip: The name of the region where the beacon is displayed.
+          type: string
+      - pos:
+          tooltip: The position vector in region coordinates to highlight.
+          type: vector
+      - options:
+          tooltip: A list of options to configure the map beacon.
+          type: list
     energy: 10.0
     func-id: 516
     return: void
     sleep: 1.0
-    tooltip: Displays an in world beacon and optionally opens world map for avatar
-      who touched the object or is wearing the script, centered on RegionName with
-      Position highlighted. Only works for scripts attached to avatar, or during touch
-      events.
+    tooltip: Displays an in-world beacon and optionally opens the world map for the
+      avatar touching or wearing the object, centered on region_name with pos
+      highlighted. Only works for attached scripts or during touch events.
     categories:
       - avatar_communication
       - user_interface
   llMapDestination:
     arguments:
-    - RegionName:
-        tooltip: ''
-        type: string
-    - Position:
-        tooltip: ''
-        type: vector
-    - Direction:
-        tooltip: ''
-        type: vector
+      - simname:
+          tooltip: The name of the target simulator region.
+          type: string
+      - pos:
+          tooltip: The position vector in region coordinates to highlight.
+          type: vector
+      - look_at:
+          tooltip: Position in local coordinates (currently unused/ignored).
+          type: vector
     energy: 10.0
     func-id: 309
     return: void
     sleep: 1.0
-    tooltip: Opens world map for avatar who touched it or is wearing the script, centred
-      on RegionName with Position highlighted. Only works for scripts attached to
-      avatar, or during touch events.\nDirection currently has no effect.
+    tooltip: "Opens the world map for the avatar touching or wearing the object,
+      centered on simname with pos highlighted. Only works for attached scripts
+      or during touch events. Note: look_at currently has no effect."
     categories:
       - avatar_communication
       - user_interface
   llMessageLinked:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
-    - Number:
-        tooltip: ''
-        type: integer
-    - Text:
-        tooltip: ''
-        type: string
-        slua-type: string | uuid
-    - ID:
-        tooltip: ''
-        type: key
-        slua-type: string | uuid
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag
+            controlling which prim(s) receive the message.
+          type: integer
+      - num:
+          tooltip: An integer value passed as the second parameter of the link_message
+            event.
+          type: integer
+      - str:
+          tooltip: A string value passed as the third parameter of the link_message event.
+          type: string
+          slua-type: string | uuid
+      - id:
+          tooltip: A key value passed as the fourth parameter of the link_message event.
+          type: key
+          slua-type: string | uuid
     energy: 10.0
     func-id: 164
     return: void
     sleep: 0.0
-    tooltip: Sends Number, Text, and ID to members of the link set identified by LinkNumber.\nLinkNumber
-      is either a linked number (available through llGetLinkNumber) or a LINK_* constant.
+    tooltip: Triggers a link_message event, sending num, str, and id to the scripts
+      in the prim(s) specified by link to allow scripts within the same object
+      to communicate.
     categories:
       - script_communication
   llMinEventDelay:
     arguments:
-    - Delay:
-        tooltip: ''
-        type: float
+      - delay:
+          tooltip: The minimum delay duration in seconds.
+          type: float
     energy: 10.0
     func-id: 125
     return: void
     sleep: 0.0
-    tooltip: Set the minimum time between events being handled.
+    tooltip: Sets the minimum delay time between events being handled (minimums and
+      defaults vary by event type).
     categories:
       - script
   llModPow:
     arguments:
-    - Value:
-        tooltip: ''
-        type: integer
-    - Power:
-        tooltip: ''
-        type: integer
-    - Modulus:
-        tooltip: ''
-        type: integer
+      - a:
+          tooltip: The base integer value.
+          type: integer
+      - b:
+          tooltip: The power exponent (capped at 0xFFFF / 16 bits).
+          type: integer
+      - c:
+          tooltip: The modulus integer value.
+          type: integer
     energy: 10.0
     func-id: 300
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns a Value raised to the Power, mod Modulus. ((a**b)%c) b is capped
-      at 0xFFFF (16 bits).\nReturns (Value ^ Power) % Modulus. (Value raised to the
-      Power, Modulus). Value is capped at 0xFFFF (16 bits).
+    tooltip: Returns an integer representing a raised to the power b, modulo c
+      (i.e., (a**b)%c). The b value is capped at 0xFFFF (16 bits).
     categories:
       - math
   llModifyLand:
     arguments:
-    - Action:
-        tooltip: LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH, LAND_NOISE or LAND_REVERT
-        type: integer
-    - Area:
-        tooltip: 0, 1, 2 (2m x 2m, 4m x 4m, or 8m x 8m)
-        type: integer
+      - action:
+          tooltip: The LAND_* action flag to perform (e.g., LAND_LEVEL, LAND_RAISE,
+            LAND_LOWER, LAND_SMOOTH, LAND_NOISE, or LAND_REVERT).
+          type: integer
+      - brush:
+          tooltip: The brush size (0, 1, or 2, representing 2m x 2m, 4m x 4m, or 8m x 8m).
+          type: integer
     energy: 10.0
     func-id: 159
     return: void
     sleep: 0.0
-    tooltip: Modify land with action (LAND_LEVEL, LAND_RAISE, LAND_LOWER, LAND_SMOOTH,
-      LAND_NOISE, LAND_REVERT) on size (0, 1, 2, corresponding to 2m x 2m, 4m x 4m,
-      8m x 8m).
+    tooltip: Modifies the terrain using the specified land action and brush size (0,
+      1, or 2, corresponding to 2m x 2m, 4m x 4m, or 8m x 8m).
     categories:
       - region
   llMoveToTarget:
     arguments:
-    - Target:
-        tooltip: ''
-        type: vector
-    - Tau:
-        tooltip: ''
-        type: float
+      - target:
+          tooltip: The target position vector in region coordinates.
+          type: vector
+      - tau:
+          tooltip: The timescale in seconds to critically damp the movement.
+          type: float
     energy: 10.0
     func-id: 70
     return: void
     sleep: 0.0
-    tooltip: Critically damp to Target in Tau seconds (if the script is physical).\nCritically
-      damp to position target in tau-seconds if the script is physical. Good tau-values
-      are greater than 0.2. A tau of 0.0 stops the critical damping.
+    tooltip: Critically damps the physical object's motion to position target in tau
+      seconds. Setting tau to 0.0 stops the critical damping; recommended tau
+      values are greater than 0.2.
     categories:
       - movement
       - physics
   llName2Key:
     arguments:
-    - Name:
-        tooltip: Name of agent in region to look up.
-        type: string
+      - name:
+          tooltip: The name of the avatar (e.g., 'First Last' or 'first.last').
+          type: string
     energy: 10.0
     func-id: 524
     must-use: true
     return: key
     sleep: 0.0
-    tooltip: Look up Agent ID for the named agent in the region.
+    tooltip: Requests the key (UUID) of the avatar name in the current region.
+      Returns NULL_KEY if no matching agent is present. Formats are 'First Last'
+      or 'first.last' (assumes 'Resident' if last name is omitted;
+      case-insensitive).
     categories:
       - avatar
   llNavigateTo:
     arguments:
-    - Location:
-        tooltip: Region coordinates for the character to navigate to.
-        type: vector
-    - Options:
-        tooltip: List of parameters to control the type of path-finding used. Currently
-          only FORCE_DIRECT_PATH supported.
-        type: list
+      - pos:
+          tooltip: The destination position vector in region coordinates.
+          type: vector
+      - options:
+          tooltip: A list of parameters to configure pathfinding behavior (currently only
+            FORCE_DIRECT_PATH is supported).
+          type: list
     energy: 10.0
     func-id: 398
     return: void
     sleep: 0.0
-    tooltip: Navigate to destination.\nDirects an object to travel to a defined position
-      in the region or adjacent regions.
+    tooltip: Directs a pathfinding character to navigate to the position pos
+      (located in the current or adjacent regions) using the parameters
+      specified in options.
     categories:
       - pathfinding
   llOffsetTexture:
     arguments:
-    - OffsetS:
-        tooltip: ''
-        type: float
-    - OffsetT:
-        tooltip: ''
-        type: float
-    - Face:
-        tooltip: ''
-        type: integer
+      - u:
+          tooltip: The horizontal (U) offset, typically in the interval [-1.0, 1.0].
+          type: float
+      - v:
+          tooltip: The vertical (V) offset, typically in the interval [-1.0, 1.0].
+          type: float
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 55
     return: void
     sleep: 0.2
-    tooltip: Sets the texture S and T offsets for the chosen Face.\nIf Face is ALL_SIDES
-      this function sets the texture offsets for all faces.
+    tooltip: Sets the texture horizontal (u) and vertical (v) offsets for the chosen
+      face. If face is ALL_SIDES, offsets all faces.
     categories:
       - prim
       - prim_appearance
   llOpenFloater:
     arguments:
-    - floater_name:
-        tooltip: Identifier for floater to open
-        type: string
-    - url:
-        tooltip: URL to pass to floater
-        type: string
-    - params:
-        tooltip: Parameters to apply to open floater
-        type: list
+      - floater_name:
+          tooltip: The identifier string of the viewer floater to open.
+          type: string
+      - url:
+          tooltip: The URL to load within the opened floater.
+          type: string
+      - params:
+          tooltip: Options or parameters to apply to the opened floater.
+          type: list
     energy: 10.0
     linden-experience: true
     func-id: 604
     mono-sleep: 0.2
     return: integer
     sleep: 0.0
-    tooltip: Returns the value for header for request_id.\nReturns a string that is
-      the value of the Header for HTTPRequestID.
+    tooltip: Opens the specified viewer floater_name loaded with url and configured
+      via params. Returns an integer error code, or 0 if successful.
     categories:
       - avatar_communication
   llOpenRemoteDataChannel:
@@ -11999,47 +12608,48 @@ functions:
     func-id: 254
     return: void
     sleep: 1.0
-    tooltip: This function is deprecated.
+    tooltip: Deprecated. Creates a channel to listen for incoming XML-RPC calls,
+      triggering a remote_data event with the channel ID once available.
     categories:
       - script_communication
   llOrd:
     arguments:
-    - value:
-        tooltip: The string to convert to Unicode.
-        type: string
-    - index:
-        tooltip: Index of character to convert to unicode.
-        type: integer
-        index-semantics: true
+      - val:
+          tooltip: The source string containing the character.
+          type: string
+      - index:
+          tooltip: The zero-based index of the character to convert.
+          type: integer
+          index-semantics: true
     energy: 10.0
     func-id: 527
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns the unicode value of the indicated character in the string.
+    tooltip: Returns the integer Unicode (ordinal) value of the character at index
+      in the string val.
     categories:
       - string
   llOverMyLand:
     arguments:
-    - ID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the group, avatar, or object to check.
+          type: key
     energy: 10.0
     func-id: 215
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if id ID over land owned by the script owner, otherwise
-      FALSE.\nReturns TRUE if key ID is over land owned by the object owner, FALSE
-      otherwise.
+    tooltip: Returns TRUE if the avatar or object specified by key id is over land
+      owned by the script owner, or FALSE otherwise.
     categories:
       - parcel
   llOwnerSay:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - msg:
+          tooltip: The text message string to send.
+          type: string
     slua-deprecated:
       use: "print"
       selene-replace: ["print(%...)"]
@@ -12047,32 +12657,33 @@ functions:
     func-id: 292
     return: void
     sleep: 0.0
-    tooltip: says Text to owner only (if owner is in region).\nSays Text to the owner
-      of the object running the script, if the owner has been within the object's
-      simulator since logging into Second Life, regardless of where they may be in-world.
+    tooltip: Sends the chat message msg privately to the object owner (the owner
+      must be currently in the same region for the message to be received).
     categories:
       - avatar_communication
   llParcelMediaCommandList:
     arguments:
-    - CommandList:
-        tooltip: 'A list of PARCEL_MEDIA_COMMAND_* flags and their parameters '
-        type: list
+      - commandList:
+          tooltip: A list containing integer PARCEL_MEDIA_COMMAND_* flags and their
+            corresponding parameters.
+          type: list
     energy: 10.0
     func-id: 298
     return: void
     sleep: 2.0
-    tooltip: Controls the playback of multimedia resources on a parcel or for an agent,
-      via one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.
+    tooltip: Controls the playback of movies and other multimedia resources on a
+      parcel or for an agent, using the PARCEL_MEDIA_COMMAND_* settings
+      specified in commandList.
     categories:
       - media
       - parcel
       - parcel_media
   llParcelMediaQuery:
     arguments:
-    - QueryList:
-        tooltip: ''
-        type: list
-        slua-type: "{number}"
+      - query:
+          tooltip: A list of PARCEL_MEDIA_COMMAND_* attributes to query.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 299
     must-use: true
@@ -12080,199 +12691,185 @@ functions:
     # There may be some bool-like entries in the list we need to convert
     bool-semantics: true
     sleep: 2.0
-    tooltip: Queries the media properties of the parcel containing the script, via
-      one or more PARCEL_MEDIA_COMMAND_* arguments specified in CommandList.\nThis
-      function will only work if the script is contained within an object owned by
-      the land-owner (or if the land is owned by a group, only if the object has been
-      deeded to the group).
+    tooltip: Queries the media properties of the parcel containing the script,
+      returning a list of values in the order requested by query. Only works if
+      the object is owned by the landowner or deeded to the land's group.
     categories:
       - media
       - parcel
       - parcel_media
   llParseString2List:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
-    - Separators:
-        tooltip: ''
-        type: list
-        slua-type: '{string}'
-    - Spacers:
-        tooltip: ''
-        type: list
-        slua-type: '{string}'
+      - src:
+          tooltip: The source string to parse.
+          type: string
+      - separators:
+          tooltip: A list of up to 8 strings representing separators to be discarded.
+          type: list
+          slua-type: '{string}'
+      - spacers:
+          tooltip: A list of up to 8 strings representing spacers to be preserved in the
+            list.
+          type: list
+          slua-type: '{string}'
     energy: 10.0
     func-id: 214
     pure: true
     return: list
     slua-return: '{string}'
     sleep: 0.0
-    tooltip: Converts Text into a list, discarding Separators, keeping Spacers (Separators
-      and Spacers must be lists of strings, maximum of 8 each).\nSeparators and Spacers
-      are lists of strings with a maximum of 8 entries each.
+    tooltip: Breaks the string src into a list of substrings, discarding any
+      separators, keeping spacers, and omitting any empty null values.
+      separators and spacers accept up to 8 string entries each.
     categories:
       - data_conversion
   llParseStringKeepNulls:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
-    - Separators:
-        tooltip: ''
-        type: list
-        slua-type: '{string}'
-    - Spacers:
-        tooltip: ''
-        type: list
-        slua-type: '{string}'
+      - src:
+          tooltip: The source string to parse.
+          type: string
+      - separators:
+          tooltip: A list of up to 8 strings representing separators to be discarded.
+          type: list
+          slua-type: '{string}'
+      - spacers:
+          tooltip: A list of up to 8 strings representing spacers to be preserved in the
+            list.
+          type: list
+          slua-type: '{string}'
     energy: 10.0
     func-id: 285
     pure: true
     return: list
     slua-return: '{string}'
     sleep: 0.0
-    tooltip: Breaks Text into a list, discarding separators, keeping spacers, keeping
-      any null values generated. (separators and spacers must be lists of strings,
-      maximum of 8 each).\nllParseStringKeepNulls works almost exactly like llParseString2List,
-      except that if a null is found it will add a null-string instead of discarding
-      it like llParseString2List does.
+    tooltip: Breaks the string src into a list, discarding separators and keeping
+      spacers, while preserving empty null values (unlike llParseString2List).
+      separators and spacers accept up to 8 string entries each.
     categories:
       - data_conversion
   llParticleSystem:
     arguments:
-    - Parameters:
-        tooltip: ''
-        type: list
+      - rules:
+          tooltip: A list of particle system rules and data pairs [rule1, data1, ...].
+          type: list
     energy: 10.0
     func-id: 229
     return: void
     sleep: 0.0
-    tooltip: Creates a particle system in the prim the script is attached to, based
-      on Parameters. An empty list removes a particle system from object.\nList format
-      is [ rule-1, data-1, rule-2, data-2 ... rule-n, data-n ].
+    tooltip: Creates or updates a particle system on the prim containing the script
+      based on rules. An empty list removes the particle system.
     categories:
       - effects
       - particles
   llPassCollisions:
     arguments:
-    - Pass:
-        tooltip: Boolean, if TRUE, collisions are passed from children on to parents.
-        type: integer
-        bool-semantics: true
+      - pass:
+          tooltip: A PASS_* flag (e.g., PASS_ALWAYS, PASS_IF_NOT_HANDLED, or PASS_NEVER).
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 166
     return: void
     sleep: 0.0
-    tooltip: Configures how collision events are passed to scripts in the linkset.\nIf
-      Pass == TRUE, collisions involving collision-handling scripted child prims are
-      also passed on to the root prim. If Pass == FALSE (default behavior), such collisions
-      will only trigger events in the affected child prim.
+    tooltip: Sets the pass-collisions attribute. If pass is TRUE, collision events
+      are passed from child prims to the root; if FALSE (default), they only
+      trigger events in the affected child prim.
     categories:
       - physics
       - sensor
   llPassTouches:
     arguments:
-    - Pass:
-        tooltip: Boolean, if TRUE, touches are passed from children on to parents.
-        type: integer
-        bool-semantics: true
+      - pass:
+          tooltip: A PASS_* flag (e.g., PASS_ALWAYS, PASS_IF_NOT_HANDLED, or PASS_NEVER).
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 154
     return: void
     sleep: 0.0
-    tooltip: Configures how touch events are passed to scripts in the linkset.\nIf
-      Pass == TRUE, touches involving touch-handling scripted child prims are also
-      passed on to the root prim. If Pass == FALSE (default behavior), such touches
-      will only trigger events in the affected child prim.
+    tooltip: Sets the pass-touches attribute. If pass is TRUE, touch events are
+      passed from child prims to the root; if FALSE (default), they only trigger
+      events in the affected child prim.
     categories:
       - touch
   llPatrolPoints:
     arguments:
-    - Points:
-        tooltip: A list of vectors for the character to travel through sequentially.
-          The list must contain at least two entries.
-        type: list
-        slua-type: "{vector}"
-    - Options:
-        tooltip: No options available at this time.
-        type: list
+      - patrolPoints:
+          tooltip: A list of at least two position vectors representing the patrol path.
+          type: list
+          slua-type: "{vector}"
+      - options:
+          tooltip: A list of PATROL_* flags and parameters to configure the patrol
+            behavior.
+          type: list
     energy: 10.0
     func-id: 403
     return: void
     sleep: 0.0
-    tooltip: Patrol a list of points.\nSets the points for a character (llCreateCharacter)
-      to patrol along.
+    tooltip: Directs a pathfinding character to patrol sequentially through the
+      coordinates specified in patrolPoints, configured by options.
     categories:
       - pathfinding
   llPlaySound:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 86
     return: void
     sleep: 0.0
-    tooltip: Plays Sound once, at Volume (0.0 - 1.0) and attached to the object.\nOnly
-      one sound may be attached to an object at a time, and attaching a new sound
-      or calling llStopSound will stop the previously attached sound.\nA second call
-      to llPlaySound with the same sound will not restart the sound, but the new volume
-      will be used, which allows control over the volume of already playing sounds.\nTo
-      restart the sound from the beginning, call llStopSound before calling llPlaySound
-      again.
+    tooltip: Plays the specified sound once at volume, attached to the object. Only
+      one sound can be attached to a prim at a time; new sounds or calling
+      llStopSound stops previous playback. A second call with the same sound
+      adjusts the volume without restarting it.
     categories:
       - sound
   llPlaySoundSlave:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 90
     return: void
     sleep: 0.0
-    tooltip: Plays attached Sound once, at Volume (0.0 - 1.0), synced to next loop
-      of most audible sync master.\nBehaviour is identical to llPlaySound, unless
-      there is a "Sync Master" present. If a Sync Master is already playing, the Slave
-      sound will not be played until the Master hits its loop point and returns to
-      the beginning.\nllPlaySoundSlave will play the sound exactly once; if it is
-      desired to have the sound play every time the Master loops, either use llLoopSoundSlave
-      with extra silence padded on the end of the sound or ensure that llPlaySoundSlave
-      is called at least once per loop of the Master.
+    tooltip: Plays the attached sound once at volume, synchronized to the next loop
+      point of the most audible active Sync Master.
     categories:
       - sound
   llPointAt:
     arguments:
-    - Point:
-        tooltip: ''
-        type: vector
+      - pos:
+          tooltip: The position vector to point at.
+          type: vector
     deprecated: true
     energy: 10.0
     func-id: 131
     private: true
     return: void
     sleep: 0.0
-    tooltip: ''
+    tooltip: Directs the avatar owning the object to point at the vector pos.
     categories:
       - movement
       - physics
   llPow:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
-    - Exponent:
-        tooltip: ''
-        type: float
+      - base:
+          tooltip: The base float value.
+          type: float
+      - exponent:
+          tooltip: The exponent float value.
+          type: float
     slua-deprecated:
       use: "^"
       reason: Double precision; operator.
@@ -12283,83 +12880,79 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the Value raised to the power Exponent, or returns 0 and triggers
-      Math Error for imaginary results.\nReturns the Value raised to the Exponent.
+    tooltip: Returns a float representing base raised to the power exponent. Returns
+      0 and triggers a Math Error for imaginary results.
     categories:
       - math
   llPreloadSound:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - sound:
+          tooltip: The name of the sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
     energy: 10.0
     func-id: 93
     return: void
     sleep: 1.0
-    tooltip: Causes nearby viewers to preload the Sound from the object's inventory.\nThis
-      is intended to prevent delays in starting new sounds when called upon.
+    tooltip: Causes nearby viewers in range to preload the specified sound from the
+      object's inventory to prevent playback delays.
     categories:
       - sound
   llPursue:
     arguments:
-    - TargetID:
-        tooltip: Agent or object to pursue.
-        type: key
-    - Options:
-        tooltip: Parameters for pursuit.
-        type: list
+      - target:
+          tooltip: The UUID of the group, avatar, or object to pursue.
+          type: key
+      - options:
+          tooltip: A list of options to configure pursuit behavior.
+          type: list
     energy: 10.0
     func-id: 400
     return: void
     sleep: 0.0
-    tooltip: Chase after a target.\nCauses the character (llCharacter) to pursue the
-      target defined by TargetID.
+    tooltip: Directs a pathfinding character to pursue and chase target, configured
+      by the parameters specified in options.
     categories:
       - pathfinding
   llPushObject:
     arguments:
-    - ObjectID:
-        tooltip: ''
-        type: key
-    - Impulse:
-        tooltip: ''
-        type: vector
-    - AngularImpulse:
-        tooltip: ''
-        type: vector
-    - Local:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
+      - target:
+          tooltip: The UUID of the target avatar or object in the same region.
+          type: key
+      - impulse:
+          tooltip: The linear impulse vector representing the direction and force of the
+            push.
+          type: vector
+      - ang_impulse:
+          tooltip: The angular impulse vector representing the rotational force.
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, forces are applied relative to the target's local
+            axes; if FALSE, relative to region axes.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 165
     return: void
     sleep: 0.0
-    tooltip: Applies Impulse and AngularImpulse to ObjectID.\nApplies the supplied
-      impulse and angular impulse to the object specified.
+    tooltip: Applies physical impulse (force) and ang_impulse (rotational force) to
+      the specified target avatar or object.
     categories:
       - movement
       - physics
   llReadKeyValue:
     arguments:
-    - Key:
-        tooltip: ''
-        type: string
+      - k:
+          tooltip: The key of the key-value pair to read.
+          type: string
     energy: 10.0
     experience: true
     func-id: 388
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction to retrieve the\
-      \ value associated with the key given. Will fail with XP_ERROR_KEY_NOT_FOUND\
-      \ if the key does not exist. The dataserver callback will be executed with the\
-      \ key returned from this call and a string describing the result. The result\
-      \ is a two element commma-delimited list. The first item is an integer specifying\
-      \ if the transaction succeeded (1) or not (0). In the failure case, the second\
-      \ item will be an integer corresponding to one of the XP_ERROR_... constants.\
-      \ In the success case the second item will be the value associated with the\
-      \ key.\n                "
+    tooltip: Starts an asynchronous transaction to read the value associated with
+      key k in the experience. Returns a key query handle for the dataserver
+      event. Fails with XP_ERROR_KEY_NOT_FOUND if the key does not exist.
     categories:
       - data_storage
       - dataserver
@@ -12373,54 +12966,57 @@ functions:
     func-id: 306
     return: void
     sleep: 20.0
-    tooltip: Reloads the web page shown on the sides of the object.
+    tooltip: Legacy function intended to reload the web page displayed on the prim's
+      faces (currently non-functional).
     categories:
       - media
       - prim_media
       - web
   llRegionSay:
     arguments:
-    - Channel:
-        tooltip: Any integer value except zero.
-        type: integer
-    - Text:
-        tooltip: Message to be transmitted.
-        type: string
+      - channel:
+          tooltip: The output chat channel to broadcast on (must be non-zero).
+          type: integer
+      - msg:
+          tooltip: The text message string to broadcast.
+          type: string
     energy: 10.0
     func-id: 331
     return: void
     sleep: 0.0
-    tooltip: Broadcasts Text to entire region on Channel (except for channel 0).
+    tooltip: Broadcasts the message msg on channel to the entire region (heard by
+      any script listening on that channel; channel 0 is not permitted).
     categories:
       - chat
       - script_communication
   llRegionSayTo:
     arguments:
-    - TargetID:
-        tooltip: Avatar or object to say to.
-        type: key
-    - Channel:
-        tooltip: Output channel, any integer value.
-        type: integer
-    - Text:
-        tooltip: Message to be transmitted.
-        type: string
+      - target:
+          tooltip: The UUID of the destination avatar or prim in the same region.
+          type: key
+      - channel:
+          tooltip: The output chat channel (any integer value).
+          type: integer
+      - msg:
+          tooltip: The text message string to send.
+          type: string
     energy: 10.0
     func-id: 364
     return: void
     sleep: 0.0
-    tooltip: Says Text, on Channel, to avatar or object indicated by TargetID (if
-      within region).\nIf TargetID is an avatar and Channel is nonzero, Text can be
-      heard by any attachment on the avatar.
+    tooltip: Sends the message msg on channel privately to the targeted avatar or
+      object (if within the region). If target is an avatar and channel is
+      non-zero, the message can also be heard by any attachments worn by the
+      avatar.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llReleaseCamera:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     deprecated:
       use: ll.ClearCameraParams
       selene-replace: ["ll.ClearCameraParams()"]
@@ -12428,7 +13024,8 @@ functions:
     func-id: 116
     return: void
     sleep: 0.0
-    tooltip: 'Return camera to agent.\nDeprecated: Use llClearCameraParams instead.'
+    tooltip: Deprecated. Intended to return camera control back to the avatar (use
+      llClearCameraParams instead).
     categories:
       - avatar
       - camera
@@ -12439,45 +13036,48 @@ functions:
     func-id: 112
     return: void
     sleep: 0.0
-    tooltip: Stop taking inputs.\nStop taking inputs from the avatar.
+    tooltip: Stops taking inputs (previously acquired via llTakeControls) from the
+      avatar, dequeuing any remaining control events and revoking the
+      PERMISSION_TAKE_CONTROLS permission.
     categories:
       - avatar
       - input
       - permissions
   llReleaseURL:
     arguments:
-    - URL:
-        tooltip: URL to release.
-        type: string
+      - url:
+          tooltip: The URL string to release.
+          type: string
     energy: 10.0
     func-id: 347
     return: void
     sleep: 0.0
-    tooltip: Releases the specified URL, which was previously obtained using llRequestURL.  Once
-      released, the URL will no longer be usable.
+    tooltip: Releases the specified url (previously obtained via llRequestURL),
+      rendering it no longer usable.
     categories:
       - media
       - web
   llRemoteDataReply:
     arguments:
-    - ChannelID:
-        tooltip: ''
-        type: key
-    - MessageID:
-        tooltip: ''
-        type: key
-    - sData:
-        tooltip: String data to send
-        type: string
-    - iData:
-        tooltip: Integer data to send
-        type: integer
+      - channel:
+          tooltip: The XML-RPC channel ID.
+          type: key
+      - message_id:
+          tooltip: The XML-RPC message ID.
+          type: key
+      - sdata:
+          tooltip: The string payload data to reply with.
+          type: string
+      - idata:
+          tooltip: The integer payload data to reply with.
+          type: integer
     deprecated: true
     energy: 10.0
     func-id: 256
     return: void
     sleep: 3.0
-    tooltip: This function is deprecated.
+    tooltip: Deprecated. Sends an XML-RPC reply on channel to message_id with
+      payload string sdata and integer idata.
     categories:
       - script_communication
   llRemoteDataSetRegion:
@@ -12487,138 +13087,142 @@ functions:
     func-id: 263
     return: void
     sleep: 0.0
-    tooltip: This function is deprecated.
+    tooltip: Deprecated. Used with XML-RPC to reregister remote data channels if the
+      object moves to another region.
     categories:
       - script_communication
   llRemoteLoadScript:
     arguments:
-    - Target:
-        tooltip: ''
-        type: key
-    - ScriptName:
-        tooltip: ''
-        type: string
-    - Unknown1:
-        tooltip: ''
-        type: integer
-    - Unknown2:
-        tooltip: ''
-        type: integer
+      - target:
+          tooltip: The UUID of the target prim.
+          type: key
+      - name:
+          tooltip: The name of the script in the prim's inventory.
+          type: string
+      - running:
+          tooltip: Whether the script should start running.
+          type: integer
+      - start_param:
+          tooltip: The start parameter passed to the script.
+          type: integer
     deprecated: true
     energy: 10.0
     func-id: 251
     private: true
     return: void
     sleep: 3.0
-    tooltip: ''
+    tooltip: Deprecated.
     categories:
       - prim_inventory
       - script
   llRemoteLoadScriptPin:
     arguments:
-    - ObjectID:
-        tooltip: Target prim to attempt copying into.
-        type: key
-    - ScriptName:
-        tooltip: Name of the script in current inventory to copy.
-        type: string
-    - PIN:
-        tooltip: Integer set on target prim as a Personal Information Number code.
-        type: integer
-    - Running:
-        tooltip: If the script should be set running in the target prim.
-        type: integer
-        bool-semantics: true
-    - StartParameter:
-        tooltip: Integer. Parameter passed to the script if set to be running.
-        type: integer
+      - target:
+          tooltip: The UUID of the target prim in the same region.
+          type: key
+      - name:
+          tooltip: The name of the script in the prim's inventory.
+          type: string
+      - pin:
+          tooltip: The integer PIN code (must match the PIN set on the target via
+            llSetRemoteScriptAccessPin).
+          type: integer
+      - running:
+          tooltip: Boolean. If TRUE, sets the copied script to run immediately; if FALSE,
+            leaves it stopped.
+          type: integer
+          bool-semantics: true
+      - start_param:
+          tooltip: The integer start parameter passed to the copied script (readable via
+            llGetStartParameter).
+          type: integer
     energy: 10.0
     func-id: 253
     return: void
     sleep: 3.0
-    tooltip: If the owner of the object containing this script can modify the object
-      identified by the specified object key, and if the PIN matches the PIN previously
-      set using llSetRemoteScriptAccessPin (on the target prim), then the script will
-      be copied into target. Running is a boolean specifying whether the script should
-      be enabled once copied into the target object.
+    tooltip: Copies the script name into target, setting it running (if running is
+      TRUE) with the start_param, provided the script owner has modify
+      permissions on target and target's PIN matches pin (set via
+      llSetRemoteScriptAccessPin).
     categories:
       - prim
       - prim_inventory
       - script
   llRemoveFromLandBanList:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar to remove.
+          type: key
     energy: 10.0
     func-id: 312
     return: void
     sleep: 0.1
-    tooltip: Remove avatar from the land ban list.\nRemove specified avatar from the
-      land parcel ban list.
+    tooltip: Removes the specified avatar from the land parcel's ban list.
     categories:
       - land_moderation
       - parcel
   llRemoveFromLandPassList:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar to remove.
+          type: key
     energy: 10.0
     func-id: 311
     return: void
     sleep: 0.1
-    tooltip: Remove avatar from the land pass list.\nRemove specified avatar from
-      the land parcel pass list.
+    tooltip: Removes the specified avatar from the land parcel's pass/access list.
     categories:
       - land_moderation
       - parcel
   llRemoveInventory:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - item:
+          tooltip: The name of the item in the prim's inventory to remove.
+          type: string
     energy: 10.0
     func-id: 151
     return: void
     sleep: 0.0
-    tooltip: Remove the named inventory item.\nRemove the named inventory item from
-      the object inventory.
+    tooltip: Permanently deletes the named inventory item from the prim's inventory.
     categories:
       - prim_inventory
   llRemoveVehicleFlags:
     arguments:
-    - Vehiclelags:
-        tooltip: ''
-        type: integer
+      - flags:
+          tooltip: A bitwise mask of VEHICLE_FLAG_* constants to disable.
+          type: integer
     energy: 10.0
     func-id: 237
     return: void
     sleep: 0.0
-    tooltip: Removes the enabled bits in 'flags'.\nSets the vehicle flags to FALSE.
-      Valid parameters can be found in the vehicle flags constants section.
+    tooltip: Disables the specified vehicle flags (sets them to FALSE) using the
+      bitwise mask flags.
     categories:
       - physics
       - vehicles
   llReplaceAgentEnvironment:
     arguments:
-    - agent_id:
-        tooltip: ''
-        type: key
-    - transition:
-        tooltip: ''
-        type: float
-    - environment:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - agent_id:
+          tooltip: The UUID of an agent in the region participating in the experience.
+          type: key
+      - transition:
+          tooltip: The duration in seconds over which to transition to the new
+            environment.
+          type: float
+      - environment:
+          tooltip: The name of an environmental setting in inventory, or its asset UUID
+            (or empty string/NULL_KEY to clear).
+          type: string
+          asset-semantics: true
     energy: 10.0
     experience: true
     func-id: 713
     return: integer
     sleep: 0.0
-    tooltip: Replaces the entire environment for an agent. Must be used as part of
-      an experience.
+    tooltip: Replaces the region and parcel environment seen by the specified
+      agent_id as part of an experience, transitioning the settings over
+      transition seconds. Passing NULL_KEY or an empty string for environment
+      restores defaults.
     categories:
       - avatar
       - experience
@@ -12626,157 +13230,147 @@ functions:
       - region_appearance
   llReplaceEnvironment:
     arguments:
-    - position:
-        tooltip: Location of parcel to change. Use <-1, -1, -1> for entire region.
-        type: vector
-    - environment:
-        tooltip: "Name of inventory item, or UUID of environment resource to apply.\n\
-          \                         Use NULL_KEY or empty string to remove environment."
-        type: string
-        asset-semantics: true
-    - track_no:
-        tooltip: Elevation zone of where to apply environment. Use -1 for all.
-        type: integer
-    - day_length:
-        tooltip: Length of day cycle for this parcel or region. -1 to leave unchanged.
-        type: integer
-    - day_offset:
-        tooltip: Offset from GMT for the day cycle on this parcel or region. -1 to
-          leave unchanged.
-        type: integer
+      - position:
+          tooltip: The position vector of the target parcel (the Z component is ignored;
+            use <-1.0, -1.0, -1.0> for the entire region).
+          type: vector
+      - environment:
+          tooltip: The name of an environmental setting in inventory, or its asset UUID
+            (or empty string/NULL_KEY to clear).
+          type: string
+          asset-semantics: true
+      - track_no:
+          tooltip: "The elevation track to change (0: water, 1: ground, 2: 1000m, 3:
+            2000m, 4: 3000m, -1: all tracks)."
+          type: integer
+      - day_length:
+          tooltip: The day cycle length in seconds (-1 to leave unchanged).
+          type: integer
+      - day_offset:
+          tooltip: The day cycle offset in seconds from UTC (-1 to leave unchanged).
+          type: integer
     energy: 10.0
     func-id: 718
     return: integer
     sleep: 0.0
-    tooltip: Replaces the environment for a parcel or region.
+    tooltip: Replaces the environment on the parcel containing position (or the
+      entire region if position is <-1.0, -1.0, -1.0>) for the specified
+      track_no. Modifies day_length and day_offset if specified. Requires edit
+      permissions on the parcel or estate management rights.
     categories:
       - parcel
       - parcel_appearance
   llReplaceSubString:
     arguments:
-    - InitialString:
-        tooltip: The original string in which to hunt for substring matches.
-        type: string
-    - SubString:
-        tooltip: The original substring to find.
-        type: string
-    - NewSubString:
-        tooltip: The new substring used to replace.
-        type: string
-    - Count:
-        tooltip: The max number of replacements to make. Zero Count means "replace
-          all". Positive Count moves left to right. Negative moves right to left.
-        type: integer
+      - src:
+          tooltip: The original source string to search.
+          type: string
+      - pattern:
+          tooltip: The substring pattern to find and replace.
+          type: string
+      - replacement_pattern:
+          tooltip: The new substring used to replace the pattern.
+          type: string
+      - count:
+          tooltip: The maximum number of replacements to make (0 for all, positive for
+            left-to-right, negative for right-to-left).
+          type: integer
     energy: 10.0
     func-id: 541
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Searches InitialString and replaces instances of SubString with NewSubString.
-      Zero Count means "replace all". Positive Count moves left to right. Negative
-      moves right to left.
+    tooltip: Returns a new string representing src with count occurrences of pattern
+      replaced by replacement_pattern. Setting count to 0 replaces all
+      occurrences; positive counts process left-to-right, while negative counts
+      process right-to-left.
     categories:
       - string
   llRequestAgentData:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Data:
-        tooltip: ''
-        type: integer
+      - id:
+          tooltip: The UUID of the agent.
+          type: key
+      - data:
+          tooltip: The DATA_* category flag of the requested information.
+          type: integer
     energy: 10.0
     func-id: 155
     return: key
     sleep: 0.1
-    tooltip: Requests data about AvatarID. When data is available the dataserver event
-      will be raised.\nThis function requests data about an avatar. If and when the
-      information is collected, the dataserver event is triggered with the key returned
-      from this function passed in the requested parameter. See the agent data constants
-      (DATA_*) for details about valid values of data and what each will return in
-      the dataserver event.
+    tooltip: Asynchronously requests the specified data category (DATA_*) about the
+      agent id. Triggers a dataserver event with the results and returns a key
+      query handle.
     categories:
       - avatar
       - dataserver
   llRequestDisplayName:
     arguments:
-    - AvatarID:
-        tooltip: Avatar UUID
-        type: key
+      - id:
+          tooltip: The UUID of the avatar to query.
+          type: key
     energy: 10.0
     func-id: 361
     return: key
     sleep: 0.0
-    tooltip: Requests the display name of the agent. When the display name is available
-      the dataserver event will be raised.\nThe avatar identified does not need to
-      be in the same region or online at the time of the request.\nReturns a key that
-      is used to identify the dataserver event when it is raised.
+    tooltip: Asynchronously requests the display name of the agent specified by id,
+      triggering a dataserver event with the results. The agent does not need to
+      be online or in the region. Returns a key query handle.
     categories:
       - avatar
       - dataserver
   llRequestExperiencePermissions:
     arguments:
-    - AgentID:
-        tooltip: ''
-        type: key
-    - unused:
-        tooltip: Not used, should be ""
-        type: string
+      - agent:
+          tooltip: The UUID of the agent to request permissions from.
+          type: key
+      - name:
+          tooltip: Deprecated parameter (no longer used).
+          type: string
     energy: 10.0
     experience: true
     func-id: 384
     return: void
     sleep: 0.0
-    tooltip: "\n                   Ask the agent for permission to participate in\
-      \ an experience. This request is similar to llRequestPermissions with the following\
-      \ permissions: PERMISSION_TAKE_CONTROLS, PERMISSION_TRIGGER_ANIMATION, PERMISSION_ATTACH,\
-      \ PERMISSION_TRACK_CAMERA, PERMISSION_CONTROL_CAMERA and PERMISSION_TELEPORT.\
-      \ However, unlike llRequestPermissions the decision to allow or block the request\
-      \ is persistent and applies to all scripts using the experience grid wide. Subsequent\
-      \ calls to llRequestExperiencePermissions from scripts in the experience will\
-      \ receive the same response automatically with no user interaction. One of experience_permissions\
-      \ or experience_permissions_denied will be generated in response to this call.\
-      \ Outstanding permission requests will be lost if the script is derezzed, moved\
-      \ to another region or reset.\n                "
+    tooltip: Requests permission from the specified agent to participate in the
+      experience. These permissions are persistent and apply grid-wide across
+      all scripts in the experience, automatically triggering
+      experience_permissions or experience_permissions_denied.
     categories:
       - avatar
       - experience
       - permissions
   llRequestInventoryData:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
+      - name:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 156
     return: key
     sleep: 1.0
-    tooltip: Requests data for the named InventoryItem.\nWhen data is available, the
-      dataserver event will be raised with the key returned from this function in
-      the requested parameter.\nThe only request currently implemented is to request
-      data from landmarks, where the data returned is in the form "<float, float,
-      float>" which can be cast to a vector. This position is in region local coordinates.
+    tooltip: Asynchronously requests data for the inventory item specified by name,
+      triggering a dataserver event. Currently, only landmark items are
+      supported (which return local region coordinates). Returns a key query
+      handle.
     categories:
       - dataserver
       - prim_inventory
   llRequestPermissions:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - PermissionMask:
-        tooltip: ''
-        type: integer
+      - agent:
+          tooltip: The UUID of the agent in the same region.
+          type: key
+      - permissions:
+          tooltip: The bitfield containing the PERMISSION_* constants to request.
+          type: integer
     energy: 10.0
     func-id: 136
     return: void
     sleep: 0.0
-    tooltip: Ask AvatarID to allow the script to perform certain actions, specified
-      in the PermissionMask bitmask. PermissionMask should be one or more PERMISSION_*
-      constants. Multiple permissions can be requested simultaneously by ORing the
-      constants together. Many of the permissions requests can only go to object owner.\nThis
-      call will not stop script execution. If the avatar grants the requested permissions,
-      the run_time_permissions event will be called.
+    tooltip: Requests permissions (a bitfield specified by permissions) from the
+      agent in the same region, calling run_time_permissions if granted. This
+      call does not pause script execution.
     categories:
       - permissions
   llRequestSecureURL:
@@ -12785,29 +13379,27 @@ functions:
     func-id: 346
     return: key
     sleep: 0.0
-    tooltip: Requests one HTTPS:// (SSL) URL for use by this object. The http_request
-      event is triggered with results.\nReturns a key that is the handle used for
-      identifying the request in the http_request event.
+    tooltip: Asynchronously requests one secure HTTPS (SSL, port 12043) URL for use
+      by this object, triggering an http_request event. Returns a key query
+      handle.
     categories:
       - media
       - script_communication
       - web
   llRequestSimulatorData:
     arguments:
-    - RegionName:
-        tooltip: ''
-        type: string
-    - Data:
-        tooltip: ''
-        type: integer
+      - region:
+          tooltip: The case-sensitive region name.
+          type: string
+      - data:
+          tooltip: The DATA_SIM_* flag of the requested simulator data.
+          type: integer
     energy: 10.0
     func-id: 293
     return: key
     sleep: 1.0
-    tooltip: Requests the specified Data about RegionName. When the specified data
-      is available, the dataserver event is raised.\nData should use one of the DATA_SIM_*
-      constants.\nReturns a dataserver query ID and triggers the dataserver event
-      when data is found.
+    tooltip: Asynchronously requests data (using a DATA_SIM_* constant) about the
+      region. Triggers a dataserver event and returns a key query handle.
     categories:
       - dataserver
       - region
@@ -12817,58 +13409,57 @@ functions:
     func-id: 345
     return: key
     sleep: 0.0
-    tooltip: Requests one HTTP:// URL for use by this script. The http_request event
-      is triggered with the result of the request.\nReturns a key that is the handle
-      used for identifying the result in the http_request event.
+    tooltip: Asynchronously requests one HTTP URL for use by this script, triggering
+      an http_request event. Returns a key query handle.
     categories:
       - media
       - script_communication
       - web
   llRequestUserKey:
     arguments:
-    - Name:
-        tooltip: Name of agent to look up.
-        type: string
+      - username:
+          tooltip: The current or historical username of the avatar to resolve.
+          type: string
     energy: 10.0
     func-id: 525
     return: key
     sleep: 0.0
-    tooltip: Look up Agent ID for the named agent using a historical name.
+    tooltip: Asynchronously requests the Agent ID key (UUID) for the agent specified
+      by their current or historical username, returning NULL_KEY if not found.
+      Returns a key query handle for the dataserver event.
     categories:
       - avatar
       - dataserver
       - uuid
   llRequestUsername:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the avatar to query.
+          type: key
     energy: 10.0
     func-id: 359
     return: key
     sleep: 0.0
-    tooltip: Requests single-word user-name of an avatar. When data is available the
-      dataserver event will be raised.\nRequests the user-name of the identified agent.
-      When the user-name is available the dataserver event is raised.\nThe agent identified
-      does not need to be in the same region or online at the time of the request.\nReturns
-      a key that is used to identify the dataserver event when it is raised.
+    tooltip: Asynchronously requests the unique single-word username of the agent
+      identified by id, triggering a dataserver event. The agent does not need
+      to be online or in the region. Returns a key query handle.
     categories:
       - avatar
       - dataserver
   llResetAnimationOverride:
     arguments:
-    - AnimationState:
-        tooltip: ''
-        type: string
+      - anim_state:
+          tooltip: The animation state string (or 'ALL') to reset.
+          type: string
     energy: 10.0
     func-id: 502
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_OVERRIDE_ANIMATIONS
-    tooltip: Resets the animation of the specified animation state to the default
-      value.\nIf animation state equals "ALL", then all animation states are reset.\nRequires
-      the PERMISSION_OVERRIDE_ANIMATIONS permission (automatically granted to attached objects).
+    tooltip: Resets the animation override for anim_state to its default value (use
+      'ALL' to reset all states). Requires the PERMISSION_OVERRIDE_ANIMATIONS
+      permission.
     categories:
       - avatar_animation
       - permissions
@@ -12878,7 +13469,7 @@ functions:
     func-id: 321
     return: void
     sleep: 0.1
-    tooltip: Removes all residents from the land ban list.
+    tooltip: Removes all blocked residents from the land parcel's ban list.
     categories:
       - land_moderation
       - parcel
@@ -12888,20 +13479,20 @@ functions:
     func-id: 322
     return: void
     sleep: 0.1
-    tooltip: Removes all residents from the land access/pass list.
+    tooltip: Removes all residents from the land parcel's access/pass list.
     categories:
       - land_moderation
       - parcel
   llResetOtherScript:
     arguments:
-    - ScriptName:
-        tooltip: ''
-        type: string
+      - name:
+          tooltip: The name of the target script in the prim's inventory.
+          type: string
     energy: 10.0
     func-id: 249
     return: void
     sleep: 0.0
-    tooltip: Resets the named script.
+    tooltip: Resets the script name located in the prim's inventory.
     categories:
       - prim_inventory
       - script
@@ -12911,7 +13502,7 @@ functions:
     func-id: 163
     return: void
     sleep: 0.0
-    tooltip: Resets the script.
+    tooltip: Resets the current script.
     categories:
       - script
   llResetTime:
@@ -12921,134 +13512,138 @@ functions:
     return: void
     slua-removed: true
     sleep: 0.0
-    tooltip: Sets the time to zero.\nSets the internal timer to zero.
+    tooltip: Resets the script's elapsed time timer back to zero.
     categories:
       - script
   llReturnObjectsByID:
     arguments:
-    - ObjectIDs:
-        tooltip: List of object UUIDs to be returned.
-        type: list
-        slua-type: "{uuid}"
+      - objects:
+          tooltip: A list of object UUID keys to return.
+          type: list
+          slua-type: "{uuid}"
     energy: 10.0
     func-id: 520
     return: integer
     sleep: 0.0
     requires-permission:
       - PERMISSION_RETURN_OBJECTS
-    tooltip: Return objects using their UUIDs.\nRequires the PERMISSION_RETURN_OBJECTS
-      permission and that the script owner owns the parcel the returned objects are
-      in, or is an estate manager or region owner.
+    tooltip: Returns objects specified by the list of UUIDs objects to their owners.
+      Requires the PERMISSION_RETURN_OBJECTS permission, and the script owner
+      must own the parcel or be an estate manager/region owner.
     categories:
       - land_moderation
       - rez
   llReturnObjectsByOwner:
     arguments:
-    - ID:
-        tooltip: Object owner's UUID.
-        type: key
-    - Scope:
-        tooltip: ''
-        type: integer
+      - owner:
+          tooltip: The UUID of the avatar or group whose objects will be returned.
+          type: key
+      - scope:
+          tooltip: The OBJECT_RETURN_* scope flag (such as OBJECT_RETURN_PARCEL,
+            OBJECT_RETURN_PARCEL_OWNER, or OBJECT_RETURN_REGION).
+          type: integer
     energy: 10.0
     func-id: 521
     return: integer
     sleep: 0.0
     requires-permission:
       - PERMISSION_RETURN_OBJECTS
-    tooltip: Return objects based upon their owner and a scope of parcel, parcel owner,
-      or region.\nRequires the PERMISSION_RETURN_OBJECTS permission and that the script
-      owner owns the parcel the returned objects are in, or is an estate manager or
-      region owner.
+    tooltip: Returns objects owned by owner within the specified scope (parcel,
+      parcel owner, or region). Requires the PERMISSION_RETURN_OBJECTS
+      permission, and the script owner must own the parcel or be an estate
+      manager/region owner.
     categories:
       - land_moderation
       - rez
   llRezAtRoot:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
-    - Position:
-        tooltip: ''
-        type: vector
-    - Velocity:
-        tooltip: ''
-        type: vector
-    - Rotation:
-        tooltip: ''
-        type: rotation
-    - StartParameter:
-        tooltip: ''
-        type: integer
+      - inventory:
+          tooltip: The name of the object in the prim's inventory.
+          type: string
+      - position:
+          tooltip: The position vector in region coordinates where the root of the object
+            will be placed.
+          type: vector
+      - velocity:
+          tooltip: The initial velocity vector for the rezzed object.
+          type: vector
+      - rot:
+          tooltip: The initial rotation of the rezzed object.
+          type: rotation
+      - param:
+          tooltip: The start parameter passed to the rezzed object's on_rez event
+            (accessible via llGetStartParameter).
+          type: integer
     energy: 200.0
     func-id: 286
     return: void
     sleep: 0.1
-    tooltip: Instantiate owner's InventoryItem at Position with Velocity, Rotation
-      and with StartParameter. The last selected root object's location will be set
-      to Position.\nCreates object's inventory item at the given Position, with Velocity,
-      Rotation, and StartParameter.
+    tooltip: Instantiates the inventory object at position moving at velocity,
+      rotated to rot with its root prim centered exactly on position, passing
+      param as the on_rez start parameter.
     categories:
       - prim_inventory
       - rez
   llRezObject:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
-    - Position:
-        tooltip: ''
-        type: vector
-    - Velocity:
-        tooltip: ''
-        type: vector
-    - Rotation:
-        tooltip: ''
-        type: rotation
-    - StartParameter:
-        tooltip: ''
-        type: integer
+      - inventory:
+          tooltip: The name of the object in the prim's inventory.
+          type: string
+      - pos:
+          tooltip: The position vector in region coordinates where the center of the
+            object will be placed.
+          type: vector
+      - vel:
+          tooltip: The initial velocity vector (maximum magnitude ~200m/s).
+          type: vector
+      - rot:
+          tooltip: The initial rotation of the rezzed object.
+          type: rotation
+      - param:
+          tooltip: The start parameter passed to the rezzed object's on_rez event
+            (accessible via llGetStartParameter).
+          type: integer
     energy: 200.0
     func-id: 104
     return: void
     sleep: 0.1
-    tooltip: Instantiate owners InventoryItem at Position with Velocity, Rotation
-      and with start StartParameter.\nCreates object's inventory item at Position
-      with Velocity and Rotation supplied. The StartParameter value will be available
-      to the newly created object in the on_rez event or through the llGetStartParameter
-      function.\nThe Velocity parameter is ignored if the rezzed object is not physical.
+    tooltip: Instantiates the inventory object at pos with velocity vel and rotation
+      rot, passing param as the on_rez start parameter. The vel parameter is
+      ignored if the rezzed object is non-physical.
     categories:
       - prim_inventory
       - rez
   llRezObjectWithParams:
     arguments:
-    - InventoryItem:
-        tooltip: ''
-        type: string
-    - Params:
-        tooltip: ''
-        type: list
+      - inventory:
+          tooltip: The name of the object in the prim's inventory.
+          type: string
+      - params:
+          tooltip: A list of REZ_* parameters to configure the rezzed object's attributes.
+          type: list
     energy: 200.0
     func-id: 544
     return: key
     sleep: 0.1
-    tooltip: Instantiate owner's InventoryItem with the given parameters.
+    tooltip: Instantiates the inventory object (defaulting to the rezzing prim's
+      position unless REZ_POS is specified) using the initial set of parameters
+      specified in params. Returns the key of the rezzed object, or a blank key
+      on failure.
     categories:
       - combat
       - prim_inventory
       - rez
   llRot2Angle:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - rot:
+          tooltip: The rotation value.
+          type: rotation
     energy: 10.0
     func-id: 171
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the rotation angle represented by Rotation.\nReturns the angle
-      represented by the Rotation.
+    tooltip: Returns a float representing the rotation angle of rot.
     categories:
       - math
       - math_3d
@@ -13056,16 +13651,15 @@ functions:
       - quaternion
   llRot2Axis:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - rot:
+          tooltip: The rotation value.
+          type: rotation
     energy: 10.0
     func-id: 170
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the rotation axis represented by Rotation.\nReturns the axis
-      represented by the Rotation.
+    tooltip: Returns a vector representing the rotation axis of rot.
     categories:
       - math
       - math_3d
@@ -13074,25 +13668,25 @@ functions:
       - vector
   llRot2Euler:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - quat:
+          tooltip: The rotation value to convert.
+          type: rotation
     energy: 10.0
     func-id: 15
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the Euler representation (roll, pitch, yaw) of Rotation.\nReturns
-      the Euler Angle representation of the Rotation.
+    tooltip: Returns a vector representing the Euler rotation (roll, pitch, yaw) of
+      quat, with each component expressed in radians.
     categories:
       - math
       - math_3d
       - quaternion
   llRot2Fwd:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - q:
+          tooltip: The rotation value.
+          type: rotation
     slua-deprecated:
       use: quaternion.tofwd
       selene-replace: ["quaternion.tofwd(%1)"]
@@ -13101,8 +13695,9 @@ functions:
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the forward vector defined by Rotation.\nReturns the forward
-      axis represented by the Rotation.
+    tooltip: Returns a unit vector pointing in the local positive X direction
+      (forward) relative to the parent (root prim or region) defined by rotation
+      q.
     categories:
       - math
       - math_3d
@@ -13111,9 +13706,9 @@ functions:
       - vector
   llRot2Left:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - q:
+          tooltip: The rotation value.
+          type: rotation
     slua-deprecated:
       use: quaternion.toleft
       selene-replace: ["quaternion.toleft(%1)"]
@@ -13122,8 +13717,8 @@ functions:
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the left vector defined by Rotation.\nReturns the left axis represented
-      by the Rotation.
+    tooltip: Returns a unit vector pointing in the local positive Y direction (left)
+      relative to the parent (root prim or region) defined by rotation q.
     categories:
       - math
       - math_3d
@@ -13132,9 +13727,9 @@ functions:
       - vector
   llRot2Up:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - q:
+          tooltip: The rotation value.
+          type: rotation
     slua-deprecated:
       use: quaternion.toup
       selene-replace: ["quaternion.toup(%1)"]
@@ -13143,8 +13738,8 @@ functions:
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the up vector defined by Rotation.\nReturns the up axis represented
-      by the Rotation.
+    tooltip: Returns a unit vector pointing in the local positive Z direction (up)
+      relative to the parent (root prim or region) defined by rotation q.
     categories:
       - math
       - math_3d
@@ -13153,19 +13748,19 @@ functions:
       - vector
   llRotBetween:
     arguments:
-    - Vector1:
-        tooltip: ''
-        type: vector
-    - Vector2:
-        tooltip: ''
-        type: vector
+      - start:
+          tooltip: The starting vector.
+          type: vector
+      - end:
+          tooltip: The target ending vector.
+          type: vector
     energy: 10.0
     func-id: 21
     pure: true
     return: rotation
     sleep: 0.0
-    tooltip: Returns the rotation to rotate Vector1 to Vector2.\nReturns the rotation
-      needed to rotate Vector1 to Vector2.
+    tooltip: Returns a rotation representing the shortest path rotation from vector
+      start to vector end.
     categories:
       - math
       - math_3d
@@ -13173,80 +13768,81 @@ functions:
       - quaternion
   llRotLookAt:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
-    - Strength:
-        tooltip: ''
-        type: float
-    - Damping:
-        tooltip: ''
-        type: float
+      - target_direction:
+          tooltip: The target rotation to align the object with.
+          type: rotation
+      - strength:
+          tooltip: The force of rotation (0.0 cancels the tracking; values around half the
+            object's mass are typical).
+          type: float
+      - damping:
+          tooltip: The timescale in seconds to critically damp the rotation.
+          type: float
     energy: 10.0
     func-id: 127
     return: void
     sleep: 0.0
-    tooltip: Cause object to rotate to Rotation, with a force function defined by
-      Strength and Damping parameters. Good strength values are around half the mass
-      of the object and good damping values are less than 1/10th of the strength.\nAsymmetrical
-      shapes require smaller damping.\nA strength of 0.0 cancels the look at.
+    tooltip: Causes the object to smoothly rotate to target_direction with a force
+      defined by strength and damping. A strength of 0.0 cancels the rotation
+      target. Rotation is maintained until stopped with llStopLookAt.
     categories:
       - movement
       - physics
   llRotTarget:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
-    - LeeWay:
-        tooltip: ''
-        type: float
+      - rot:
+          tooltip: The target rotation to track.
+          type: rotation
+      - error:
+          tooltip: The tolerance angle in radians defining when the target rotation is
+            considered reached.
+          type: float
     energy: 10.0
     func-id: 68
     return: integer
     sleep: 0.0
-    tooltip: Set rotations with error of LeeWay radians as a rotational target, and
-      return an ID for the rotational target.\nThe returned number is a handle that
-      can be used in at_rot_target and llRotTargetRemove.
+    tooltip: Registers the rotation rot with a leeway tolerance error (in radians)
+      as a target, triggering at_rot_target and not_at_rot_target events.
+      Returns an integer handle to unregister the target via llRotTargetRemove.
     categories:
       - movement
       - physics
   llRotTargetRemove:
     arguments:
-    - Handle:
-        tooltip: ''
-        type: integer
+      - handle:
+          tooltip: The integer target handle returned by llRotTarget to remove.
+          type: integer
     energy: 10.0
     func-id: 69
     return: void
     sleep: 0.0
-    tooltip: Removes rotational target number.\nRemove rotational target indicated
-      by the handle.
+    tooltip: Removes the rotational target specified by the integer handle
+      registered with llRotTarget.
     categories:
       - movement
       - physics
   llRotateTexture:
     arguments:
-    - Radians:
-        tooltip: ''
-        type: float
-    - Face:
-        tooltip: ''
-        type: integer
+      - angle:
+          tooltip: The rotation angle expressed in radians.
+          type: float
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 56
     return: void
     sleep: 0.2
-    tooltip: Sets the texture rotation for the specified Face to angle Radians.\nIf
-      Face is ALL_SIDES, rotates the texture of all sides.
+    tooltip: Sets the texture rotation of face to the specified angle (in radians).
+      If face is ALL_SIDES, rotates the texture on all faces.
     categories:
       - prim
       - prim_appearance
   llRound:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The float value to round.
+          type: float
     slua-deprecated:
       use: math.round
       reason: Fastcall.
@@ -13256,196 +13852,199 @@ functions:
     must-use: true
     return: integer
     sleep: 0.0
-    tooltip: Returns Value rounded to the nearest integer.\nReturns the Value rounded
-      to the nearest integer.
+    tooltip: Returns the integer that float val is closest to.
     categories:
       - math
   llSHA1String:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The source string to hash.
+          type: string
     energy: 10.0
     func-id: 343
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string of 40 hex characters that is the SHA1 security hash
-      of text.
+    tooltip: Returns a string of 40 hex characters representing the SHA-1 security
+      hash of src.
     categories:
       - cryptography
   llSHA256String:
     arguments:
-    - text:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The source string to hash.
+          type: string
     energy: 10.0
     func-id: 531
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string of 64 hex characters that is the SHA256 security hash
-      of text.
+    tooltip: Returns a string of 64 hex characters representing the SHA-256 security
+      hash of src.
     categories:
       - cryptography
   llSameGroup:
     arguments:
-    - ID:
-        tooltip: ''
-        type: key
+      - uuid:
+          tooltip: The UUID of the group, avatar, or prim to check.
+          type: key
     energy: 10.0
     func-id: 219
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if avatar ID is in the same region and has the same active
-      group, otherwise FALSE.\nReturns TRUE if the object or agent identified is in
-      the same simulator and has the same active group as this object. Otherwise,
-      returns FALSE.
+    tooltip: Returns TRUE if the agent or object specified by uuid is in the same
+      region (simulator) and shares the same active group as the prim containing
+      the script; returns FALSE otherwise.
     categories:
       - object
   llSay:
     arguments:
-    - Channel:
-        tooltip: Channel to use to say text on.
-        type: integer
-    - Text:
-        tooltip: Text to say.
-        type: string
+      - channel:
+          tooltip: The integer chat channel to transmit the message on.
+          type: integer
+      - msg:
+          tooltip: The text message string to transmit.
+          type: string
     energy: 10.0
     func-id: 23
     return: void
     sleep: 0.0
-    tooltip: Says Text on Channel.\nThis chat method has a range of 20m radius.\nPUBLIC_CHANNEL
-      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
-      is the script debug channel, and is also visible to nearby avatars. All other
-      channels are are not sent to avatars, but may be used to communicate with scripts.
+    tooltip: Says the text message msg on the specified channel. The message can be
+      heard up to a 20m radius. Channels other than PUBLIC_CHANNEL (0) and
+      DEBUG_CHANNEL (2147483647) are not visible to avatars and can be used for
+      script-to-script communication.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llScaleByFactor:
     arguments:
-    - ScalingFactor:
-        tooltip: The multiplier to be used with the prim sizes and their local positions.
-        type: float
+      - scaling_factor:
+          tooltip: The multiplier scale factor to apply to the prim sizes and their local
+            positions.
+          type: float
     energy: 10.0
     func-id: 592
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Attempts to resize the entire object by ScalingFactor, maintaining the
-      size-position ratios of the prims.\n\nResizing is subject to prim scale limits
-      and linkability limits. This function can not resize the object if the linkset
-      is physical, a pathfinding character, in a keyframed motion, or if resizing
-      would cause the parcel to overflow.\nReturns a boolean (an integer) TRUE if
-      it succeeds, FALSE if it fails.
+    tooltip: Attempts to uniformly resize the entire object by scaling_factor,
+      maintaining size-position ratios of the prims. Fails if the linkset is
+      physical, a pathfinding character, in keyframed motion, would exceed prim
+      scale/linkability limits, or would overflow parcel capacity.
     categories:
       - linkset
       - prim_appearance
   llScaleTexture:
     arguments:
-    - Horizontal:
-        tooltip: ''
-        type: float
-    - Vertical:
-        tooltip: ''
-        type: float
-    - Face:
-        tooltip: ''
-        type: integer
+      - u:
+          tooltip: The horizontal (U) texture repeats scale value, in the interval
+            [-100.0, 100.0].
+          type: float
+      - v:
+          tooltip: The vertical (V) texture repeats scale value, in the interval [-100.0,
+            100.0].
+          type: float
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 54
     return: void
     sleep: 0.2
-    tooltip: Sets the diffuse texture Horizontal and Vertical repeats on Face of the
-      prim the script is attached to.\nIf Face == ALL_SIDES, all sides are set in
-      one call.\nNegative values for horizontal and vertical will flip the texture.
+    tooltip: Sets the diffuse texture horizontal u and vertical v scales (repeats)
+      on the specified face of the prim. Setting face to ALL_SIDES updates all
+      sides. Negative scale values flip the texture.
     categories:
       - prim
       - prim_appearance
   llScriptDanger:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
+      - pos:
+          tooltip: The position vector in region coordinates to check.
+          type: vector
     energy: 10.0
     func-id: 246
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if Position is over public land, sandbox land, land that
-      doesn't allow everyone to edit and build, or land that doesn't allow outside
-      scripts.\nReturns true if the position is over public land, land that doesn't
-      allow everyone to edit and build, or land that doesn't allow outside scripts.
+    tooltip: Returns TRUE if the vector position pos is over public land, sandbox
+      land, land restricting edit/build permissions, or land that disables
+      outside scripts.
     categories:
       - parcel
       - script
   llScriptProfiler:
     arguments:
-    - State:
-        tooltip: PROFILE_NONE or PROFILE_SCRIPT_MEMORY flags to control the state.
-        type: integer
+      - flags:
+          tooltip: The PROFILE_* flag (such as PROFILE_NONE or PROFILE_SCRIPT_MEMORY) to
+            set the profiling state.
+          type: integer
     energy: 10.0
     func-id: 367
     return: void
     sleep: 0.0
-    tooltip: Enables or disables script profiling options. Currently only supports
-      PROFILE_SCRIPT_MEMORY (Mono only) and PROFILE_NONE.\nMay significantly reduce
-      script performance.
+    tooltip: Enables or disables the script's profiling state using flags (supports
+      PROFILE_SCRIPT_MEMORY on Mono, or PROFILE_NONE). Active profiling can
+      significantly reduce script performance.
     categories:
       - script
   llSendRemoteData:
     arguments:
-    - ChannelID:
-        tooltip: ''
-        type: key
-    - Destination:
-        tooltip: ''
-        type: string
-    - Value:
-        tooltip: ''
-        type: integer
-    - Text:
-        tooltip: ''
-        type: string
+      - channel:
+          tooltip: The XML-RPC channel ID.
+          type: key
+      - dest:
+          tooltip: The destination XML-RPC URL or server.
+          type: string
+      - idata:
+          tooltip: The integer payload data.
+          type: integer
+      - sdata:
+          tooltip: The string payload data.
+          type: string
     deprecated: true
     energy: 10.0
     func-id: 255
     return: key
     sleep: 3.0
-    tooltip: This function is deprecated.
+    tooltip: Deprecated. Sends an XML-RPC request to dest on channel, containing the
+      channel ID as a string, integer idata, and string sdata. Returns a key
+      representing the message_id.
     categories:
       - script_communication
   llSensor:
     arguments:
-    - Name:
-        tooltip: Object or avatar name.
-        type: string
-    - ID:
-        tooltip: Object or avatar UUID.
-        type: key
-    - Type:
-        tooltip: Bit-field mask of AGENT, AGENT_BY_LEGACY_NAME, AGENT_BY_USERNAME,
-          ACTIVE, PASSIVE, and/or SCRIPTED
-        type: integer
-    - Range:
-        tooltip: Distance to scan. 0.0 - 96.0m.
-        type: float
-    - Arc:
-        tooltip: Angle, in radians, from the local x-axis of the prim to scan.
-        type: float
+      - name:
+          tooltip: The specific object or avatar name to filter for (or empty string for
+            no filter).
+          type: string
+      - id:
+          tooltip: The UUID of the group, avatar, or object to filter by (or NULL_KEY for
+            no filter).
+          type: key
+      - type:
+          tooltip: The integer bitfield type mask containing AGENT, AGENT_BY_LEGACY_NAME,
+            AGENT_BY_USERNAME, ACTIVE, PASSIVE, or SCRIPTED (0 for no filter).
+          type: integer
+      - radius:
+          tooltip: The maximum distance in meters to scan (range [0.0, 96.0]).
+          type: float
+      - arc:
+          tooltip: The maximum angle in radians relative to the local X-axis to scan
+            (range [0.0, PI]).
+          type: float
     energy: 10.0
     func-id: 28
     return: void
     sleep: 0.0
-    tooltip: Performs a single scan for Name and ID with Type (AGENT, ACTIVE, PASSIVE,
-      and/or SCRIPTED) within Range meters and Arc radians of forward vector.\nSpecifying
-      a blank Name, 0 Type, or NULL_KEY ID will prevent filtering results based on
-      that parameter. A range of 0.0 does not perform a scan.\nResults are returned
-      in the sensor and no_sensor events.
+    tooltip: Performs a single scan from the prim's forward vector for name and id
+      of type within radius meters and arc radians. Results trigger a sensor or
+      no_sensor event. Passing empty filters (blank name, 0 type, or NULL_KEY
+      id) disables that filter.
     categories:
       - sensor
   llSensorRemove:
@@ -13454,59 +14053,61 @@ functions:
     func-id: 30
     return: void
     sleep: 0.0
-    tooltip: removes sensor.\nRemoves the sensor set by llSensorRepeat.
+    tooltip: Removes the periodic sensor previously configured by llSensorRepeat.
     categories:
       - sensor
   llSensorRepeat:
     arguments:
-    - Name:
-        tooltip: Object or avatar name.
-        type: string
-    - ID:
-        tooltip: Object or avatar UUID.
-        type: key
-    - Type:
-        tooltip: Bit-field mask of AGENT, AGENT_BY_LEGACY_NAME, AGENT_BY_USERNAME,
-          ACTIVE, PASSIVE, and/or SCRIPTED
-        type: integer
-    - Range:
-        tooltip: Distance to scan. 0.0 - 96.0m.
-        type: float
-    - Arc:
-        tooltip: Angle, in radians, from the local x-axis of the prim to scan.
-        type: float
-    - Rate:
-        tooltip: Period, in seconds, between scans.
-        type: float
+      - name:
+          tooltip: The specific object or avatar name to filter for (or empty string for
+            no filter).
+          type: string
+      - id:
+          tooltip: The UUID of the group, avatar, or object to filter by (or NULL_KEY for
+            no filter).
+          type: key
+      - type:
+          tooltip: The integer bitfield type mask containing AGENT, AGENT_BY_LEGACY_NAME,
+            AGENT_BY_USERNAME, ACTIVE, PASSIVE, or SCRIPTED (0 for no filter).
+          type: integer
+      - radius:
+          tooltip: The maximum distance in meters to scan (range [0.0, 96.0]).
+          type: float
+      - arc:
+          tooltip: The maximum angle in radians relative to the local X-axis to scan
+            (range [0.0, PI]).
+          type: float
+      - rate:
+          tooltip: The interval in seconds between repeated scans.
+          type: float
     energy: 10.0
     func-id: 29
     return: void
     sleep: 0.0
-    tooltip: Initiates a periodic scan every Rate seconds, for Name and ID with Type
-      (AGENT, ACTIVE, PASSIVE, and/or SCRIPTED) within Range meters and Arc radians
-      of forward vector.\nSpecifying a blank Name, 0 Type, or NULL_KEY ID will prevent
-      filtering results based on that parameter. A range of 0.0 does not perform a
-      scan.\nResults are returned in the sensor and no_sensor events.
+    tooltip: Sets up a repeating periodic scan every rate seconds for name and id of
+      type within radius meters and arc radians of the forward vector. Results
+      trigger sensor or no_sensor events.
     categories:
       - sensor
   llSetAgentEnvironment:
     arguments:
-    - agent_id:
-        tooltip: Agent to receive new environment settings.
-        type: key
-    - transition:
-        tooltip: Number of seconds over which to apply new settings.
-        type: float
-    - Settings:
-        tooltip: List of environment settings to replace for agent.
-        type: list
+      - agent_id:
+          tooltip: The UUID of the agent participating in the experience.
+          type: key
+      - transition:
+          tooltip: The transition duration in seconds.
+          type: float
+      - params:
+          tooltip: A list of environmental parameters to apply.
+          type: list
     energy: 10.0
     experience: true
     func-id: 714
     return: integer
     sleep: 0.0
-    tooltip: Sets an agent's environmental values to the specified values. Must be
-      used as part of an experience.
+    tooltip: Sets an individual agent's environmental settings using the attributes
+      in params over a duration of transition seconds. Must be used as part of
+      an experience; passing an empty list removes overrides.
     categories:
       - avatar
       - experience
@@ -13514,148 +14115,150 @@ functions:
       - region_appearance
   llSetAgentRot:
     arguments:
-    - rot:
-        tooltip: Rotation to turn the avatar to face.
-        type: rotation
-    - flags:
-        tooltip: flags
-        type: integer
+      - rot:
+          tooltip: The target rotation to turn the avatar to face.
+          type: rotation
+      - flags:
+          tooltip: Flags to configure the rotation behavior.
+          type: integer
     energy: 10.0
     func-id: 515
     return: void
     sleep: 0.0
-    tooltip: Sets the avatar rotation to the given value.
+    tooltip: Sets the rotation of the avatar to rot, controlled by flags.
     categories:
       - avatar
       - movement
       - physics
   llSetAlpha:
     arguments:
-    - Opacity:
-        tooltip: ''
-        type: float
-    - Face:
-        tooltip: ''
-        type: integer
+      - alpha:
+          tooltip: The transparency value to set, from 0.0 (clear) to 1.0 (solid; clamped
+            to a minimum of 0.1).
+          type: float
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 51
     return: void
     sleep: 0.0
-    tooltip: Sets the alpha (opacity) of Face.\nSets the alpha (opacity) value for
-      Face. If Face is ALL_SIDES, sets the alpha for all faces. The alpha value is
-      interpreted as an opacity percentage (1.0 is fully opaque, and 0.2 is mostly
-      transparent). This function will clamp alpha values less than 0.1 to 0.1 and
-      greater than 1.0 to 1.
+    tooltip: Sets the diffuse texture alpha (opacity) of face. If face is ALL_SIDES,
+      applies to all faces. Values are clamped between 0.1 and 1.0 (where 1.0 is
+      fully opaque).
     categories:
       - prim
       - prim_appearance
   llSetAngularVelocity:
     arguments:
-    - AngVel:
-        tooltip: The angular velocity to set the object to.
-        type: vector
-    - Local:
-        tooltip: If TRUE, the AngVel is treated as a local directional vector instead
-          of a regional directional vector.
-        type: integer
-        bool-semantics: true
+      - initial_omega:
+          tooltip: The angular velocity vector to apply (in radians per second).
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, initial_omega is treated as a local vector; if FALSE,
+            as a global region vector.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 379
     return: void
     sleep: 0.0
-    tooltip: Sets an object's angular velocity to AngVel, in local coordinates if
-      Local == TRUE (if the script is physical).\nHas no effect on non-physical objects.
+    tooltip: Sets the angular velocity of a physical object to initial_omega
+      (mass-independent). If local is TRUE, applied in local coordinates; if
+      FALSE, applied in global coordinates. Has no effect on non-physical
+      objects.
     categories:
       - movement
       - physics
   llSetAnimationOverride:
     arguments:
-    - AnimationState:
-        tooltip: ''
-        type: string
-    - AnimationName:
-        tooltip: ''
-        type: string
+      - anim_state:
+          tooltip: The animation state to override.
+          type: string
+      - anim:
+          tooltip: The name of an animation in the prim's inventory, or a built-in
+            animation name.
+          type: string
     energy: 10.0
     func-id: 501
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_OVERRIDE_ANIMATIONS
-    tooltip: Sets the animation (in object inventory) that will play for the given
-      animation state.\nTo use this function the script must obtain the PERMISSION_OVERRIDE_ANIMATIONS
-      permission.
+    tooltip: Overrides the default animation for anim_state with anim (which must be
+      in the object's inventory or a built-in animation). Requires the
+      PERMISSION_OVERRIDE_ANIMATIONS permission.
     categories:
       - avatar_animation
       - permissions
   llSetBuoyancy:
     arguments:
-    - Buoyancy:
-        tooltip: ''
-        type: float
+      - buoyancy:
+          tooltip: The float buoyancy value to set.
+          type: float
     energy: 10.0
     func-id: 122
     return: void
     sleep: 0.0
-    tooltip: Set the tasks buoyancy (0 is none, < 1.0 sinks, 1.0 floats, > 1.0 rises).\nSet
-      the object buoyancy. A value of 0 is none, less than 1.0 sinks, 1.0 floats,
-      and greater than 1.0 rises.
+    tooltip: Sets the buoyancy of a physical object (requires physics to be
+      enabled). A value of 0.0 offers no buoyancy, < 1.0 sinks, 1.0 counteracts
+      gravity, and > 1.0 rises.
     categories:
       - physics
   llSetCameraAtOffset:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset position vector in local coordinates relative to the prim.
+          type: vector
     energy: 10.0
     func-id: 244
     return: void
     sleep: 0.0
-    tooltip: Sets the camera used in this object, at offset, if an avatar sits on
-      it.\nSets the offset that an avatar's camera will be moved to if the avatar
-      sits on the object.
+    tooltip: Sets the target offset vector (in local coordinates) that a seated
+      avatar's camera will look at.
     categories:
       - camera
   llSetCameraEyeOffset:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset position vector in local coordinates relative to the prim.
+          type: vector
     energy: 10.0
     func-id: 243
     return: void
     sleep: 0.0
-    tooltip: Sets the camera eye offset used in this object if an avatar sits on it.
+    tooltip: Sets the eye offset vector (in local coordinates) where a seated
+      avatar's camera is positioned.
     categories:
       - camera
   llSetCameraParams:
     arguments:
-    - Parameters:
-        tooltip: ''
-        type: list
+      - rules:
+          tooltip: A strided list of rules and data pairs configuring the camera.
+          type: list
     energy: 10.0
     func-id: 313
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_CONTROL_CAMERA
-    tooltip: Sets multiple camera parameters at once. List format is [ rule-1, data-1,
-      rule-2, data-2 . . . rule-n, data-n ].\nRequires the PERMISSION_CONTROL_CAMERA runtime permission
-      (automatically granted to attached or sat on objects).
+    tooltip: Sets multiple camera parameters simultaneously using the list of rules.
+      Requires the PERMISSION_CONTROL_CAMERA runtime permission.
     categories:
       - avatar
       - camera
       - permissions
   llSetClickAction:
     arguments:
-    - Action:
-        tooltip: A CLICK_ACTION_* flag
-        type: integer
+      - action:
+          tooltip: The CLICK_ACTION_* flag representing the action to apply.
+          type: integer
     energy: 10.0
     func-id: 333
     return: void
     sleep: 0.0
-    tooltip: Sets the action performed when a prim is clicked upon.
+    tooltip: Sets the action (a CLICK_ACTION_* flag) performed when an avatar
+      left-clicks the prim.
     categories:
       - input
       - money
@@ -13664,308 +14267,311 @@ functions:
       - user_interface
   llSetColor:
     arguments:
-    - Color:
-        tooltip: ''
-        type: vector
-    - Face:
-        tooltip: ''
-        type: integer
+      - color:
+          tooltip: The color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+          type: vector
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 49
     return: void
     sleep: 0.0
-    tooltip: Sets the color, for the face.\nSets the color of the side specified.
-      If Face is ALL_SIDES, sets the color on all faces.
+    tooltip: Sets the Blinn-Phong diffuse RGB color of face. If face is ALL_SIDES,
+      applies the color to all faces.
     categories:
       - prim
       - prim_appearance
   llSetContentType:
     arguments:
-    - HTTPRequestID:
-        tooltip: A valid http_request() key
-        type: key
-    - ContentType:
-        tooltip: Media type to use with any following llHTTPResponse(HTTPRequestID,
-          ...)
-        type: integer
+      - request_id:
+          tooltip: The unique key identifying the incoming HTTP request.
+          type: key
+      - content_type:
+          tooltip: The CONTENT_TYPE_* constant representing the Internet media type to
+            use.
+          type: integer
     energy: 10.0
     func-id: 374
     return: void
     sleep: 0.0
-    tooltip: Set the media type of an LSL HTTP server response to ContentType.\nHTTPRequestID
-      must be a valid http_request ID. ContentType must be one of the CONTENT_TYPE_*
-      constants.
+    tooltip: Sets the 'Content-Type' header of subsequent HTTP server responses (via
+      llHTTPResponse) for request_id using the specified content_type (a
+      CONTENT_TYPE_* constant).
     categories:
       - media
       - prim_media
       - web
   llSetDamage:
     arguments:
-    - Damage:
-        tooltip: ''
-        type: float
+      - damage:
+          tooltip: The float damage value to set (range -100.0 for full heal to 100.0 for
+            instant kill).
+          type: float
     energy: 10.0
     func-id: 157
     return: void
     sleep: 0.0
-    tooltip: "Sets the amount of damage that will be done to an avatar that this task\
-      \ hits.\tTask will be killed.\\nSets the amount of damage that will be done\
-      \ to an avatar that this object hits. This object will be destroyed on damaging\
-      \ an avatar, and no collision event is triggered."
+    tooltip: Sets the amount of damage delivered when this object hits an avatar.
+      The object is immediately destroyed upon inflicting damage, and no
+      collision event is triggered.
     categories:
       - combat
   llSetEnvironment:
     arguments:
-    - Position:
-        tooltip: Location within the region.
-        type: vector
-    - EnvParams:
-        tooltip: List of environment settings to change for the specified parcel location.
-        type: list
+      - position:
+          tooltip: The position vector in region coordinates to specify the target parcel,
+            or <-1.0, -1.0, z> for the entire region (where z specifies the sky
+            track, or -1 for all tracks).
+          type: vector
+      - params:
+          tooltip: A list of environmental attributes and values to apply (or empty to
+            clear).
+          type: list
     energy: 10.0
     func-id: 717
     return: integer
     sleep: 0.0
-    tooltip: Returns a string with the requested data about the region.
+    tooltip: Overrides the environmental settings at position for a parcel (or
+      region if position is <-1.0, -1.0, z>) using the parameters in params.
+      Passing an empty params list removes previous overrides.
     categories:
       - parcel
       - parcel_appearance
   llSetExperienceKey:
     arguments:
-    - ExperienceID:
-        tooltip: ''
-        type: key
+      - experienceid:
+          tooltip: ''
+          type: key
     deprecated: true
     energy: 10.0
     func-id: 386
     private: true
     return: integer
     sleep: 0.0
-    tooltip: ''
+    tooltip: ""
     categories:
       - experience
   llSetForce:
     arguments:
-    - Force:
-        tooltip: Directional force.
-        type: vector
-    - Local:
-        tooltip: Boolean, if TRUE uses local axis, if FALSE uses region axis.
-        type: integer
-        bool-semantics: true
+      - force:
+          tooltip: The directional force vector to apply.
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, force is treated as a local vector; if FALSE, as a
+            global region vector.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 64
     return: void
     sleep: 0.0
-    tooltip: Sets Force on object, in object-local coordinates if Local == TRUE (otherwise,
-      the region reference frame is used).\nOnly works on physical objects.
+    tooltip: Applies a constant linear force to a physical object. If local is TRUE,
+      force is applied relative to local coordinates; if FALSE, applied relative
+      to region coordinates.
     categories:
       - movement
       - physics
   llSetForceAndTorque:
     arguments:
-    - Force:
-        tooltip: Directional force.
-        type: vector
-    - Torque:
-        tooltip: Torque force.
-        type: vector
-    - Local:
-        tooltip: Boolean, if TRUE uses local axis, if FALSE uses region axis.
-        type: integer
-        bool-semantics: true
+      - force:
+          tooltip: The directional linear force vector.
+          type: vector
+      - torque:
+          tooltip: The torque rotational force vector.
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, force and torque are treated as local vectors; if
+            FALSE, as global region vectors.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 76
     return: void
     sleep: 0.0
-    tooltip: Sets the Force and Torque of object, in object-local coordinates if Local
-      == TRUE (otherwise, the region reference frame is used).\nOnly works on physical
-      objects.
+    tooltip: Sets both the constant linear force and constant torque acting on a
+      physical object. If local is TRUE, forces are applied in local
+      coordinates; if FALSE, in global coordinates.
     categories:
       - movement
       - physics
   llSetGroundTexture:
     arguments:
-    - Changes:
-        tooltip: A list of ground texture properties to change.
-        type: list
+      - changes:
+          tooltip: A list of terrain detail properties and values to change.
+          type: list
     energy: 10.0
     func-id: 558
     return: integer
     sleep: 0.0
-    tooltip: Changes terrain texture properties in the region.
+    tooltip: Changes the painted terrain textures on the region based on changes.
+      The script owner must have estate management rights. Returns an integer
+      status.
     categories:
       - region
   llSetHoverHeight:
     arguments:
-    - Height:
-        tooltip: Distance above the ground.
-        type: float
-    - Water:
-        tooltip: Boolean, if TRUE then hover above water too.
-        type: integer
-        bool-semantics: true
-    - Tau:
-        tooltip: Seconds to critically damp in.
-        type: float
+      - height:
+          tooltip: The distance to hover above the ground or water.
+          type: float
+      - water:
+          tooltip: Boolean. If TRUE, hovers above water too; if FALSE, water is ignored.
+          type: integer
+          bool-semantics: true
+      - tau:
+          tooltip: The timescale in seconds to critically damp the movement.
+          type: float
     energy: 10.0
     func-id: 123
     return: void
     sleep: 0.0
-    tooltip: Critically damps a physical object to a Height (either above ground level
-      or above the higher of land and water if water == TRUE).\nDo not use with vehicles.
-      Use llStopHover to stop hovering.
+    tooltip: Critically damps the physical object's vertical movement to hover at
+      height (above ground, or above water if water is TRUE) in tau seconds. Do
+      not use with vehicles; call llStopHover to cancel.
     categories:
       - movement
       - physics
   llSetInventoryPermMask:
     arguments:
-    - InventoryItem:
-        tooltip: An item in the prim's inventory
-        type: string
-    - PermissionFlag:
-        tooltip: MASK_* flag
-        type: integer
-    - PermissionMask:
-        tooltip: Permission bit-field (PERM_* flags)
-        type: integer
+      - item:
+          tooltip: The name of the item in the prim's inventory.
+          type: string
+      - category:
+          tooltip: The MASK_* category flag (such as MASK_NEXT, MASK_OWNER, etc.).
+          type: integer
+      - value:
+          tooltip: The bitfield of permissions (PERM_* flags) to set.
+          type: integer
     energy: 10.0
     func-id: 290
     god-mode: true
     return: void
     sleep: 0.0
-    tooltip: Sets the given permission mask to the new value on the inventory item.
+    tooltip: Sets the specified permission category of the inventory item to the
+      value permissions mask.
     categories:
       - asset_permissions
       - prim_inventory
   llSetKeyframedMotion:
     arguments:
-    - Keyframes:
-        tooltip: 'Strided keyframe list of the form: position, orientation, time.
-          Each keyframe is interpreted relative to the previous transform of the object.'
-        type: list
-    - Options:
-        tooltip: ''
-        type: list
+      - keyframes:
+          tooltip: A strided list of the form [vector position, rotation orientation,
+            float time] representing sequential relative keyframes (minimum time
+            is 1/9s).
+          type: list
+      - options:
+          tooltip: A list of options (KFM_* constants) to modify playback behavior.
+          type: list
     energy: 10.0
     func-id: 394
     return: void
     sleep: 0.0
-    tooltip: Requests that a non-physical object be key-framed according to key-frame
-      list.\nSpecify a list of times, positions, and orientations to be followed by
-      an object. The object will be smoothly moved between key-frames by the simulator.
-      Collisions with other non-physical or key-framed objects will be ignored (no
-      script events will fire and collision processing will not occur). Collisions
-      with physical objects will be computed and reported, but the key-framed object
-      will be unaffected by those collisions.\nKeyframes is a strided list containing
-      positional, rotational, and time data for each step in the motion.  Options
-      is a list containing optional arguments and parameters (specified by KFM_* constants).
+    tooltip: Smoothly moves a non-physical object between the positions,
+      orientations, and times specified in the keyframes list, configured via
+      options. Collisions with keyframed objects are ignored. An empty keyframes
+      list terminates the motion.
     categories:
       - movement
       - physics
   llSetLinkAlpha:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
-    - Opacity:
-        tooltip: ''
-        type: float
-    - Face:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - alpha:
+          tooltip: The transparency value to set, from 0.0 (clear) to 1.0 (solid).
+          type: float
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 274
     return: void
     sleep: 0.0
-    tooltip: If a prim exists in the link chain at LinkNumber, set Face to Opacity.\nSets
-      the Face, on the linked prim specified, to the Opacity.
+    tooltip: Sets the Blinn-Phong alpha (transparency) of face on the linked prim link.
     categories:
       - linkset
       - prim_appearance
   llSetLinkCamera:
     arguments:
-    - LinkNumber:
-        tooltip: 'Prim link number (0: unlinked, 1: root prim, >1: child prims) or
-          a LINK_* flag'
-        type: integer
-    - EyeOffset:
-        tooltip: Offset, relative to the object's centre and expressed in local coordinates,
-          that the camera looks from.
-        type: vector
-    - LookOffset:
-        tooltip: Offset, relative to the object's centre and expressed in local coordinates,
-          that the camera looks toward.
-        type: vector
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - eye:
+          tooltip: The eye offset position vector in local coordinates relative to the
+            prim.
+          type: vector
+      - at:
+          tooltip: The look-at offset position vector in local coordinates relative to the
+            prim.
+          type: vector
     energy: 10.0
     func-id: 377
     return: void
     sleep: 0.0
-    tooltip: Sets the camera eye offset, and the offset that camera is looking at,
-      for avatars that sit on the linked prim.
+    tooltip: Sets the camera eye position offset eye and looking-at position offset
+      at for avatars who sit on the linked prim link.
     categories:
       - camera
       - sit
   llSetLinkColor:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag.'
-        type: integer
-    - Color:
-        tooltip: Color in RGB <R.R, G.G, B.B>
-        type: vector
-    - Face:
-        tooltip: Side number or ALL_SIDES.
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - color:
+          tooltip: The color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+          type: vector
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 140
     return: void
     sleep: 0.0
-    tooltip: If a task exists in the link chain at LinkNumber, set the Face to color.\nSets
-      the color of the linked child's side, specified by LinkNumber.
+    tooltip: Sets the Blinn-Phong diffuse RGB color of face on the linked prim link.
     categories:
       - linkset
       - prim_appearance
   llSetLinkGLTFOverrides:
     arguments:
-    - link:
-        tooltip: Link number to check.
-        type: integer
-    - face:
-        tooltip: Side to check for a PBR material. Use ALL_SIDES to check for all.
-        type: integer
-    - options:
-        tooltip: List of individual overrides to set.
-        type: list
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
+      - params:
+          tooltip: A list of overrides and their corresponding values to set.
+          type: list
     energy: 10.0
     func-id: 560
     return: void
     sleep: 0.0
-    tooltip: Sets or changes GLTF Overrides set on the selected faces.
+    tooltip: Sets or removes individual GLTF override parameters specified by params
+      on face of the linked prim link.
     categories:
       - linkset
       - prim_appearance
   llSetLinkMedia:
     arguments:
-    - Link:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims).'
-        type: integer
-    - Face:
-        tooltip: Face number.
-        type: integer
-    - Parameters:
-        tooltip: A set of name/value pairs (in no particular order)
-        type: list
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - face:
+          tooltip: The face number (side) of the prim.
+          type: integer
+      - params:
+          tooltip: A set of property-value pairs (in no particular order) specifying media
+            parameters.
+          type: list
     energy: 10.0
     func-id: 371
     return: integer
     sleep: 0.0
-    tooltip: Set the media parameters for a particular face on linked prim, specified
-      by Link. Returns an integer that is a STATUS_* flag which details the success/failure
-      of the operation(s).\nMediaParameters is a set of name/value pairs in no particular
-      order. Parameters not specified are unchanged, or if new media is added then
-      set to the default specified.
+    tooltip: Sets the media parameters specified by params on face of the linked
+      prim link without a script delay. Returns an integer STATUS_* flag
+      detailing success or failure.
     categories:
       - linkset
       - media
@@ -13973,13 +14579,12 @@ functions:
       - web
   llSetLinkPrimitiveParams:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - Parameters:
-        tooltip: ''
-        type: list
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - rules:
+          tooltip: A list of PRIM_* rules and data to apply.
+          type: list
     deprecated:
       use: ll.SetLinkPrimitiveParamsFast
       selene-replace: ["ll.SetLinkPrimitiveParamsFast(%...)"]
@@ -13987,331 +14592,323 @@ functions:
     func-id: 328
     return: void
     sleep: 0.2
-    tooltip: 'Deprecated: Use llSetLinkPrimitiveParamsFast instead.'
+    tooltip: Deprecated (use llSetLinkPrimitiveParamsFast instead). Sets primitive
+      parameters for the linked prim link according to rules.
     categories:
       - linkset
       - prim_appearance
       - prim_properties
   llSetLinkPrimitiveParamsFast:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag'
-        type: integer
-    - Parameters:
-        tooltip: ''
-        type: list
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - rules:
+          tooltip: A list of PRIM_* rules and data to apply.
+          type: list
     energy: 10.0
     func-id: 353
     return: void
     sleep: 0.0
-    tooltip: Set primitive parameters for LinkNumber based on Parameters, without
-      a delay.\nSet parameters for link number, from the list of Parameters, with
-      no built-in script sleep. This function is identical to llSetLinkPrimitiveParams,
-      except without the delay.
+    tooltip: Sets primitive parameters for the linked prim link according to rules
+      with no built-in script sleep delay.
     categories:
       - linkset
       - prim_appearance
       - prim_properties
   llSetLinkRenderMaterial:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
-    - RenderMaterial:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Face:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - material:
+          tooltip: The name of a material in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 762
     return: void
     sleep: 0.2
-    tooltip: Sets the Render Material of Face on a linked prim, specified by LinkNumber.
-      Render Material may be a UUID or name of a material in prim inventory.
+    tooltip: "Applies material (UUID or inventory name) to face of the linked prim
+      link. Note: This clears most PRIM_GLTF_* properties on the face except for
+      repeats, offsets, and rotation."
     categories:
       - linkset
       - prim_appearance
   llSetLinkSitFlags:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag.'
-        type: integer
-    - Flags:
-        tooltip: The new set of sit flags to apply to the specified prims in this
-          linkset.
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - flags:
+          tooltip: A bitfield of sit flags (SIT_FLAG_*) to apply.
+          type: integer
     energy: 10.0
     func-id: 550
     return: void
     sleep: 0.0
-    tooltip: Sets the sit flags for the specified prim in a linkset.
+    tooltip: Sets the sit target flags for the linked prim link inside the linkset.
     categories:
       - linkset
       - sit
   llSetLinkTexture:
     arguments:
-    - LinkNumber:
-        tooltip: ''
-        type: integer
-    - Texture:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Face:
-        tooltip: ''
-        type: integer
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag.
+          type: integer
+      - texture:
+          tooltip: The name of a texture in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 329
     return: void
     sleep: 0.2
-    tooltip: Sets the Texture of Face on a linked prim, specified by LinkNumber. Texture
-      may be a UUID or name of a texture in prim inventory.
+    tooltip: Applies texture (UUID or inventory name) to face of the linked prim link.
     categories:
       - linkset
       - prim_appearance
   llSetLinkTextureAnim:
     arguments:
-    - LinkNumber:
-        tooltip: 'Link number (0: unlinked, 1: root prim, >1: child prims) or a LINK_*
-          flag to effect'
-        type: integer
-    - Mode:
-        tooltip: Bitmask of animation options.
-        type: integer
-    - Face:
-        tooltip: Specifies which object face to animate or ALL_SIDES.
-        type: integer
-    - SizeX:
-        tooltip: Horizontal frames (ignored for ROTATE and SCALE).
-        type: integer
-    - SizeY:
-        tooltip: Vertical frames (ignored for ROTATE and SCALE).
-        type: integer
-    - Start:
-        tooltip: Start position/frame number (or radians for ROTATE).
-        type: float
-    - Length:
-        tooltip: Specifies the animation duration, in frames (or radians for ROTATE).
-        type: float
-    - Rate:
-        tooltip: Specifies the animation playback rate, in frames per second (must
-          be greater than zero).
-        type: float
+      - link:
+          tooltip: The link number (1 for root, >1 for children) or a LINK_* flag to
+            animate.
+          type: integer
+      - mode:
+          tooltip: The bitfield of texture animation mode flags (ANIM_ON, LOOP, etc.).
+          type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
+      - sizex:
+          tooltip: The number of horizontal frames (ignored for ROTATE and SCALE).
+          type: integer
+      - sizey:
+          tooltip: The number of vertical frames (ignored for ROTATE and SCALE).
+          type: integer
+      - start:
+          tooltip: The start frame number (or radians for ROTATE).
+          type: float
+      - length:
+          tooltip: The number of frames to display (or radians for ROTATE).
+          type: float
+      - rate:
+          tooltip: The playback rate in frames per second (or radians/sec for ROTATE, UV
+            coords/sec for SMOOTH). Must not be zero.
+          type: float
     energy: 10.0
     func-id: 356
     return: void
     sleep: 0.0
-    tooltip: Animates a texture on the prim specified by LinkNumber, by setting the
-      texture scale and offset.\nMode is a bitmask of animation options.\nFace specifies
-      which object face to animate.\nSizeX and SizeY specify the number of horizontal
-      and vertical frames.Start specifes the animation start point.\nLength specifies
-      the animation duration.\nRate specifies the animation playback rate.
+    tooltip: Animates the texture on face of the linked prim link by setting the
+      scale and offset according to mode. Parameters sizex/sizey define frames,
+      start defines the start frame/angle, length defines duration, and rate
+      defines playback speed.
     categories:
       - effects
       - linkset
       - prim_appearance
   llSetLocalRot:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - rot:
+          tooltip: The local rotation to set.
+          type: rotation
     energy: 10.0
     func-id: 284
     return: void
     sleep: 0.2
-    tooltip: Sets the rotation of a child prim relative to the root prim.
+    tooltip: Sets the rotation of a child prim relative to its root prim using rot.
     categories:
       - movement
       - prim
   llSetMemoryLimit:
     arguments:
-    - Limit:
-        tooltip: The amount to reserve, which must be less than the allowed maximum
-          (currently 64KB) and not already have been exceeded.
-        type: integer
+      - limit:
+          tooltip: The integer memory limit in bytes to reserve (must be less than the
+            64KB maximum).
+          type: integer
     energy: 10.0
     func-id: 369
     return: integer
     bool-semantics: true
     slua-removed: true
     sleep: 0.0
-    tooltip: Requests Limit bytes to be reserved for this script.\nReturns TRUE or
-      FALSE indicating whether the limit was set successfully.\nThis function has
-      no effect if the script is running in the LSO VM.
+    tooltip: Requests that limit bytes are reserved for the script. Returns TRUE on
+      success or FALSE on failure (has no effect in LSO).
     categories:
       - script
   llSetObjectDesc:
     arguments:
-    - Description:
-        tooltip: ''
-        type: string
+      - description:
+          tooltip: The new description string (up to 127 characters).
+          type: string
     energy: 10.0
     func-id: 271
     return: void
     sleep: 0.0
-    tooltip: Sets the description of the prim to Description.\nThe description field
-      is limited to 127 characters.
+    tooltip: Sets the description of the prim containing the script to description
+      (limited to 127 characters).
     categories:
       - prim
       - prim_properties
   llSetObjectName:
     arguments:
-    - Name:
-        tooltip: ''
-        type: string
+      - name:
+          tooltip: The new name string.
+          type: string
     energy: 10.0
     func-id: 203
     return: void
     sleep: 0.0
-    tooltip: Sets the prim's name to Name.
+    tooltip: Sets the name of the prim containing the script to name.
     categories:
       - prim
       - prim_properties
   llSetObjectPermMask:
     arguments:
-    - PermissionFlag:
-        tooltip: MASK_* flag
-        type: integer
-    - PermissionMask:
-        tooltip: Permission bit-field (PERM_* flags)
-        type: integer
+      - mask:
+          tooltip: The MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, etc.).
+          type: integer
+      - value:
+          tooltip: The bitfield of permissions (PERM_* flags) to set.
+          type: integer
     energy: 10.0
     func-id: 288
     god-mode: true
     return: void
     sleep: 0.0
-    tooltip: Sets the specified PermissionFlag permission to the value specified by
-      PermissionMask on the object the script is attached to.
+    tooltip: Sets the specified permission mask category to value on the root object
+      containing the script.
     categories:
       - asset_permissions
       - linkset
   llSetParcelForSale:
     arguments:
-    - ForSale:
-        tooltip: If TRUE, the parcel is put up for sale.
-        type: integer
-        bool-semantics: true
-    - Options:
-        tooltip: A list of options to set for the sale.
-        type: list
+      - ForSale:
+          tooltip: Boolean. If TRUE, puts the parcel up for sale; if FALSE, removes it
+            from sale.
+          type: integer
+          bool-semantics: true
+      - Options:
+          tooltip: A list of options to configure the sale (e.g., price, authorized buyer,
+            and object inclusion).
+          type: list
     energy: 10.0
     func-id: 561
     return: integer
     sleep: 0.0
     requires-permission:
       - PERMISSION_PRIVILEGED_LAND_ACCESS
-    tooltip: Sets the parcel the object is on for sale.\nForSale is a boolean, if TRUE
-      the parcel is put up for sale. Options is a list of options to set for the sale,
-      such as price, authorized buyer, and whether to include objects on the parcel.\n
-      Setting ForSale to FALSE will remove the parcel from sale and clear any options
-      that were set.\nRequires the PERMISSION_PRIVILEGED_LAND_ACCESS permission.
+    tooltip: Sets the parcel the object is on for sale. If ForSale is TRUE, puts the
+      land up for sale using Options (price, buyer, objects included). Setting
+      ForSale to FALSE removes the parcel from sale. Requires parcel ownership
+      and the PERMISSION_PRIVILEGED_LAND_ACCESS permission. Returns an error
+      code or 0 if successful.
     categories:
       - parcel
   llSetParcelMusicURL:
     arguments:
-    - URL:
-        tooltip: ''
-        type: string
+      - url:
+          tooltip: The streaming audio URL string.
+          type: string
     energy: 10.0
     func-id: 267
     return: void
     sleep: 2.0
-    tooltip: Sets the streaming audio URL for the parcel the object is on.\nThe object
-      must be owned by the owner of the parcel; if the parcel is group owned the object
-      must be owned by that group.
+    tooltip: Sets the streaming audio (music) URL for the parcel containing the
+      object. The object owner must match the landowner or land group.
     categories:
       - media
       - parcel
       - parcel_media
   llSetPayPrice:
     arguments:
-    - Price:
-        tooltip: The default price shown in the text input field.
-        type: integer
-    - QuickButtons:
-        tooltip: Specifies the 4 payment values shown in the payment dialog's buttons
-          (or PAY_HIDE).
-        type: list
-        slua-type: "{number}"
+      - price:
+          tooltip: The default price integer shown in the text field (can accept PAY_*
+            constants or positive values).
+          type: integer
+      - quick_pay_buttons:
+          tooltip: A list of four integer values or PAY_* constants specifying the button
+            payment choices.
+          type: list
+          slua-type: "{number}"
     energy: 10.0
     func-id: 302
     return: void
     sleep: 0.0
-    tooltip: Sets the default amount when someone chooses to pay this object.\nPrice
-      is the default price shown in the text input field.  QuickButtons specifies
-      the 4 payment values shown in the payment dialog's buttons.\nInput field and
-      buttons may be hidden with PAY_HIDE constant, and may be set to their default
-      values using PAY_DEFAULT.
+    tooltip: Suggests default amounts for the pay text input field price and the
+      four payment dialog quick_pay_buttons when an avatar pays this object.
     categories:
       - money
       - prim_properties
       - user_interface
   llSetPhysicsMaterial:
     arguments:
-    - MaterialBits:
-        tooltip: A bitmask specifying which of the parameters in the other arguments
-          should be applied to the object.
-        type: integer
-    - GravityMultiplier:
-        tooltip: ''
-        type: float
-    - Restitution:
-        tooltip: ''
-        type: float
-    - Friction:
-        tooltip: ''
-        type: float
-    - Density:
-        tooltip: ''
-        type: float
+      - mask:
+          tooltip: The bitwise mask combination specifying which of the floats (DENSITY,
+            FRICTION, RESTITUTION, or GRAVITY_MULTIPLIER) to apply.
+          type: integer
+      - gravity_multiplier:
+          tooltip: The gravity multiplier float value (range [-1.0, +28.0], default is
+            1.0).
+          type: float
+      - restitution:
+          tooltip: The elasticity restitution float value (range [0.0, 1.0]).
+          type: float
+      - friction:
+          tooltip: The friction coefficient float value (range [0.0, 255.0]).
+          type: float
+      - density:
+          tooltip: The density float value in kg/m³ (range [1.0, 22587.0]).
+          type: float
     energy: 10.0
     func-id: 380
     return: void
     sleep: 0.0
-    tooltip: Sets the selected parameters of the object's physics behavior.\nMaterialBits
-      is a bitmask specifying which of the parameters in the other arguments should
-      be applied to the object. GravityMultiplier, Restitution, Friction, and Density
-      are the possible parameters to manipulate.
+    tooltip: Configures the physical characteristics of an object. The mask bitfield
+      specifies which of the other parameters (gravity_multiplier, restitution,
+      friction, or density) should be applied to the object.
     categories:
       - physics
       - prim
       - prim_properties
   llSetPos:
     arguments:
-    - Position:
-        tooltip: Region coordinates to move to (within 10m).
-        type: vector
+      - pos:
+          tooltip: The position vector to move to (in region coordinates, or local
+            coordinates if in a child prim).
+          type: vector
     energy: 10.0
     func-id: 58
     return: void
     sleep: 0.2
-    tooltip: If the object is not physical, this function sets the position of the
-      prim.\nIf the script is in a child prim, Position is treated as root relative
-      and the link-set is adjusted.\nIf the prim is the root prim, the entire object
-      is moved (up to 10m) to Position in region coordinates.
+    tooltip: Moves the non-physical object or prim toward the vector pos (up to
+      10m). If called in a child prim, pos is treated as root-relative; if
+      called from the root prim, the entire object is moved.
     categories:
       - movement
       - prim
   llSetPrimMediaParams:
     arguments:
-    - Face:
-        tooltip: Face number
-        type: integer
-    - MediaParameters:
-        tooltip: A set of name/value pairs (in no particular order)
-        type: list
+      - face:
+          tooltip: The face number (side) of the prim.
+          type: integer
+      - params:
+          tooltip: A set of property-value pairs (in no particular order) specifying media
+            parameters.
+          type: list
     energy: 10.0
     func-id: 350
     return: integer
     sleep: 1.0
-    tooltip: Sets the MediaParameters for a particular Face on the prim. Returns an
-      integer that is a STATUS_* flag which details the success/failure of the operation(s).\nMediaParameters
-      is a set of name/value pairs in no particular order. Parameters not specified
-      are unchanged, or if new media is added then set to the default specified.
+    tooltip: Sets the media parameters specified by params on the designated face of
+      the prim. Returns an integer STATUS_* flag detailing success or failure.
     categories:
       - media
       - prim
@@ -14319,9 +14916,9 @@ functions:
       - web
   llSetPrimURL:
     arguments:
-    - URL:
-        tooltip: ''
-        type: string
+      - url:
+          tooltip: The web URL to display.
+          type: string
     deprecated:
       use: ll.SetPrimMediaParams
       selene-replace: ["ll.SetPrimMediaParams(ALL_SIDES, {PRIM_MEDIA_CURRENT_URL, %1})"]
@@ -14329,7 +14926,8 @@ functions:
     func-id: 305
     return: void
     sleep: 20.0
-    tooltip: 'Deprecated: Use llSetPrimMediaParams instead.'
+    tooltip: Deprecated (use llSetPrimMediaParams instead). Updates the URL
+      displayed on the prim's faces.
     categories:
       - media
       - prim
@@ -14337,9 +14935,9 @@ functions:
       - web
   llSetPrimitiveParams:
     arguments:
-    - Parameters:
-        tooltip: A list of changes.
-        type: list
+      - rules:
+          tooltip: A list of PRIM_* rules and data to apply.
+          type: list
     deprecated:
       use: ll.SetLinkPrimitiveParamsFast
       selene-replace: ["ll.SetLinkPrimitiveParamsFast(%...)"]
@@ -14347,187 +14945,187 @@ functions:
     func-id: 259
     return: void
     sleep: 0.2
-    tooltip: 'Deprecated: Use llSetLinkPrimitiveParamsFast instead.'
+    tooltip: Deprecated (use llSetLinkPrimitiveParamsFast instead). Sets the prim's
+      attributes according to rules.
     categories:
       - prim
       - prim_appearance
       - prim_properties
   llSetRegionPos:
     arguments:
-    - Position:
-        tooltip: Vector. The location to move to, in region coordinates.
-        type: vector
+      - position:
+          tooltip: The target position vector in region coordinates (can cross up to 10m
+            over a region border).
+          type: vector
     energy: 10.0
     func-id: 397
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Attempts to move the object so that the root prim is within 0.1m of Position.\nReturns
-      an integer boolean, TRUE if the object is successfully placed within 0.1 m of
-      Position, FALSE otherwise.\nPosition may be any location within the region or
-      up to 10m across a region border.\nIf the position is below ground, it will
-      be set to the ground level at that x,y location.
+    tooltip: Tries to move the entire object so that its root prim is within 0.1m of
+      the vector position (underground positions are set to ground level).
+      Returns TRUE on success or FALSE on failure.
     categories:
       - movement
       - prim
   llSetRemoteScriptAccessPin:
     arguments:
-    - PIN:
-        tooltip: ''
-        type: integer
+      - pin:
+          tooltip: The integer PIN code (non-zero enables, zero disables).
+          type: integer
     energy: 10.0
     func-id: 252
     return: void
     sleep: 0.2
-    tooltip: If PIN is set to a non-zero number, the task will accept remote script
-      loads via llRemoteLoadScriptPin() if it passes in the correct PIN. Othersise,
-      llRemoteLoadScriptPin() is ignored.
+    tooltip: Sets the prim's remote script access PIN to pin (a non-zero value
+      enables loading via llRemoteLoadScriptPin, while zero disables it).
     categories:
       - prim_inventory
       - script
   llSetRenderMaterial:
     arguments:
-    - Material:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Face:
-        tooltip: ''
-        type: integer
+      - material:
+          tooltip: The name of a material in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 761
     return: void
     sleep: 0.2
-    tooltip: Applies Render Material to Face of prim.\nRender Material may be a UUID
-      or name of a material in prim inventory.\nIf Face is ALL_SIDES, set the render
-      material on all faces.
+    tooltip: "Applies material (UUID or inventory name) to face of the prim. Note:
+      This clears most PRIM_GLTF_* properties on the face except for repeats,
+      offsets, and rotation."
     categories:
       - prim
       - prim_appearance
   llSetRot:
     arguments:
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - rot:
+          tooltip: The target rotation.
+          type: rotation
     energy: 10.0
     func-id: 61
     return: void
     sleep: 0.2
-    tooltip: If the object is not physical, this function sets the rotation of the
-      prim.\nIf the script is in a child prim, Rotation is treated as root relative
-      and the link-set is adjusted.\nIf the prim is the root prim, the entire object
-      is rotated to Rotation in the global reference frame.
+    tooltip: Sets the rotation of the prim to rot. If in a child prim, rot is
+      treated as root-relative; if in the root prim of a non-physical object,
+      rotates the entire object.
     categories:
       - movement
       - prim
   llSetScale:
     arguments:
-    - Scale:
-        tooltip: ''
-        type: vector
+      - size:
+          tooltip: The target size vector.
+          type: vector
     energy: 10.0
     func-id: 47
     return: void
     sleep: 0.0
-    tooltip: Sets the prim's scale (size) to Scale.
+    tooltip: Sets the physical scale (dimensions) of the prim containing the script
+      to size.
     categories:
       - prim
       - prim_appearance
   llSetScriptState:
     arguments:
-    - ScriptName:
-        tooltip: ''
-        type: string
-    - Running:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
+      - name:
+          tooltip: The name of the script in the prim's inventory.
+          type: string
+      - running:
+          tooltip: Boolean. If TRUE, enables the script; if FALSE, disables it.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 148
     return: void
     sleep: 0.0
-    tooltip: Enable or disable the script Running state of Script in the prim.
+    tooltip: Sets the running state of the script name in the prim's inventory. If
+      running is TRUE, the script is enabled; if FALSE, it is disabled.
     categories:
       - prim_inventory
       - script
   llSetSitText:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - text:
+          tooltip: The context menu text to display.
+          type: string
     energy: 10.0
     func-id: 242
     return: void
     sleep: 0.0
-    tooltip: Displays Text rather than 'Sit' in the viewer's context menu.
+    tooltip: Displays the string text instead of 'Sit' (or 'Sit Here') in the
+      viewer's right-click context menu.
     categories:
       - prim
       - sit
       - user_interface
   llSetSoundQueueing:
     arguments:
-    - QueueEnable:
-        tooltip: 'Boolean, sound queuing: TRUE enables, FALSE disables (default).'
-        type: integer
-        bool-semantics: true
+      - queue:
+          tooltip: Boolean. If TRUE, sound queuing is enabled; if FALSE, it is disabled.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 208
     return: void
     sleep: 0.0
-    tooltip: Sets whether successive calls to llPlaySound, llLoopSound, etc., (attached
-      sounds) interrupt the currently playing sound.\nThe default for objects is FALSE.
-      Setting this value to TRUE will make the sound wait until the current playing
-      sound reaches its end. The queue is one level deep.
+    tooltip: Sets whether attached sounds wait for the current sound to end before
+      playing (enables queuing if queue is TRUE, disables if FALSE). The queue
+      is one level deep.
     categories:
       - sound
   llSetSoundRadius:
     arguments:
-    - Radius:
-        tooltip: Maximum distance that sounds can be heard.
-        type: float
+      - radius:
+          tooltip: The maximum distance in meters at which the sounds can be heard.
+          type: float
     energy: 10.0
     func-id: 209
     return: void
     sleep: 0.0
-    tooltip: Limits radius for audibility of scripted sounds (both attached and triggered)
-      to distance Radius.
+    tooltip: Limits the audibility radius of attached and triggered scripted sounds
+      to distance radius.
     categories:
       - sound
   llSetStatus:
     arguments:
-    - Status:
-        tooltip: ''
-        type: integer
-    - Value:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
+      - status:
+          tooltip: The bitmask representing the STATUS_* flag(s) to change.
+          type: integer
+      - value:
+          tooltip: Boolean. If TRUE, enables the status; if FALSE, disables it.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 45
     return: void
     sleep: 0.0
-    tooltip: Sets object status specified in Status bitmask (e.g. STATUS_PHYSICS|STATUS_PHANTOM)
-      to boolean Value.\nFor a full list of STATUS_* constants, see wiki documentation.
+    tooltip: Sets the object status attributes specified by status to value.
     categories:
       - linkset
       - physics
       - prim_properties
   llSetText:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
-    - Color:
-        tooltip: ''
-        type: vector
-    - Opacity:
-        tooltip: ''
-        type: float
+      - text:
+          tooltip: The floating text string to display.
+          type: string
+      - color:
+          tooltip: The color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+          type: vector
+      - alpha:
+          tooltip: The transparency value to set, from 0.0 (clear) to 1.0 (solid).
+          type: float
     energy: 10.0
     func-id: 152
     return: void
     sleep: 0.0
-    tooltip: Causes Text to float above the prim, using the specified Color and Opacity.
+    tooltip: Displays floating text above the prim with the specified color vector
+      and transparency alpha.
     categories:
       - avatar_communication
       - effects
@@ -14535,245 +15133,243 @@ functions:
       - prim_properties
   llSetTexture:
     arguments:
-    - Texture:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Face:
-        tooltip: ''
-        type: integer
+      - texture:
+          tooltip: The name of a texture in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
     energy: 10.0
     func-id: 53
     return: void
     sleep: 0.2
-    tooltip: Applies Texture to Face of prim.\nTexture may be a UUID or name of a
-      texture in prim inventory.\nIf Face is ALL_SIDES, set the texture on all faces.
+    tooltip: Applies the Blinn-Phong diffuse texture to face of the prim.
     categories:
       - prim
       - prim_appearance
   llSetTextureAnim:
     arguments:
-    - Mode:
-        tooltip: Mask of Mode flags.
-        type: integer
-    - Face:
-        tooltip: Face number or ALL_SIDES.
-        type: integer
-    - SizeX:
-        tooltip: Horizontal frames (ignored for ROTATE and SCALE).
-        type: integer
-    - SizeY:
-        tooltip: Vertical frames (ignored for ROTATE and SCALE).
-        type: integer
-    - Start:
-        tooltip: Start position/frame number (or radians for ROTATE).
-        type: float
-    - Length:
-        tooltip: number of frames to display (or radians for ROTATE).
-        type: float
-    - Rate:
-        tooltip: Frames per second (must not greater than zero).
-        type: float
+      - mode:
+          tooltip: The bitfield of texture animation mode flags (ANIM_ON, LOOP, etc.).
+          type: integer
+      - face:
+          tooltip: The face number or ALL_SIDES.
+          type: integer
+      - sizex:
+          tooltip: The number of horizontal frames (ignored for ROTATE and SCALE).
+          type: integer
+      - sizey:
+          tooltip: The number of vertical frames (ignored for ROTATE and SCALE).
+          type: integer
+      - start:
+          tooltip: The start frame number (or radians for ROTATE).
+          type: float
+      - length:
+          tooltip: The number of frames to display (or radians for ROTATE).
+          type: float
+      - rate:
+          tooltip: The playback rate in frames per second (or radians/sec for ROTATE, UV
+            coords/sec for SMOOTH). Must not be zero.
+          type: float
     energy: 10.0
     func-id: 211
     return: void
     sleep: 0.0
-    tooltip: Animates a texture by setting the texture scale and offset.\nMode is
-      a bitmask of animation options.\nFace specifies which object face to animate.\nSizeX
-      and SizeY specify the number of horizontal and vertical frames.Start specifes
-      the animation start point.\nLength specifies the animation duration.\nRate specifies
-      the animation playback rate.
+    tooltip: Animates the texture on face of the prim by setting its scale and
+      offset. mode defines options, sizex/sizey define frames, start defines the
+      start frame/angle, length defines duration, and rate defines playback
+      speed.
     categories:
       - effects
       - prim
       - prim_appearance
   llSetTimerEvent:
     arguments:
-    - Rate:
-        tooltip: ''
-        type: float
+      - sec:
+          tooltip: The interval in seconds between timer events (0.0 to disable).
+          type: float
     energy: 10.0
     func-id: 107
     return: void
     slua-removed: true
     sleep: 0.0
-    tooltip: Causes the timer event to be triggered every Rate seconds.\n Passing
-      in 0.0 stops further timer events.
+    tooltip: Sets a timer to trigger a timer event periodically every sec seconds.
+      Passing 0.0 stops further timer events.
     categories:
       - script
       - time
   llSetTorque:
     arguments:
-    - Torque:
-        tooltip: Torque force.
-        type: vector
-    - Local:
-        tooltip: Boolean, if TRUE uses local axis, if FALSE uses region axis.
-        type: integer
-        bool-semantics: true
+      - torque:
+          tooltip: The torque rotational force vector.
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, torque is treated as a local vector; if FALSE, as a
+            global region vector.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 74
     return: void
     sleep: 0.0
-    tooltip: Sets the Torque acting on the script's object, in object-local coordinates
-      if Local == TRUE (otherwise, the region reference frame is used).\nOnly works
-      on physical objects.
+    tooltip: Applies a constant torque rotational force to a physical object. If
+      local is TRUE, torque is applied in local coordinates; if FALSE, applied
+      in global coordinates.
     categories:
       - movement
       - physics
   llSetTouchText:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - text:
+          tooltip: The context menu text to display.
+          type: string
     energy: 10.0
     func-id: 241
     return: void
     sleep: 0.0
-    tooltip: Displays Text in the viewer context menu that acts on a touch.
+    tooltip: Displays the string text instead of 'Touch' in the right-click context
+      menu.
     categories:
       - prim_properties
       - touch
       - user_interface
   llSetVehicleFlags:
     arguments:
-    - Flags:
-        tooltip: ''
-        type: integer
+      - flags:
+          tooltip: A bitwise mask of VEHICLE_FLAG_* constants to enable.
+          type: integer
     energy: 10.0
     func-id: 236
     return: void
     sleep: 0.0
-    tooltip: Enables the vehicle flags specified in the Flags bitmask.\nValid parameters
-      can be found in the wiki documentation.
+    tooltip: Enables the vehicle flags specified in the Flags bitmask.
     categories:
       - vehicles
   llSetVehicleFloatParam:
     arguments:
-    - ParameterName:
-        tooltip: ''
-        type: integer
-    - ParameterValue:
-        tooltip: ''
-        type: float
+      - param:
+          tooltip: The VEHICLE_* float parameter constant to set.
+          type: integer
+      - value:
+          tooltip: The float value to set.
+          type: float
     energy: 10.0
     func-id: 233
     return: void
     sleep: 0.0
-    tooltip: Sets a vehicle float parameter.\nValid parameters can be found in the
-      wiki documentation.
+    tooltip: Sets the specified vehicle float parameter param to value.
     categories:
       - vehicles
   llSetVehicleRotationParam:
     arguments:
-    - ParameterName:
-        tooltip: ''
-        type: integer
-    - ParameterValue:
-        tooltip: ''
-        type: rotation
+      - param:
+          tooltip: The VEHICLE_* rotation parameter constant to set.
+          type: integer
+      - rot:
+          tooltip: The rotation value to set.
+          type: rotation
     energy: 10.0
     func-id: 235
     return: void
     sleep: 0.0
-    tooltip: Sets a vehicle rotation parameter.\nValid parameters can be found in
-      the wiki documentation.
+    tooltip: Sets the specified vehicle rotation parameter param to rot.
     categories:
       - vehicles
   llSetVehicleType:
     arguments:
-    - Type:
-        tooltip: ''
-        type: integer
+      - type:
+          tooltip: The VEHICLE_TYPE_* constant to set.
+          type: integer
     energy: 10.0
     func-id: 232
     return: void
     sleep: 0.0
-    tooltip: Activates the vehicle action on the object with vehicle preset Type.\nValid
-      Types and an explanation of their characteristics can be found in wiki documentation.
+    tooltip: Sets the vehicle physics preset type to one of the default vehicle types.
     categories:
       - vehicles
   llSetVehicleVectorParam:
     arguments:
-    - ParameterName:
-        tooltip: ''
-        type: integer
-    - ParameterValue:
-        tooltip: ''
-        type: vector
+      - param:
+          tooltip: The VEHICLE_* vector parameter constant to set.
+          type: integer
+      - vec:
+          tooltip: The vector value to set.
+          type: vector
     energy: 10.0
     func-id: 234
     return: void
     sleep: 0.0
-    tooltip: Sets a vehicle vector parameter.\nValid parameters can be found in the
-      wiki documentation.
+    tooltip: Sets the specified vehicle vector parameter param to vec.
     categories:
       - vehicles
   llSetVelocity:
     arguments:
-    - Velocity:
-        tooltip: The velocity to apply.
-        type: vector
-    - Local:
-        tooltip: If TRUE, the Velocity is treated as a local directional vector instead
-          of a regional directional vector.
-        type: integer
-        bool-semantics: true
+      - velocity:
+          tooltip: The linear velocity vector to apply (in meters per second).
+          type: vector
+      - local:
+          tooltip: Boolean. If TRUE, velocity is treated as a local directional vector; if
+            FALSE, as a global region vector.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 378
     return: void
     sleep: 0.0
-    tooltip: If the object is physics-enabled, sets the object's linear velocity to
-      Velocity.\nIf Local==TRUE, Velocity is treated as a local directional vector;
-      otherwise, Velocity is treated as a global directional vector.
+    tooltip: Sets the linear velocity of a physical object to velocity. If local is
+      TRUE, velocity is treated as a local directional vector; if FALSE, as a
+      global region directional vector. Has no effect on non-physical objects.
     categories:
       - movement
       - physics
   llShout:
     arguments:
-    - Channel:
-        tooltip: ''
-        type: integer
-    - Text:
-        tooltip: ''
-        type: string
+      - channel:
+          tooltip: The integer chat channel to shout the message on.
+          type: integer
+      - msg:
+          tooltip: The text message string to transmit.
+          type: string
     energy: 10.0
     func-id: 24
     return: void
     sleep: 0.0
-    tooltip: Shouts Text on Channel.\nThis chat method has a range of 100m radius.\nPUBLIC_CHANNEL
-      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
-      is the script debug channel, and is also visible to nearby avatars. All other
-      channels are are not sent to avatars, but may be used to communicate with scripts.
+    tooltip: Shouts the text message msg on the specified channel. The message can
+      be heard up to a 100m radius. All channels other than PUBLIC_CHANNEL (0)
+      and DEBUG_CHANNEL (2147483647) are not sent to avatars and are used to
+      communicate with scripts.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llSignRSA:
     arguments:
-    - PrivateKey:
-        tooltip: The PEM-formatted private key
-        type: string
-    - Message:
-        tooltip: The message contents to sign
-        type: string
-    - Algorithm:
-        tooltip: 'The digest algorithnm to use: sha1, sha224, sha256, sha384, sha512'
-        type: string
+      - private_key:
+          tooltip: The PEM-formatted private key.
+          type: string
+      - msg:
+          tooltip: The message contents to sign.
+          type: string
+      - algorithm:
+          tooltip: The digest algorithm to use (sha1, sha224, sha256, sha384, or sha512).
+          type: string
     energy: 10.0
     func-id: 539
     must-use: true
     return: string
     sleep: 0.0
-    tooltip: Returns the base64-encoded RSA signature of Message using PEM-formatted
-      PrivateKey and digest Algorithm (sha1, sha224, sha256, sha384, sha512).
+    tooltip: Returns the Base64-encoded RSA signature of msg using the PEM-formatted
+      private_key and the specified digest algorithm (sha1, sha224, sha256,
+      sha384, or sha512). Can be paired with llVerifyRSA to pass verifiable
+      messages.
     categories:
       - cryptography
   llSin:
     arguments:
-    - Theta:
-        tooltip: ''
-        type: float
+      - theta:
+          tooltip: The angle expressed in radians.
+          type: float
     slua-deprecated:
       use: math.sin
       reason: Double precision; fastcall.
@@ -14784,75 +15380,81 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the sine of Theta (Theta in radians).
+    tooltip: Returns a float representing the sine of theta.
     categories:
       - math
       - math_trig
   llSitOnLink:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - LinkID:
-        tooltip: ''
-        type: integer
+      - agent_id:
+          tooltip: The UUID of the avatar being forced to sit.
+          type: key
+      - link:
+          tooltip: The link number for the prim containing the desired sit target.
+          type: integer
     energy: 10.0
     func-id: 503
     experience: true
     return: integer
     sleep: 0.0
-    tooltip: If agent identified by AvatarID is participating in the experience, sit
-      them on the specified link's sit target.
+    tooltip: Forces the avatar specified by agent_id (who must be participating in
+      the experience) to sit on the sit target of the prim indicated by link. If
+      occupied, searches down the linkset for an available sit target. Returns
+      an integer.
     categories:
       - experience
       - sit
   llSitTarget:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
-    - Rotation:
-        tooltip: ''
-        type: rotation
+      - offset:
+          tooltip: The target position vector in local prim coordinates.
+          type: vector
+      - rot:
+          tooltip: The target rotation relative to the prim's rotation.
+          type: rotation
     energy: 10.0
     func-id: 238
     return: void
     sleep: 0.0
-    tooltip: Set the sit location for this object. If offset == ZERO_VECTOR, clears
-      the sit target.
+    tooltip: Sets the sit target position (offset) and rotation (rot) relative to
+      the prim's position and orientation. Clears the sit target if offset is
+      ZERO_VECTOR.
     categories:
       - prim
       - sit
   llSleep:
     arguments:
-    - Time:
-        tooltip: ''
-        type: float
+      - sec:
+          tooltip: The duration in seconds to put the script to sleep.
+          type: float
     energy: 0.0
     func-id: 108
     return: void
     sleep: 0.0
-    tooltip: Put script to sleep for Time seconds.
+    tooltip: Puts the script to sleep for sec seconds (at least until the next
+      server-frame, ~0.02222 seconds). The script is inactive during this time.
+      If sec is 0.0 or less, the script does not sleep.
     categories:
       - script
       - time
   llSound:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
-    - Queue:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
-    - Loop:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
+      - queue:
+          tooltip: Boolean. If TRUE, queues the sound; if FALSE, interrupts the currently
+            playing sound.
+          type: integer
+          bool-semantics: true
+      - loop:
+          tooltip: Boolean. If TRUE, loops the sound.
+          type: integer
+          bool-semantics: true
     deprecated:
       use: ll.PlaySound
       selene-replace: ["ll.PlaySound(%1, %2)", "ll.LoopSound(%1, %2)"]
@@ -14860,16 +15462,16 @@ functions:
     func-id: 85
     return: void
     sleep: 0.0
-    tooltip: 'Deprecated: Use llPlaySound instead.\nPlays Sound at Volume and specifies
-      whether the sound should loop and/or be enqueued.'
+    tooltip: Deprecated (use llPlaySound instead). Plays the specified sound at
+      volume, with options to loop or queue the sound.
     categories:
       - sound
   llSoundPreload:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
     deprecated:
       use: ll.PreloadSound
       selene-replace: ["ll.PreloadSound(%1)"]
@@ -14877,15 +15479,15 @@ functions:
     func-id: 126
     return: void
     sleep: 0.0
-    tooltip: 'Deprecated: Use llPreloadSound instead.\nPreloads a sound on viewers
-      within range.'
+    tooltip: Deprecated (use llPreloadSound instead). Preloads the specified sound
+      on viewers within range.
     categories:
       - sound
   llSqrt:
     arguments:
-    - Value:
-        tooltip: ''
-        type: float
+      - val:
+          tooltip: The positive float value (must be >= 0.0).
+          type: float
     slua-deprecated:
       use: math.sqrt
       reason: Double precision; fastcall.
@@ -14896,60 +15498,58 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the square root of Value.\nTriggers a math runtime error for
-      imaginary results (if Value < 0.0).
+    tooltip: Returns a float representing the square root of the positive value val.
+      Triggers a math runtime error if val is less than 0.0 (imaginary results).
     categories:
       - math
   llStartAnimation:
     arguments:
-    - Animation:
-        tooltip: ''
-        type: string
+      - anim:
+          tooltip: The name of an animation in the prim's inventory, or a built-in
+            animation.
+          type: string
     energy: 10.0
     func-id: 129
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRIGGER_ANIMATION
-    tooltip: This function plays the specified animation from playing on the avatar
-      who received the script's most recent permissions request.\nAnimation may be
-      an animation in task inventory or a built-in animation.\nRequires the PERMISSION_TRIGGER_ANIMATION
-      runtime permission (automatically granted to attached or sat on objects).
+    tooltip: Starts the animation anim (inventory or built-in) on the avatar who
+      granted the script the PERMISSION_TRIGGER_ANIMATION permission
+      (automatically granted for attached or sat-on objects).
     categories:
       - avatar
       - avatar_animation
       - permissions
   llStartObjectAnimation:
     arguments:
-    - Animation:
-        tooltip: ''
-        type: string
+      - anim:
+          tooltip: The name of an animation in the current object's inventory.
+          type: string
     energy: 10.0
     func-id: 504
     return: void
     sleep: 0.0
-    tooltip: This function plays the specified animation on the rigged mesh object
-      associated with the current script.\nAnimation may be an animation in task inventory
-      or a built-in animation.\n
+    tooltip: Starts the specified animation anim (inventory or built-in) on the
+      rigged mesh object associated with the current script.
     categories:
       - object_animation
   llStopAnimation:
     arguments:
-    - Animation:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - anim:
+          tooltip: The name of an animation in the prim's inventory, a UUID of an
+            animation, or a built-in animation name.
+          type: string
+          asset-semantics: true
     energy: 10.0
     func-id: 130
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRIGGER_ANIMATION
-    tooltip: This function stops the specified animation on the avatar who received
-      the script's most recent permissions request.\nAnimation may be an animation
-      in task inventory, a built-in animation, or the uuid of an animation.\nRequires
-      the PERMISSION_TRIGGER_ANIMATION runtime permission (automatically granted to
-      attached or sat on objects).
+    tooltip: Stops the specified animation anim (inventory, built-in, or UUID) on
+      the avatar who granted the script the PERMISSION_TRIGGER_ANIMATION
+      permission (automatically granted for attached or sat-on objects).
     categories:
       - avatar
       - avatar_animation
@@ -14960,7 +15560,7 @@ functions:
     func-id: 124
     return: void
     sleep: 0.0
-    tooltip: Stop hovering to a height (due to llSetHoverHeight()).
+    tooltip: Stops the hover behavior (such as that initiated by llSetHoverHeight).
     categories:
       - movement
       - physics
@@ -14970,7 +15570,8 @@ functions:
     func-id: 106
     return: void
     sleep: 0.0
-    tooltip: Stop causing object to point at a target (due to llLookAt() or llRotLookAt()).
+    tooltip: Stops causing the object to look at or point toward a target (canceling
+      llLookAt or llRotLookAt).
     categories:
       - movement
       - physics
@@ -14980,23 +15581,24 @@ functions:
     func-id: 71
     return: void
     sleep: 0.0
-    tooltip: Stops critically damped motion (due to llMoveToTarget()).
+    tooltip: Stops the critically damped movement of the object toward a target
+      (canceling llMoveToTarget). Use llStopLookAt to stop rotational tracking.
     categories:
       - movement
       - physics
   llStopObjectAnimation:
     arguments:
-    - Animation:
-        tooltip: ''
-        type: string
-        asset-semantics: true
+      - anim:
+          tooltip: The name of an animation in the current object's inventory, or an
+            animation UUID.
+          type: string
+          asset-semantics: true
     energy: 10.0
     func-id: 505
     return: void
     sleep: 0.0
-    tooltip: This function stops the specified animation on the rigged mesh object
-      associated with the current script.\nAnimation may be an animation in task inventory,
-      a built-in animation, or the uuid of an animation.\n
+    tooltip: Stops the specified animation anim (inventory, built-in, or UUID) on
+      the rigged mesh object associated with the current script.
     categories:
       - object_animation
   llStopPointAt:
@@ -15007,7 +15609,7 @@ functions:
     private: true
     return: void
     sleep: 0.0
-    tooltip: ''
+    tooltip: Stops the avatar who owns the object from pointing.
     categories:
       - movement
       - physics
@@ -15017,14 +15619,14 @@ functions:
     func-id: 92
     return: void
     sleep: 0.0
-    tooltip: Stops playback of the currently attached sound.
+    tooltip: Stops playback of the currently playing attached sound.
     categories:
       - sound
   llStringLength:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - str:
+          tooltip: The string to measure.
+          type: string
     slua-deprecated:
       reason: "Use 'utf8.len' or '#' or 'string.len' instead."
       selene-replace: ["utf8.len(%1)", "#%1", "string.len(%1)"]
@@ -15033,21 +15635,22 @@ functions:
     pure: true
     return: integer
     sleep: 0.0
-    tooltip: Returns an integer that is the number of characters in Text (not counting
-      the null).
+    tooltip: Returns an integer representing the number of characters in the string
+      str (excluding the null terminator).
     categories:
       - string
   llStringToBase64:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - str:
+          tooltip: The source string to encode.
+          type: string
     energy: 10.0
     func-id: 260
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns the string Base64 representation of the input string.
+    tooltip: Returns the Base64 representation string of str, interpreting it as a
+      UTF-8 byte sequence.
     categories:
       - data_conversion
     slua-deprecated:
@@ -15055,88 +15658,92 @@ functions:
       selene-replace: ["llbase64.encode(%1)"]
   llStringTrim:
     arguments:
-    - Text:
-        tooltip: String to trim
-        type: string
-    - TrimType:
-        tooltip: STRING_TRIM_HEAD, STRING_TRIM_TAIL, or STRING_TRIM.
-        type: integer
+      - src:
+          tooltip: The string to trim.
+          type: string
+      - type:
+          tooltip: The trim type flag (STRING_TRIM_HEAD, STRING_TRIM_TAIL, or
+            STRING_TRIM).
+          type: integer
     energy: 10.0
     func-id: 330
     pure: true
     return: string
     sleep: 0.0
-    tooltip: 'Outputs a string, eliminating white-space from the start and/or end
-      of the input string Text.\nValid options for TrimType:\nSTRING_TRIM_HEAD: trim
-      all leading spaces in Text\nSTRING_TRIM_TAIL: trim all trailing spaces in Text\nSTRING_TRIM:
-      trim all leading and trailing spaces in Text.'
+    tooltip: Returns a copy of the string src with leading, trailing, or both types
+      of whitespace (including spaces, tabs, and line feeds) eliminated,
+      according to the specified trim type.
     categories:
       - string
   llSubStringIndex:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
-    - Sequence:
-        tooltip: ''
-        type: string
+      - source:
+          tooltip: The source string to search within.
+          type: string
+      - pattern:
+          tooltip: The substring pattern to search for.
+          type: string
     energy: 10.0
     func-id: 181
     pure: true
     return: integer
     index-semantics: true
     sleep: 0.0
-    tooltip: Returns the first index where Sequence appears in Text. Returns -1 if not found.
+    tooltip: Returns the zero-based index of the first instance of the pattern
+      substring inside the string source. Returns -1 if not found.
     categories:
       - string
   llTakeCamera:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
     deprecated:
       use: ll.SetCameraParams
     energy: 10.0
     func-id: 115
     return: void
     sleep: 0.0
-    tooltip: 'Deprecated: Use llSetCameraParams instead.'
+    tooltip: Deprecated (use llSetCameraParams instead). Formerly used to take
+      control of the agent's camera.
     categories:
       - avatar
       - camera
       - permissions
   llTakeControls:
     arguments:
-    - Controls:
-        tooltip: Bit-field of CONTROL_* flags.
-        type: integer
-    - Accept:
-        tooltip: Boolean, determines whether control events are generated.
-        type: integer
-        bool-semantics: true
-    - PassOn:
-        tooltip: Boolean, determines whether controls are disabled.
-        type: integer
-        bool-semantics: true
+      - controls:
+          tooltip: The bitfield of CONTROL_* flags to intercept.
+          type: integer
+      - accept:
+          tooltip: Boolean. Determines whether control events are generated to trigger
+            script handlers.
+          type: integer
+          bool-semantics: true
+      - pass_on:
+          tooltip: Boolean. If TRUE, the keys also perform their default functions; if
+            FALSE, default actions are suppressed.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 111
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_TAKE_CONTROLS
-    tooltip: Take controls from the agent the script has permissions for.\nIf (Accept
-      == (Controls & input)), send input to the script.  PassOn determines whether
-      Controls also perform their normal functions.\nRequires the PERMISSION_TAKE_CONTROLS
-      runtime permission (automatically granted to attached or sat on objects).
+    tooltip: Intercepts inputs (keyboard/mouse clicks) from the agent, specifically
+      those specified by controls. The boolean accept determines if events are
+      generated, and pass_on determines if inputs also perform their default
+      functions. Requires the PERMISSION_TAKE_CONTROLS runtime permission.
     categories:
       - avatar
       - input
       - permissions
   llTan:
     arguments:
-    - Theta:
-        tooltip: ''
-        type: float
+      - theta:
+          tooltip: The angle expressed in radians.
+          type: float
     slua-deprecated:
       use: math.tan
       reason: Double precision; fastcall.
@@ -15147,367 +15754,362 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the tangent of Theta (Theta in radians).
+    tooltip: Returns a float representing the tangent of theta.
     categories:
       - math
       - math_trig
   llTarget:
     arguments:
-    - Position:
-        tooltip: ''
-        type: vector
-    - Range:
-        tooltip: ''
-        type: float
+      - position:
+          tooltip: The target position vector in region coordinates.
+          type: vector
+      - range:
+          tooltip: The radius tolerance in meters surrounding the target position.
+          type: float
     energy: 10.0
     func-id: 66
     return: integer
     sleep: 0.0
-    tooltip: This function is to have the script know when it has reached a position.\nIt
-      registers a Position with a Range that triggers at_target and not_at_target
-      events continuously until unregistered.
+    tooltip: Registers a positional target at position with a leeway radius range.
+      This triggers at_target and not_at_target events. Returns an integer
+      handle to unregister the target via llTargetRemove.
     categories:
       - movement
   llTargetOmega:
     arguments:
-    - Axis:
-        tooltip: ''
-        type: vector
-    - SpinRate:
-        tooltip: ''
-        type: float
-    - Gain:
-        tooltip: ''
-        type: float
+      - axis:
+          tooltip: The local axis vector around which the object rotates.
+          type: vector
+      - spinrate:
+          tooltip: The rotation rate multiplier in radians per second.
+          type: float
+      - gain:
+          tooltip: A float modulating the rotational strength (disables the rotation if
+            set to 0.0).
+          type: float
     energy: 10.0
     func-id: 133
     return: void
     sleep: 0.0
-    tooltip: Attempt to spin at SpinRate with strength Gain on Axis.\nA spin rate
-      of 0.0 cancels the spin. This function always works in object-local coordinates.
+    tooltip: Applies a smooth client-side rotation around the local axis at a rate
+      equal to spinrate multiplied by the magnitude of axis (in radians per
+      second) with a force defined by gain. Set spinrate to 0.0 to cancel.
     categories:
       - movement
       - physics
   llTargetRemove:
     arguments:
-    - Target:
-        tooltip: ''
-        type: integer
+      - handle:
+          tooltip: The integer target handle returned by llTarget to remove.
+          type: integer
     energy: 10.0
     func-id: 67
     return: void
     sleep: 0.0
-    tooltip: Removes positional target Handle registered with llTarget.
+    tooltip: Removes the positional target specified by the integer handle
+      registered with llTarget.
     categories:
       - movement
   llTargetedEmail:
     arguments:
-    - Target:
-        tooltip: ''
-        type: integer
-    - Subject:
-        tooltip: ''
-        type: string
-    - Text:
-        tooltip: ''
-        type: string
+      - target:
+          tooltip: The target constant (e.g., TARGETED_EMAIL_OBJECT_OWNER or
+            TARGETED_EMAIL_ROOT_CREATOR).
+          type: integer
+      - subject:
+          tooltip: The subject of the email.
+          type: string
+      - message:
+          tooltip: The email message body.
+          type: string
     energy: 10.0
     func-id: 750
     return: void
     sleep: 20.0
-    tooltip: Sends an email with Subject and Message to the owner or creator of an
-      object.
+    tooltip: Sends an email containing subject and message to the target (which can
+      designate the owner or creator of the object).
     categories:
       - avatar_communication
   llTeleportAgent:
     arguments:
-    - AvatarID:
-        tooltip: UUID of avatar.
-        type: key
-    - LandmarkName:
-        tooltip: Name of landmark (in object contents), or empty string, to use.
-        type: string
-    - Position:
-        tooltip: If no landmark was provided, the position within the current region
-          to teleport the avatar to.
-        type: vector
-    - LookAtPoint:
-        tooltip: The position within the target region that the avatar should be turned
-          to face upon arrival.
-        type: vector
+      - agent:
+          tooltip: The UUID of the owning avatar to teleport.
+          type: key
+      - landmark:
+          tooltip: The name of the landmark in the prim's inventory, or an empty string to
+            teleport locally.
+          type: string
+      - position:
+          tooltip: The position vector in local region coordinates to teleport to if
+            landmark is empty.
+          type: vector
+      - look_at:
+          tooltip: The position vector (or direction unit vector if teleporting out of
+            region) the agent faces upon landing.
+          type: vector
     energy: 10.0
     func-id: 368
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_TELEPORT
-    tooltip: Requests a teleport of avatar to a landmark stored in the object's inventory.
-      If no landmark is provided (an empty string), the avatar is teleported to the
-      location position in the current region. In either case, the avatar is turned
-      to face the position given by look_at in local coordinates.\nRequires the PERMISSION_TELEPORT
-      runtime permission.\nThis function can only teleport the owner of the object.
+    tooltip: Teleports the owning agent (who must grant PERMISSION_TELEPORT) to a
+      landmark in the object's inventory. If landmark is empty, teleports them
+      to position within the current region. Upon arrival, the agent is turned
+      to face look_at. Can only teleport the owner.
     categories:
       - avatar
       - permissions
       - teleport
   llTeleportAgentGlobalCoords:
     arguments:
-    - AvatarID:
-        tooltip: UUID of avatar.
-        type: key
-    - GlobalPosition:
-        tooltip: Global coordinates of the destination region. Can be retrieved by
-          using llRequestSimulatorData(region_name, DATA_SIM_POS).
-        type: vector
-    - RegionPosition:
-        tooltip: The position within the target region to teleport the avatar to,
-          if no landmark was provided.
-        type: vector
-    - LookAtPoint:
-        tooltip: The position within the target region that the avatar should be turned
-          to face upon arrival.
-        type: vector
+      - agent:
+          tooltip: The UUID of the owning avatar to teleport.
+          type: key
+      - global_coordinates:
+          tooltip: The global coordinates vector of the target region (obtained via
+            llRequestSimulatorData).
+          type: vector
+      - region_coordinates:
+          tooltip: The target coordinates vector within the destination region.
+          type: vector
+      - look_at:
+          tooltip: The position vector within the region (or unit direction vector if out
+            of region) that the agent faces upon landing.
+          type: vector
     energy: 10.0
     func-id: 414
     return: void
     sleep: 0.0
     requires-permission:
       - PERMISSION_TELEPORT
-    tooltip: Teleports an agent to the RegionPosition local coordinates within a region
-      which is specified by the GlobalPosition global coordinates. The agent lands
-      facing the position defined by LookAtPoint local coordinates.\nRequires the
-      PERMISSION_TELEPORT runtime permission.\nThis function can only teleport the owner of
-      the object.
+    tooltip: Teleports the owning agent (who must grant PERMISSION_TELEPORT) to
+      region_coordinates within a target region specified by global_coordinates.
+      Upon landing, the agent faces the direction look_at. Can only teleport the
+      owner.
     categories:
       - avatar
       - permissions
       - teleport
   llTeleportAgentHome:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - avatar:
+          tooltip: The UUID of the avatar to teleport.
+          type: key
     energy: 100.0
     func-id: 158
     return: void
     sleep: 5.0
-    tooltip: Teleport agent over the owner's land to agent's home location.
+    tooltip: Teleports the avatar (who must be standing on land owned by the script
+      owner) directly to their designated home location without warning (similar
+      to a God Summons).
     categories:
       - avatar
       - land_moderation
       - teleport
   llTextBox:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Text:
-        tooltip: ''
-        type: string
-    - Channel:
-        tooltip: ''
-        type: integer
+      - avatar:
+          tooltip: The UUID of the avatar in the same region.
+          type: key
+      - message:
+          tooltip: The text message to display in the text box.
+          type: string
+      - channel:
+          tooltip: The output chat channel (any integer value) where the input text is
+            chatted.
+          type: integer
     energy: 10.0
     func-id: 335
     mono-sleep: 0.0
     return: void
     sleep: 1.0
-    tooltip: Opens a dialog for the specified avatar with message Text, which contains
-      a text box for input. Any text that is entered is said on the specified Channel
-      (as if by the avatar) when the "OK" button is clicked.
+    tooltip: Opens an input text box dialog displaying message to the avatar.
+      Submitting text chats the input string on channel as if said by the
+      avatar.
     categories:
       - avatar_communication
       - chat
       - user_interface
   llToLower:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The source string to convert.
+          type: string
     energy: 10.0
     func-id: 98
     native: true
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string that is Text with all lower-case characters.
+    tooltip: Returns a copy of the string src converted entirely to lowercase.
     categories:
       - string
   llToUpper:
     arguments:
-    - Text:
-        tooltip: ''
-        type: string
+      - src:
+          tooltip: The source string to convert.
+          type: string
     energy: 10.0
     func-id: 97
     native: true
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns a string that is Text with all upper-case characters.
+    tooltip: Returns a copy of the string src converted entirely to uppercase.
     categories:
       - string
   llTransferLindenDollars:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
-    - Amount:
-        tooltip: ''
-        type: integer
+      - destination:
+          tooltip: The UUID of the destination avatar.
+          type: key
+      - amount:
+          tooltip: The quantity of L$ to transfer (must be greater than 0).
+          type: integer
     energy: 10.0
     func-id: 395
     return: key
     sleep: 0.0
     requires-permission:
       - PERMISSION_DEBIT
-    tooltip: Transfer Amount of linden dollars (L$) from script owner to AvatarID.
-      Returns a key to a corresponding transaction_result event for the success of
-      the transfer.\nAttempts to send the amount of money to the specified avatar,
-      and trigger a transaction_result event identified by the returned key. Requires
-      the PERMISSION_DEBIT runtime permission.
+    tooltip: Transfers amount of L$ from the script owner to the destination avatar,
+      requiring the PERMISSION_DEBIT permission. Returns a key query handle
+      matching the resulting transaction_result event.
     categories:
       - money
       - permissions
   llTransferOwnership:
     arguments:
-    - AgentID:
-        tooltip: An agent in the region.
-        type: key
-    - Flags:
-        tooltip: Flags to control type of inventory transfer.
-        type: integer
-    - Params:
-        tooltip: Extra parameters to llTransferOwnership. None are defined at this
-          time.
-        type: list
+      - agent_id:
+          tooltip: The UUID of the avatar to receive ownership of the object.
+          type: key
+      - flags:
+          tooltip: Flags controlling the transfer type (such as TRANSFER_FLAG_COPY or
+            TRANSFER_FLAG_TAKE).
+          type: integer
+      - options:
+          tooltip: Extra options applied to the transfer (currently unused).
+          type: list
     energy: 10.0
     func-id: 519
     return: integer
     sleep: 0.0
-    tooltip: Transfers ownership of an object, or a copy of the object to a new agent.
+    tooltip: Transfers ownership of the object (or a copy of it, depending on flags)
+      to the avatar agent_id. Returns an integer indicating the success or
+      failure of the transfer.
     categories:
       - asset_permissions
   llTriggerSound:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
     energy: 10.0
     func-id: 91
     return: void
     sleep: 0.0
-    tooltip: Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object.\nThere
-      is no limit to the number of triggered sounds which can be generated by an object,
-      and calling llTriggerSound does not affect the attached sounds created by llPlaySound
-      and llLoopSound. This is very useful for things like collision noises, explosions,
-      etc. There is no way to stop or alter the volume of a sound triggered by this
-      function.
+    tooltip: Plays specified sound once at volume, centered at the object's current
+      position but not attached (does not move with the object and cannot be
+      stopped or adjusted). Does not affect attached sounds.
     categories:
       - sound
   llTriggerSoundLimited:
     arguments:
-    - Sound:
-        tooltip: ''
-        type: string
-        asset-semantics: true
-    - Volume:
-        tooltip: ''
-        type: float
-    - TNE:
-        tooltip: ''
-        type: vector
-    - BSW:
-        tooltip: ''
-        type: vector
+      - sound:
+          tooltip: The name of a sound in the prim's inventory, or a UUID.
+          type: string
+          asset-semantics: true
+      - volume:
+          tooltip: The volume level to set, between 0.0 (silent) and 1.0 (loud).
+          type: float
+      - top_north_east:
+          tooltip: The top-north-east boundary position vector in region coordinates.
+          type: vector
+      - bottom_south_west:
+          tooltip: The bottom-south-west boundary position vector in region coordinates.
+          type: vector
     energy: 10.0
     func-id: 212
     return: void
     sleep: 0.0
-    tooltip: Plays Sound at Volume (0.0 - 1.0), centered at but not attached to object,
-      limited to axis-aligned bounding box defined by vectors top-north-east (TNE)
-      and bottom-south-west (BSW).\nThere is no limit to the number of triggered sounds
-      which can be generated by an object, and calling llTriggerSound does not affect
-      the attached sounds created by llPlaySound and llLoopSound. This is very useful
-      for things like collision noises, explosions, etc. There is no way to stop or
-      alter the volume of a sound triggered by this function.
+    tooltip: Plays the specified sound once at volume, centered at the object but
+      not attached, restricted to the axis-aligned bounding box defined by the
+      coordinates top_north_east and bottom_south_west.
     categories:
       - sound
   llUnSit:
     arguments:
-    - AvatarID:
-        tooltip: ''
-        type: key
+      - id:
+          tooltip: The UUID of the avatar to unsit.
+          type: key
     energy: 10.0
     func-id: 220
     return: void
     sleep: 0.0
-    tooltip: If agent identified by AvatarID is sitting on the object the script is
-      attached to or is over land owned by the object's owner, the agent is forced
-      to stand up.
+    tooltip: Forces the agent specified by id to stand up if they are sitting on the
+      object containing the script, or are currently over land owned by the
+      object's owner.
     categories:
       - avatar
       - sit
   llUnescapeURL:
     arguments:
-    - URL:
-        tooltip: ''
-        type: string
+      - url:
+          tooltip: The escaped URL string to decode.
+          type: string
     energy: 10.0
     func-id: 308
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Returns the string that is the URL unescaped, replacing "%20" with spaces,
-      etc., version of URL.\nThis function can output raw UTF-8 strings.
+    tooltip: Returns a string representing the unescaped/decoded version of url,
+      replacing '%20' with spaces and decoding raw UTF-8 characters.
     categories:
       - web
   llUpdateCharacter:
     arguments:
-    - Options:
-        tooltip: Character configuration options. Takes the same constants as llCreateCharacter().
-        type: list
+      - options:
+          tooltip: A list of key-value pairs specifying the character's new configuration
+            options (takes same constants as llCreateCharacter).
+          type: list
     energy: 10.0
     func-id: 406
     return: void
     sleep: 0.0
-    tooltip: Updates settings for a pathfinding character.
+    tooltip: Updates settings for a pathfinding character using the parameters
+      specified in options.
     categories:
       - pathfinding
   llUpdateKeyValue:
     arguments:
-    - Key:
-        tooltip: ''
-        type: string
-    - Value:
-        tooltip: ''
-        type: string
-    - Checked:
-        tooltip: ''
-        type: integer
-        bool-semantics: true
-    - OriginalValue:
-        tooltip: ''
-        type: string
+      - k:
+          tooltip: The key of the key-value pair to update.
+          type: string
+      - v:
+          tooltip: The new value for the key-value pair.
+          type: string
+      - checked:
+          tooltip: Boolean. If TRUE, requires the existing value to match original_value
+            to complete the update; if FALSE, creates the key if needed.
+          type: integer
+          bool-semantics: true
+      - original_value:
+          tooltip: The string value to compare against the existing value in the
+            datastore.
+          type: string
     energy: 10.0
     experience: true
     func-id: 389
     return: key
     sleep: 0.0
-    tooltip: "\n                   Starts an asychronous transaction to update the\
-      \ value associated with the key given. The dataserver callback will be executed\
-      \ with the key returned from this call and a string describing the result. The\
-      \ result is a two element commma-delimited list. The first item is an integer\
-      \ specifying if the transaction succeeded (1) or not (0). In the failure case,\
-      \ the second item will be an integer corresponding to one of the XP_ERROR_...\
-      \ constants. In the success case the second item will be the value associated\
-      \ with the key. If Checked is 1 the existing value in the data store must match\
-      \ the OriginalValue passed or XP_ERROR_RETRY_UPDATE will be returned. If Checked\
-      \ is 0 the key will be created if necessary.\n                "
+    tooltip: Starts an asynchronous transaction to update the key k to value v
+      inside the experience datastore. If checked is TRUE, the update fails with
+      XP_ERROR_RETRY_UPDATE unless the existing value matches original_value.
     categories:
       - data_storage
       - dataserver
@@ -15515,12 +16117,12 @@ functions:
       - experience_data
   llVecDist:
     arguments:
-    - Location1:
-        tooltip: ''
-        type: vector
-    - Location2:
-        tooltip: ''
-        type: vector
+      - vec_a:
+          tooltip: The first vector.
+          type: vector
+      - vec_b:
+          tooltip: The second vector.
+          type: vector
     slua-deprecated:
       use: vector.magnitude
       reason: It's a fastcall.
@@ -15530,16 +16132,17 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the distance between Location1 and Location2.
+    tooltip: Returns a float representing the undirected, non-negative distance
+      between vectors vec_a and vec_b.
     categories:
       - math
       - math_3d
       - vector
   llVecMag:
     arguments:
-    - Vector:
-        tooltip: ''
-        type: vector
+      - vec:
+          tooltip: The vector to evaluate.
+          type: vector
     slua-deprecated:
       use: vector.magnitude
       reason: It's a fastcall.
@@ -15549,16 +16152,17 @@ functions:
     pure: true
     return: float
     sleep: 0.0
-    tooltip: Returns the magnitude of the vector.
+    tooltip: Returns a float representing the magnitude (geometric length) of the
+      vector vec.
     categories:
       - math
       - math_3d
       - vector
   llVecNorm:
     arguments:
-    - Vector:
-        tooltip: ''
-        type: vector
+      - vec:
+          tooltip: The vector to normalize.
+          type: vector
     slua-deprecated:
       use: vector.normalize
       reason: It's a fastcall.
@@ -15568,125 +16172,131 @@ functions:
     pure: true
     return: vector
     sleep: 0.0
-    tooltip: Returns normalized vector.
+    tooltip: Returns a normalized unit vector sharing the same direction as vec.
     categories:
       - math
       - math_3d
       - vector
   llVerifyRSA:
     arguments:
-    - PublicKey:
-        tooltip: The PEM-formatted public key for signature verifiation.
-        type: string
-    - Message:
-        tooltip: The message that was signed.
-        type: string
-    - Signature:
-        tooltip: The base64-formatted signature of the message.
-        type: string
-    - Algorithm:
-        tooltip: 'The digest algorithm: sha1, sha224, sha256, sha384, sha512.'
-        type: string
+      - public_key:
+          tooltip: The PEM-formatted public key to use for signature verification.
+          type: string
+      - msg:
+          tooltip: The message string that was signed.
+          type: string
+      - signature:
+          tooltip: The Base64-encoded signature to verify.
+          type: string
+      - algorithm:
+          tooltip: The cryptographic digest algorithm to use.
+          type: string
     energy: 10.0
     func-id: 540
     must-use: true
     return: integer
     bool-semantics: true
     sleep: 0.0
-    tooltip: Returns TRUE if PublicKey, Message, and Algorithm produce the same base64-formatted
-      Signature.
+    tooltip: Returns TRUE if the Base64-formatted signature is verified as valid for
+      the message msg when using the digest algorithm and public_key. Returns
+      FALSE otherwise.
     categories:
       - cryptography
   llVolumeDetect:
     arguments:
-    - DetectEnabled:
-        tooltip: TRUE enables, FALSE disables.
-        type: integer
-        bool-semantics: true
+      - detect:
+          tooltip: Boolean. If TRUE, enables VolumeDetect; if FALSE (default), disables
+            it.
+          type: integer
+          bool-semantics: true
     energy: 10.0
     func-id: 248
     return: void
     sleep: 0.0
-    tooltip: If DetectEnabled = TRUE, object becomes phantom but triggers collision_start
-      and collision_end events when other objects start and stop interpenetrating.\nIf
-      another object (including avatars) interpenetrates it, it will get a collision_start
-      event.\nWhen an object stops interpenetrating, a collision_end event is generated.
-      While the other is inter-penetrating, collision events are NOT generated.
+    tooltip: If detect is TRUE, enables VolumeDetect (object becomes phantom and
+      physical objects/avatars can pass through it). Triggers collision_start on
+      initial intersection and collision_end when intersection stops (standard
+      collision events are suppressed while intersecting).
     categories:
       - physics
       - sensor
   llWanderWithin:
     arguments:
-    - Origin:
-        tooltip: Central point to wander about.
-        type: vector
-    - Area:
-        tooltip: Half-extents of an area the character may wander within. (i.e., it
-          can wander from the specified origin by up to +/-Distance.x in x, +/-Distance.y
-          in y, etc.)
-        type: vector
-    - Options:
-        tooltip: No options available at this time.
-        type: list
+      - origin:
+          tooltip: The center coordinate position vector to wander about.
+          type: vector
+      - dist:
+          tooltip: A vector specifying the maximum distance limits (half-extents) along
+            each world-aligned axis from the origin.
+          type: vector
+      - options:
+          tooltip: A list of WANDER_* flags and parameters to configure the wander
+            behavior.
+          type: list
     energy: 10.0
     func-id: 401
     return: void
     sleep: 0.0
-    tooltip: Wander within a specified volume.\nSets a character to wander about a
-      central spot within a specified area.
+    tooltip: Directs a pathfinding character to wander around a central coordinate
+      origin, restricted within the bounding distance limits of dist and
+      configured by options.
     categories:
       - pathfinding
   llWater:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     energy: 10.0
     func-id: 153
     must-use: true
     return: float
     sleep: 0.0
-    tooltip: Returns the water height below the object position + Offset.
+    tooltip: Returns a float representing the water height directly below the prim's
+      position offset by the vector offset.
     categories:
       - region
   llWhisper:
     arguments:
-    - Channel:
-        tooltip: ''
-        type: integer
-    - Text:
-        tooltip: ''
-        type: string
+      - channel:
+          tooltip: The integer chat channel to whisper the message on.
+          type: integer
+      - msg:
+          tooltip: The text message string to transmit.
+          type: string
     energy: 10.0
     func-id: 22
     return: void
     sleep: 0.0
-    tooltip: Whispers Text on Channel.\nThis chat method has a range of 10m radius.\nPUBLIC_CHANNEL
-      is the public chat channel that all avatars see as chat text. DEBUG_CHANNEL
-      is the script debug channel, and is also visible to nearby avatars. All other
-      channels are are not sent to avatars, but may be used to communicate with scripts.
+    tooltip: Whispers the text message msg on the specified channel. The message can
+      be heard up to a 10m radius. All channels other than PUBLIC_CHANNEL (0)
+      and DEBUG_CHANNEL (2147483647) are not sent to avatars and are used to
+      communicate with scripts.
     categories:
       - avatar_communication
       - chat
       - script_communication
   llWind:
     arguments:
-    - Offset:
-        tooltip: ''
-        type: vector
+      - offset:
+          tooltip: The offset relative to the prim's position, expressed in local
+            coordinates.
+          type: vector
     energy: 10.0
     func-id: 44
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Returns the wind velocity at the object position + Offset.
+    tooltip: Returns a vector representing the wind velocity at the prim's position
+      offset by the vector offset.
     categories:
       - region
   llWorldPosToHUD:
     arguments:
-    - world_pos:
-        tooltip: The world-frame position to project into HUD space
-        type: vector
+      - world_pos:
+          tooltip: The world-frame position vector to project into HUD space.
+          type: vector
     energy: 10.0
     func-id: 547
     must-use: true
@@ -15694,9 +16304,9 @@ functions:
     sleep: 0.0
     requires-permission:
       - PERMISSION_TRACK_CAMERA
-    tooltip: Returns the local position that would put the origin of a HUD object
-      directly over world_pos as viewed by the current camera. Requires the PERMISSION_TRACK_CAMERA
-      runtime permission (else will return zero vector).
+    tooltip: Returns the local position vector that places the center of the HUD
+      object directly over the world coordinate world_pos as viewed by the
+      current camera. Requires the PERMISSION_TRACK_CAMERA runtime permission.
     categories:
       - avatar
       - camera
@@ -15704,29 +16314,30 @@ functions:
       - user_interface
   llXorBase64:
     arguments:
-    - Text1:
-        tooltip: ''
-        type: string
-    - Text2:
-        tooltip: ''
-        type: string
+      - str1:
+          tooltip: The first Base64 string.
+          type: string
+      - str2:
+          tooltip: The second Base64 string (will repeat if shorter than str1).
+          type: string
     energy: 10.0
     func-id: 522
     pure: true
     return: string
     sleep: 0.0
-    tooltip: Performs an exclusive OR on two Base64 strings and returns a Base64 string.
-      Text2 repeats if it is shorter than Text1.
+    tooltip: Correctly performs a bitwise exclusive OR (XOR) on Base64 strings str1
+      and str2, returning the result as a Base64 string. The string str2 repeats
+      if it is shorter than str1.
     categories:
       - data_conversion
   llXorBase64Strings:
     arguments:
-    - Text1:
-        tooltip: ''
-        type: string
-    - Text2:
-        tooltip: ''
-        type: string
+      - str1:
+          tooltip: The first Base64 string.
+          type: string
+      - str2:
+          tooltip: The second Base64 string (will repeat if shorter than str1).
+          type: string
     deprecated:
       use: ll.XorBase64
       selene-replace: ["ll.XorBase64(%1, %2)"]
@@ -15735,19 +16346,19 @@ functions:
     pure: true
     return: string
     sleep: 0.3
-    tooltip: 'Deprecated: Please use llXorBase64 instead.\nIncorrectly performs an
-      exclusive OR on two Base64 strings and returns a Base64 string. Text2 repeats
-      if it is shorter than Text1.\nRetained for backwards compatibility.'
+    tooltip: Deprecated (use llXorBase64 instead). Retained for backwards
+      compatibility. Incorrectly performs a bitwise exclusive OR (XOR) on Base64
+      strings str1 and str2.
     categories:
       - data_conversion
   llXorBase64StringsCorrect:
     arguments:
-    - Text1:
-        tooltip: ''
-        type: string
-    - Text2:
-        tooltip: ''
-        type: string
+      - str1:
+          tooltip: The first Base64 string.
+          type: string
+      - str2:
+          tooltip: The second Base64 string (will repeat if shorter than str1).
+          type: string
     deprecated:
       use: ll.XorBase64
       selene-replace: ["ll.XorBase64(%1, %2)"]
@@ -15756,55 +16367,58 @@ functions:
     pure: true
     return: string
     sleep: 0.0
-    tooltip: 'Deprecated: Please use llXorBase64 instead.\nCorrectly (unless nulls
-      are present) performs an exclusive OR on two Base64 strings and returns a Base64
-      string.\nText2 repeats if it is shorter than Text1.'
+    tooltip: Deprecated (use llXorBase64 instead). Correctly performs (unless nulls
+      are present) a bitwise exclusive OR (XOR) on Base64 strings str1 and str2.
     categories:
       - data_conversion
   llsRGB2Linear:
     arguments:
-    - srgb:
-        tooltip: A color in the sRGB colorspace.
-        type: vector
+      - srgb:
+          tooltip: The color vector in the sRGB colorspace to convert.
+          type: vector
     energy: 10.0
     func-id: 716
     must-use: true
     return: vector
     sleep: 0.0
-    tooltip: Converts a color from the sRGB to the linear colorspace.
+    tooltip: Returns a vector representing the conversion of the color srgb from the
+      sRGB colorspace into the linear RGB colorspace.
     categories:
       - math
       - prim_appearance
 types:
   float:
-    tooltip: 32 bit floating point value.\nThe range is 1.175494351E-38 to 3.402823466E+38.
+    tooltip: 32 bit floating point value.\nThe range is 1.175494351E-38 to
+      3.402823466E+38.
   integer:
-    tooltip: "32 bit integer value.\\n\u22122,147,483,648 and +2,147,483,647 (that\
-      \ is 0x80000000 to 0x7FFFFFFF in hex)."
+    tooltip: "32 bit integer value.\\n−2,147,483,648 and +2,147,483,647 (that is
+      0x80000000 to 0x7FFFFFFF in hex)."
   key:
-    tooltip: A 128 bit unique identifier (UUID).\nThe key is represented as hexidecimal
-      characters (A-F and 0-9), grouped into sections (8,4,4,4,12 characters) and
-      separated by hyphens (for a total of 36 characters). e.g. "A822FF2B-FF02-461D-B45D-DCD10A2DE0C2".
+    tooltip: A 128 bit unique identifier (UUID).\nThe key is represented as
+      hexidecimal characters (A-F and 0-9), grouped into sections (8,4,4,4,12
+      characters) and separated by hyphens (for a total of 36 characters). e.g.
+      "A822FF2B-FF02-461D-B45D-DCD10A2DE0C2".
   list:
-    tooltip: A collection of other data types.\nLists are signified by square brackets
-      surrounding their elements; the elements inside are separated by commas. e.g.
-      [0, 1, 2, 3, 4] or ["Yes", "No", "Perhaps"].
+    tooltip: A collection of other data types.\nLists are signified by square
+      brackets surrounding their elements; the elements inside are separated by
+      commas. e.g. [0, 1, 2, 3, 4] or ["Yes", "No", "Perhaps"].
   quaternion:
     private: true
     tooltip: The quaternion type is a left over from way back when LSL was created.
-      It was later renamed to <rotation> to make it more user friendly, but it appears
-      someone forgot to remove it ;-)
+      It was later renamed to <rotation> to make it more user friendly, but it
+      appears someone forgot to remove it ;-)
   rotation:
-    tooltip: The rotation type is one of several ways to represent an orientation
-      in 3D.\nIt is a mathematical object called a quaternion. You can think of a
-      quaternion as four numbers (x, y, z, w), three of which represent the direction
-      an object is facing and a fourth that represents the object's banking left or
-      right around that direction.
+    tooltip: The rotation type is one of several ways to represent an orientation in
+      3D.\nIt is a mathematical object called a quaternion. You can think of a
+      quaternion as four numbers (x, y, z, w), three of which represent the
+      direction an object is facing and a fourth that represents the object's
+      banking left or right around that direction.
   string:
     tooltip: Text data.\nThe editor accepts UTF-8 encoded text.
   vector:
-    tooltip: A vector is a data type that contains a set of three float values.\nVectors
-      are used to represent colors (RGB), positions, and directions/velocities.
+    tooltip: A vector is a data type that contains a set of three float
+      values.\nVectors are used to represent colors (RGB), positions, and
+      directions/velocities.
 controls:
   default:
     tooltip: |-
@@ -15813,15 +16427,17 @@ controls:
   do:
     tooltip: do / while loop\ndo {\n...\n} while (<condition>);
   else:
-    tooltip: if / else block\nif (<condition>) {\n...\n[} else [if (<condition>) {\n...]]\n}
+    tooltip: if / else block\nif (<condition>) {\n...\n[} else [if (<condition>)
+      {\n...]]\n}
   event:
     deprecated: true
     tooltip: Undefined reserved word.
   for:
-    tooltip: for loop\nfor (<initializer>; <condition>; <post-iteration-statement>)\n{
-      ...\n}
+    tooltip: for loop\nfor (<initializer>; <condition>;
+      <post-iteration-statement>)\n{ ...\n}
   if:
-    tooltip: if / else block\nif (<condition>) {\n...\n[} else [if (<condition>) {\n...]]\n}
+    tooltip: if / else block\nif (<condition>) {\n...\n[} else [if (<condition>)
+      {\n...]]\n}
   jump:
     tooltip: jump statement\njump <label>
   print:
@@ -15849,259 +16465,259 @@ builder-rulesets:
         # Make this more obviously verb-y since it's a meta-command
         method-name: "targetLink"
         params:
-          - [ link, link_target ]
+          - [link, link_target]
       MATERIAL:
         # Otherwise this is _very_ easy to confuse with render materials
         method-name: 'physicsMaterial'
         params:
-          - [ integer, flag ]
+          - [integer, flag]
       PHYSICS:
         method-name: 'physical'
         params:
           # Note that we use "asset" and "boolean" types to denote places where
-          # `asset-semantics` or `bool-semantics` would apply.
-          - [ boolean, enabled ]
+          # 'asset-semantics' or 'bool-semantics' would apply.
+          - [boolean, enabled]
       TEMP_ON_REZ:
         method-name: 'temporary'
         params:
-          - [ boolean, enabled ]
+          - [boolean, enabled]
       PHANTOM:
         params:
-          - [ boolean, enabled ]
+          - [boolean, enabled]
       POSITION:
         method-name: "pos"
         params:
-          - [ vector, position ]
+          - [vector, position]
       SIZE:
         params:
-          - [ vector, size ]
+          - [vector, size]
       ROTATION:
         method-name: "rot"
         params:
-          - [ rotation, rot ]
+          - [rotation, rot]
       TYPE:
         params:
           # TODO: express an enum-like relationship here?
-          - [ integer, prim_type ]
+          - [integer, prim_type]
         variants-on: prim_type
         variant-enum: PrimType
         variants:
-          - applies-to: [ BOX, CYLINDER, PRISM ]
+          - applies-to: [BOX, CYLINDER, PRISM]
             params:
-              - [ integer, hole_type ]
-              - [ vector, cut ]
-              - [ float, hollow ]
-              - [ vector, twist ]
-              - [ vector, top_size ]
-              - [ vector, top_shear ]
-          - applies-to: [ SPHERE ]
+              - [integer, hole_type]
+              - [vector, cut]
+              - [float, hollow]
+              - [vector, twist]
+              - [vector, top_size]
+              - [vector, top_shear]
+          - applies-to: [SPHERE]
             params:
-              - [ integer, hole_type ]
-              - [ vector, cut ]
-              - [ float, hollow ]
-              - [ vector, twist ]
-              - [ vector, dimple ]
-          - applies-to: [ TORUS, TUBE, RING ]
+              - [integer, hole_type]
+              - [vector, cut]
+              - [float, hollow]
+              - [vector, twist]
+              - [vector, dimple]
+          - applies-to: [TORUS, TUBE, RING]
             params:
-              - [ integer, hole_type ]
-              - [ vector, cut ]
-              - [ float, hollow ]
-              - [ vector, twist ]
-              - [ vector, hole_size ]
-              - [ vector, top_shear ]
-              - [ vector, advanced_cut ]
-              - [ vector, taper ]
-              - [ float, revolutions ]
-              - [ float, radius_offset ]
-              - [ float, skew ]
-          - applies-to: [ SCULPT ]
+              - [integer, hole_type]
+              - [vector, cut]
+              - [float, hollow]
+              - [vector, twist]
+              - [vector, hole_size]
+              - [vector, top_shear]
+              - [vector, advanced_cut]
+              - [vector, taper]
+              - [float, revolutions]
+              - [float, radius_offset]
+              - [float, skew]
+          - applies-to: [SCULPT]
             params:
-              - [ asset,   texture ]
-              - [ integer, sculpt_type ]
+              - [asset, texture]
+              - [integer, sculpt_type]
       TEXTURE:
         face-target: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
       COLOR:
         face-target: true
         params:
-          - [ vector, color ]
-          - [ float, alpha ]
+          - [vector, color]
+          - [float, alpha]
       BUMP_SHINY:
         face-target: true
         # Neither name is very good, but at least this makes sense
         method-name: 'shinyBump'
         params:
-          - [ integer, shiny ]
-          - [ integer, bump ]
+          - [integer, shiny]
+          - [integer, bump]
       FULLBRIGHT:
         face-target: true
         params:
-          - [ boolean, enabled ]
+          - [boolean, enabled]
       FLEXIBLE:
         params:
-          - [ boolean, enabled ]
-          - [ integer, softness ]
-          - [ float, gravity ]
-          - [ float, friction ]
-          - [ float, wind ]
-          - [ float, tension ]
-          - [ vector, force ]
+          - [boolean, enabled]
+          - [integer, softness]
+          - [float, gravity]
+          - [float, friction]
+          - [float, wind]
+          - [float, tension]
+          - [vector, force]
       TEXGEN:
         face-target: true
         params:
-          - [ integer, mode ]
+          - [integer, mode]
       POINT_LIGHT:
         params:
-          - [ boolean, enabled ]
-          - [ vector, linear_color ]
-          - [ float, intensity ]
-          - [ float, radius ]
-          - [ float, falloff ]
+          - [boolean, enabled]
+          - [vector, linear_color]
+          - [float, intensity]
+          - [float, radius]
+          - [float, falloff]
       GLOW:
         face-target: true
         params:
-          - [ float, intensity ]
+          - [float, intensity]
       TEXT:
         params:
-          - [ string, text ]
-          - [ vector, color ]
-          - [ float, alpha ]
+          - [string, text]
+          - [vector, color]
+          - [float, alpha]
       NAME:
         params:
-          - [ string, name ]
+          - [string, name]
       DESC:
         method-name: "description"
         params:
-          - [ string, description ]
+          - [string, description]
       ROT_LOCAL:
         params:
-          - [ rotation, rot ]
+          - [rotation, rot]
       PHYSICS_SHAPE_TYPE:
         params:
-          - [ integer, shape_type ]
+          - [integer, shape_type]
       OMEGA:
         params:
-          - [ vector, axis ]
-          - [ float, spinrate ]
-          - [ float, gain ]
+          - [vector, axis]
+          - [float, spinrate]
+          - [float, gain]
       POS_LOCAL:
         params:
-          - [ vector, position ]
+          - [vector, position]
       SLICE:
         params:
-          - [ vector, slice ]
+          - [vector, slice]
       SPECULAR:
         face-target: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
-          - [ vector, color ]
-          - [ integer, glossiness ]
-          - [ integer, environment ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
+          - [vector, color]
+          - [integer, glossiness]
+          - [integer, environment]
       NORMAL:
         face-target: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
       ALPHA_MODE:
         face-target: true
         params:
-          - [ integer, alpha_mode ]
-          - [ integer, mask_cutoff ]
+          - [integer, alpha_mode]
+          - [integer, mask_cutoff]
       ALLOW_UNSIT:
         params:
-          - [ boolean, allowed ]
+          - [boolean, allowed]
       SCRIPTED_SIT_ONLY:
         params:
-          - [ boolean, enabled ]
+          - [boolean, enabled]
       SIT_TARGET:
         params:
-          - [ boolean, active ]
-          - [ vector, offset ]
-          - [ rotation, rot ]
+          - [boolean, active]
+          - [vector, offset]
+          - [rotation, rot]
       PROJECTOR:
         params:
           # This should almost certainly have asset semantics, but the server
-          # appears to only allow `string`, though stringified UUID is fine?
+          # appears to only allow 'string', though stringified UUID is fine?
           # Will need to fix that. Also, llGetPrimitiveParams does not allow reading:
           # https://feedback.secondlife.com/scripting-features/p/make-prim-projector-readable
           # https://community.secondlife.com/forums/topic/486118-only-set-ambiance-on-prim_projector#comment-2446570
-          - [ string, texture ]
-          - [ float, fov ]
-          - [ float, focus ]
-          - [ float, ambiance ]
+          - [string, texture]
+          - [float, fov]
+          - [float, focus]
+          - [float, ambiance]
       CLICK_ACTION:
         params:
-          - [ integer, action ]
+          - [integer, action]
       REFLECTION_PROBE:
         params:
-          - [ boolean, enabled ]
-          - [ float, ambiance ]
-          - [ float, clip_distance ]
-          - [ integer, flags ]
+          - [boolean, enabled]
+          - [float, ambiance]
+          - [float, clip_distance]
+          - [integer, flags]
       GLTF_NORMAL:
         face-target: true
         nullable: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
       GLTF_EMISSIVE:
         face-target: true
         nullable: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
-          - [ vector, linear_emissive_tint ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
+          - [vector, linear_emissive_tint]
       GLTF_METALLIC_ROUGHNESS:
         face-target: true
         nullable: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
-          - [ float, metallic_factor ]
-          - [ float, roughness_factor ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
+          - [float, metallic_factor]
+          - [float, roughness_factor]
       GLTF_BASE_COLOR:
         face-target: true
         nullable: true
         params:
-          - [ asset, texture ]
-          - [ vector, repeats ]
-          - [ vector, offsets ]
-          - [ float, rotation_in_radians ]
-          - [ vector, linear_color ]
-          - [ float, alpha ]
-          - [ integer, gltf_alpha_mode ]
-          - [ float, alpha_mask_cutoff ]
-          - [ boolean, double_sided ]
+          - [asset, texture]
+          - [vector, repeats]
+          - [vector, offsets]
+          - [float, rotation_in_radians]
+          - [vector, linear_color]
+          - [float, alpha]
+          - [integer, gltf_alpha_mode]
+          - [float, alpha_mask_cutoff]
+          - [boolean, double_sided]
       RENDER_MATERIAL:
         face-target: true
         params:
-          - [ asset, render_material ]
+          - [asset, render_material]
       SIT_FLAGS:
         params:
-          - [ integer, flags ]
+          - [integer, flags]
       DAMAGE:
         params:
-          - [ float, damage ]
-          - [ integer, damage_type ]
+          - [float, damage]
+          - [integer, damage_type]
       HEALTH:
         params:
-          - [ float, health ]
+          - [float, health]
       COLLISION_SOUND:
         params:
-          - [ asset, sound ]
-          - [ float, volume ]
+          - [asset, sound]
+          - [float, volume]


### PR DESCRIPTION
This PR does two different but related things:
- Changes the names of arguments in functions and events to their Wiki names.
- Completes and improves the tooltips for functions, events, their arguments, and constants.

I originally wanted to make two separate PRs, but some of the tooltips refer to the argument names, so they have to go together. 
Everything was generated by script, so there shouldn't be any manual typos, only potential scripting errors.

Why change the argument names to match the Wiki?
- Avoids keyword conflicts: Some current Yaml arguments are named Key, Vector, or Rotation. If we lowercase them directly, they become reserved keywords in LSL/Lua and break. Using the Wiki names avoids this.
- Standardization: Yaml names currently start with an uppercase letter, which isn't standard in Lua.
- Accuracy: Wiki names have been heavily checked and corrected by the community over time.
- Conciseness: Wiki names are often shorter, whereas some of the current Yaml names are too verbose.
- Documentation consistency: The Wiki texts already use these argument names (Although hey could be changed, since usually they are in bold).

I have published the intermediate results in JSON format to help review these changes:
- All Yaml and Wiki names: https://suzanna-linn.github.io/slua/wiki-args-names.html
- Only names with changes (not including lettercase changes): https://suzanna-linn.github.io/slua/wiki-args-names-changes.html
- Only names with significant changes (not including changes like Position - pos, Value - val, etc): https://suzanna-linn.github.io/slua/wiki-args-names-big-changes.html

For functions that don't exist on the Wiki, I kept their original argument names but changed them to lowercase:
- llClearExperience
- llClearExperiencePermissions
- llFindNotecardTextCount
- llGetExperienceList
- llSetExperienceKey


Tooltip Improvements
- This PR adds and improves tooltips for functions, events, constants, and arguments based on data scraped from the Wiki.
- This part is still incomplete. While there are a lot of new and improved tooltips, these are just what could be scraped from the Wiki. We will need a second phase later to manually add the remaining ones.

Intermediate results in JSON format, showing where the new tooltips come from:
- functions and events, and their arguments: https://suzanna-linn.github.io/slua/wiki-tooltips-functions-events.html"
  - "tooltip" : the current tooltip
  - "description" : the description on Wiki
  - "newtooltip" : the new tooltip obtained from the previous ones
  - the argument key is the current Yaml name, "newname" is the new name in this PR.
- constants: https://suzanna-linn.github.io/slua/wiki-tooltips-constants.html
  - "tooltip" : the current tooltip
  - "description" : the description on Wiki
  - names of constants, functions and events : the description of the constant in tables in them 
  - "newtooltip" : the new tooltip obtained from the previous ones

All of these JSON files are linked in https://suzanna-linn.github.io/slua/wiki-json-index.html, along with some other results I'm publishing in case they are useful to anyone.
