### PR TITLE
Add slua_definitions.yaml to generated output

### DIFF
--- a/gen_all_definitions.sh
+++ b/gen_all_definitions.sh
@@ -18,6 +18,7 @@ $CMD $DEFS slua_lsp_defs $SLUA "$outdir/secondlife.d.luau"
 $CMD $DEFS slua_lsp_docs $SLUA "$outdir/secondlife.docs.json"
 $CMD $DEFS gen_builtins_txt "$outdir/builtins.txt"
 $CMD $DEFS slua_selene $SLUA "$outdir/secondlife_selene.yml"
+$CMD $DEFS slua_definitions $SLUA "$outdir/slua_definitions.yaml"
 
 # Syntax highlighting
 $CMD $DEFS syntax_textmate_slua ./templates/syntax/slua.tmLanguage $SLUA "$outdir/syntax/slua.tmLanguage"

--- a/generated/slua_definitions.yaml
+++ b/generated/slua_definitions.yaml
@@ -1,0 +1,20733 @@
+# Second Life SLua (Server Lua) standard library definitions
+#
+# increment only when the file format changes, not just the content
+version: 1.0.0
+base-classes:
+- name: quaternion
+  comment: A set of four float values. Used to represent rotations and orientations.
+  properties:
+  - name: x
+    type: number
+  - name: y
+    type: number
+  - name: z
+    type: number
+  - name: s
+    type: number
+  methods:
+  - parameters:
+    - name: self
+    - name: other
+      type: quaternion
+    return-type: quaternion
+    name: __add
+  - parameters:
+    - name: self
+    - name: other
+      type: quaternion
+    return-type: quaternion
+    name: __sub
+  - parameters:
+    - name: self
+    - name: other
+      type: quaternion
+    return-type: quaternion
+    name: __mul
+  - parameters:
+    - name: self
+    - name: other
+      type: quaternion
+    return-type: quaternion
+    name: __div
+  - parameters:
+    - name: self
+    return-type: quaternion
+    name: __unm
+  - parameters:
+    - name: self
+    - name: other
+      type: quaternion
+    return-type: boolean
+    name: __eq
+  - parameters:
+    - name: self
+    return-type: string
+    name: __tostring
+- name: uuid
+  comment: "A 128\u2011bit unique identifier formatted as 36 hexadecimal characters\
+    \ (8\u20114\u20114\u20114\u201112), e.g. \"A822FF2B-FF02-461D-B45D-DCD10A2DE0C2\"\
+    ."
+  properties:
+  - name: istruthy
+    type: boolean
+    comment: Returns true if the UUID is not the null UUID (all zeros)
+  - name: bytes
+    type: string
+    comment: Returns the raw 16-byte binary string of the UUID
+  methods:
+  - parameters:
+    - name: self
+    return-type: string
+    name: __tostring
+- name: vector
+  comment: A set of three float values. Used to represent colors (RGB), positions,
+    directions, and velocities.
+  properties:
+  - name: x
+    type: number
+  - name: y
+    type: number
+  - name: z
+    type: number
+  methods:
+  - parameters:
+    - name: self
+    - name: other
+      type: vector
+    return-type: vector
+    comment: Native component-wise addition
+    name: __add
+  - parameters:
+    - name: self
+    - name: other
+      type: vector
+    return-type: vector
+    comment: Native component-wise subtraction
+    name: __sub
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Unary negation
+    name: __unm
+  - parameters:
+    - name: self
+    - name: other
+      type: number | vector | quaternion
+    return-type: vector
+    comment: 'Multiplication: vector * vector / number -> vector (Scale), vector *
+      quaternion -> vector (Rotation)'
+    name: __mul
+  - parameters:
+    - name: self
+    - name: other
+      type: number | vector | quaternion
+    return-type: vector
+    comment: 'Division: vector / number -> vector (Scale), vector / quaternion ->
+      vector (Rotation by inverse)'
+    name: __div
+  - parameters:
+    - name: self
+    - name: other
+      type: vector
+    return-type: vector
+    comment: 'LSL-style modulo: vector % vector -> vector (Cross Product)'
+    name: __mod
+  - parameters:
+    - name: self
+    return-type: string
+    name: __tostring
+- name: DetectedEvent
+  comment: Event detection class providing access to detected object/avatar information
+  properties:
+  - name: index
+    type: number
+  - name: valid
+    type: boolean
+  - name: canAdjustDamage
+    type: boolean
+  methods:
+  - parameters:
+    - name: self
+    - name: new_damage
+      type: number
+      comment: New damage value to be applied or distributed after on_damage processing.
+    comment: Modifies the amount of damage applied by the current on_damage event
+      after it completes processing, specified by the damage event index number.
+    name: adjustDamage
+  - parameters:
+    - name: self
+    return-type: '{any}'
+    comment: Returns a list containing pending damage information for the event specified
+      by number, including the current damage, the damage type, and the original damage
+      delivered.
+    name: getDamage
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns a vector representing the grab offset of the user touching the
+      object. Only works in touch events and returns <0.0, 0.0, 0.0> if number is
+      not a valid index.
+    name: getGrab
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: boolean
+    comment: Returns TRUE if the detected object or avatar specified by number has
+      the same active group as the prim containing the script. Returns FALSE if the
+      group is not active or if they are not in the group.
+    name: getGroup
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: uuid
+    comment: Returns the key (UUID) of the detected object or avatar specified by
+      number, or NULL_KEY if number is not a valid index.
+    name: getKey
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: number
+    comment: Returns the link number (integer) of the triggered event (touches and
+      collisions only) specified by number. Returns 0 for non-linked objects, 1 for
+      the root prim, and 2+ for child prims. Returns 0 if not supported by the event.
+    name: getLinkNumber
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: string
+    comment: Returns a string representing the name of the detected object or avatar
+      specified by item. Returns an empty string if item is not a valid index.
+    name: getName
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: uuid
+    comment: Returns the key (UUID) of the owner of the detected object specified
+      by number. Returns an invalid key if number is not a valid index.
+    name: getOwner
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the vector position (in region coordinates) of the detected object
+      or avatar specified by number, or <0.0, 0.0, 0.0> if number is not a valid index.
+    name: getPos
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: uuid
+    comment: Returns the key (UUID) of the object or avatar that rezzed the detected
+      object specified by number.
+    name: getRezzer
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: quaternion
+    comment: Returns the rotation of the detected object or avatar specified by number,
+      or <0.0, 0.0, 0.0, 1.0> if number is not a valid offset index.
+    name: getRot
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the surface binormal vector (tangent to the surface, pointing
+      along the positive T (V) direction of tangent space) at the touched location
+      specified by index. Can be used with llDetectedTouchNormal to determine the
+      tangent space.
+    name: getTouchBinormal
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: number
+    comment: Returns the integer index of the face clicked by the avatar in the touch
+      event specified by index.
+    name: getTouchFace
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the surface normal vector (perpendicular to the surface) at the
+      touched location specified by index. Can be used with llDetectedTouchBinormal
+      to determine the tangent space.
+    name: getTouchNormal
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the vector position where the object was touched (specified by
+      index) in region coordinates, or in screen-space coordinates if the object is
+      attached as a HUD.
+    name: getTouchPos
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the surface coordinates (<s, t, 0.0>) where the prim was touched,
+      specified by index. X and Y contain the horizontal (s) and vertical (t) face
+      coordinates, typically in the interval [0.0, 1.0]. Returns TOUCH_INVALID_TEXCOORD
+      if coordinates cannot be determined.
+    name: getTouchST
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the texture coordinates (<u, v, 0.0>) where the prim was touched,
+      specified by index. X and Y contain the horizontal (u) and vertical (v) texture
+      coordinates, typically in the interval [0.0, 1.0] (affected by repeats and rotation).
+      Returns TOUCH_INVALID_TEXCOORD if coordinates cannot be determined.
+    name: getTouchUV
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: number
+    comment: Returns an integer bitfield representing the types (AGENT, ACTIVE, PASSIVE,
+      or SCRIPTED) of the detected object or avatar specified by number. Returns 0
+      if number is not a valid index.
+    name: getType
+    must-use: true
+  - parameters:
+    - name: self
+    return-type: vector
+    comment: Returns the vector velocity of the detected object or avatar specified
+      by number, or <0.0, 0.0, 0.0> if number is not a valid offset index.
+    name: getVel
+    must-use: true
+type-aliases:
+- name: rotation
+  definition: quaternion
+  selene-type:
+    display: quaternion
+  comment: '''rotation'' is an alias for ''quaternion'''
+  export: true
+- name: list
+  definition: '{string | number | vector | uuid | quaternion | boolean}'
+  selene-type: table
+  export: true
+- name: LLDetectedEventName
+  definition: '"collision" | "collision_end" | "collision_start" | "final_damage"
+    | "on_damage" | "sensor" | "touch" | "touch_end" | "touch_start"'
+  selene-type:
+  - collision
+  - collision_end
+  - collision_start
+  - final_damage
+  - on_damage
+  - sensor
+  - touch
+  - touch_end
+  - touch_start
+- name: LLNonDetectedEventName
+  definition: '"at_rot_target" | "at_target" | "attach" | "changed" | "control" |
+    "dataserver" | "email" | "experience_permissions" | "experience_permissions_denied"
+    | "game_control" | "http_request" | "http_response" | "land_collision" | "land_collision_end"
+    | "land_collision_start" | "link_message" | "linkset_data" | "listen" | "money"
+    | "moving_end" | "moving_start" | "no_sensor" | "not_at_rot_target" | "not_at_target"
+    | "object_rez" | "on_death" | "on_rez" | "path_update" | "remote_data" | "run_time_permissions"
+    | "timer" | "transaction_result"'
+  selene-type:
+  - at_rot_target
+  - at_target
+  - attach
+  - changed
+  - control
+  - dataserver
+  - email
+  - experience_permissions
+  - experience_permissions_denied
+  - game_control
+  - http_request
+  - http_response
+  - land_collision
+  - land_collision_end
+  - land_collision_start
+  - link_message
+  - linkset_data
+  - listen
+  - money
+  - moving_end
+  - moving_start
+  - no_sensor
+  - not_at_rot_target
+  - not_at_target
+  - object_rez
+  - on_death
+  - on_rez
+  - path_update
+  - remote_data
+  - run_time_permissions
+  - timer
+  - transaction_result
+- name: LLEventName
+  definition: LLDetectedEventName | LLNonDetectedEventName
+  selene-type:
+  - collision
+  - collision_end
+  - collision_start
+  - final_damage
+  - on_damage
+  - sensor
+  - touch
+  - touch_end
+  - touch_start
+  - at_rot_target
+  - at_target
+  - attach
+  - changed
+  - control
+  - dataserver
+  - email
+  - experience_permissions
+  - experience_permissions_denied
+  - game_control
+  - http_request
+  - http_response
+  - land_collision
+  - land_collision_end
+  - land_collision_start
+  - link_message
+  - linkset_data
+  - listen
+  - money
+  - moving_end
+  - moving_start
+  - no_sensor
+  - not_at_rot_target
+  - not_at_target
+  - object_rez
+  - on_death
+  - on_rez
+  - path_update
+  - remote_data
+  - run_time_permissions
+  - timer
+  - transaction_result
+- name: LLEventHandler
+  definition: (...any) -> ()
+  selene-type: function
+- name: LLDetectedEventHandler
+  definition: '(detected: {DetectedEvent}) -> ()'
+  selene-type: function
+- name: LLTimerEveryCallback
+  definition: '(scheduled: number, interval: number) -> ()'
+  selene-type: function
+  comment: Callback type for LLTimers.every() - receives scheduled time and interval
+- name: LLTimerOnceCallback
+  definition: '(scheduled: number) -> ()'
+  selene-type: function
+  comment: Callback type for LLTimers.once() - receives scheduled time
+- name: LLTimerCallback
+  definition: LLTimerEveryCallback | LLTimerOnceCallback
+  selene-type: function
+  comment: Union of timer callback types
+- name: DateTypeArg
+  definition: "{\n  year: number,\n  month: number,\n  day: number,\n  hour: number?,\n\
+    \  min: number?,\n  sec: number?,\n  isdst: boolean?,\n}"
+  selene-type:
+    display: DateTypeArg
+  comment: Date/time table structure used by os.date and os.time
+  export: true
+- name: DateTypeResult
+  definition: "{\n  year: number,\n  month: number,\n  day: number,\n  hour: number?,\n\
+    \  min: number?,\n  sec: number?,\n  wday: number?,\n  yday: number?,\n  isdst:\
+    \ boolean?,\n}"
+  selene-type:
+    display: DateTypeResult
+  comment: Date/time table structure used by os.date and os.time
+  export: true
+- name: LLJsonEncodeOptions
+  definition: "{\n  tight: boolean?,\n  skip_tojson: boolean?,\n  allow_sparse: boolean?,\n\
+    \  replacer: ((key: any, value: any, parent: {}?) -> any)?,\n}"
+  selene-type: table
+  comment: Configuration options for lljson encoding
+- name: LLJsonDecodeReviverWithoutPath
+  definition: '(key: string | number, value: any, parent: {}?, ctx: {}) -> any'
+  selene-type: function
+- name: LLJsonDecodeOptionsWithoutPath
+  definition: "{\n  track_path: false?,\n  reviver: LLJsonDecodeReviverWithoutPath?,\n\
+    } | LLJsonDecodeReviverWithoutPath"
+  selene-type: any
+- name: LLJsonDecodeOptionsWithPath
+  definition: "{\n  track_path: true,\n  reviver: (key: string | number, value: any,\
+    \ parent: {}?, ctx: {path: {string | number}}) -> any\n}"
+  selene-type: table
+- name: LLJsonDecodeOptions
+  definition: LLJsonDecodeOptionsWithoutPath | LLJsonDecodeOptionsWithPath
+  selene-type: any
+  comment: Configuration options for lljson decoding
+classes:
+- name: LLEvents
+  comment: Event registration and management class for Second Life events
+  properties:
+  - name: at_rot_target
+    type: '((handle: number, targetrot: quaternion, ourrot: quaternion) -> ())?'
+    comment: Triggered when the script's rotation (ourrot) comes within a defined
+      angle (error) of the target rotation (targetrot) set by a call to llRotTarget
+      (which returns the associated handle).
+    modifiable: override-fields
+  - name: at_target
+    type: '((tnum: number, targetpos: vector, ourpos: vector) -> ())?'
+    comment: Triggered when the scripted object's position (ourpos) comes within the
+      defined range of the target position (targetpos) set by llTarget (which returns
+      the associated handle tnum).
+    modifiable: override-fields
+  - name: attach
+    type: '((id: uuid) -> ())?'
+    comment: Triggered whenever the object is attached to or detached from an avatar.
+      Passes the UUID key of the avatar (id) if attached, or NULL_KEY if detached.
+    modifiable: override-fields
+  - name: changed
+    type: '((change: number) -> ())?'
+    comment: Triggered when various properties of the object change. The parameter
+      change is a bitfield of CHANGED_* constants.
+    modifiable: override-fields
+  - name: collision
+    type: LLDetectedEventHandler?
+    comment: Triggered continuously while an avatar or another object is colliding
+      with the object containing the script. Passes num_detected, representing the
+      number of detected collisions.
+    modifiable: override-fields
+  - name: collision_end
+    type: LLDetectedEventHandler?
+    comment: Triggered when an avatar or another object stops colliding with the object
+      containing the script. Passes num_detected, representing the number of detected
+      collisions.
+    modifiable: override-fields
+  - name: collision_start
+    type: LLDetectedEventHandler?
+    comment: Triggered when an avatar or another object first begins colliding with
+      the object containing the script. Passes num_detected, representing the number
+      of detected collisions.
+    modifiable: override-fields
+  - name: control
+    type: '((id: uuid, level: number, edge: number) -> ())?'
+    comment: Triggered to pass captured avatar control inputs into the script. The
+      parameter level indicates held controls, and edge indicates change in controls
+      (both are bitfields of CONTROL_* constants).
+    modifiable: override-fields
+  - name: dataserver
+    type: '((queryid: uuid, data: string) -> ())?'
+    comment: Triggered when requested data is returned to the script (e.g., from llRequestAgentData,
+      llRequestInventoryData, or llGetNotecardLine).
+    modifiable: override-fields
+  - name: email
+    type: '((time: string, address: string, subject: string, message: string, num_left:
+      number) -> ())?'
+    comment: Triggered when an email sent to this script's address arrives. num_left
+      indicates the number of pending emails remaining in the queue.
+    modifiable: override-fields
+  - name: experience_permissions
+    type: '((agent_id: uuid) -> ())?'
+    comment: Triggered when the agent specified by agent_id approves an experience
+      permissions request (interactively or automatically if previously approved).
+    modifiable: override-fields
+  - name: experience_permissions_denied
+    type: '((agent_id: uuid, reason: number) -> ())?'
+    comment: Triggered when the agent specified by agent_id denies experience permissions,
+      or when permission is blocked for other reasons (specified by the error code
+      reason).
+    modifiable: override-fields
+  - name: final_damage
+    type: LLDetectedEventHandler?
+    comment: Triggered after all on_damage events across all scripts have completed
+      and damage is actively applied to the avatar or distributed among seated avatars.
+      Collision detected functions (llDetected*) and llDetectedDamage are available.
+    modifiable: override-fields
+  - name: game_control
+    type: '((id: uuid, button_levels: number, axes: {number}) -> ())?'
+    comment: Triggered when a compatible viewer sends game controller input changes
+      for the avatar specified by id. Only triggers for scripts in attachments or
+      seats.
+    modifiable: override-fields
+  - name: http_request
+    type: '((request_id: uuid, method: string, body: string) -> ())?'
+    comment: Triggered when the script's registered URL receives an incoming HTTP
+      request identified by request_id.
+    modifiable: override-fields
+  - name: http_response
+    type: '((request_id: uuid, status: number, metadata: {any}, body: string) -> ())?'
+    comment: Triggered when an HTTP response body is received for a pending request_id,
+      or if the request fails or times out.
+    modifiable: override-fields
+  - name: land_collision
+    type: '((pos: vector) -> ())?'
+    comment: Triggered in the root prim when a physical object or attached avatar
+      is colliding with the ground at position pos.
+    modifiable: override-fields
+  - name: land_collision_end
+    type: '((pos: vector) -> ())?'
+    comment: Triggered in the root prim when a physical object or attached avatar
+      stops colliding with the ground at position pos.
+    modifiable: override-fields
+  - name: land_collision_start
+    type: '((pos: vector) -> ())?'
+    comment: Triggered in the root prim when a physical object or attached avatar
+      first begins colliding with the ground at position pos.
+    modifiable: override-fields
+  - name: link_message
+    type: '((sender_num: number, num: number, str: string, id: string) -> ())?'
+    comment: Triggered when the script receives a link message from sender_num, containing
+      the parameters num, str, and id sent via llMessageLinked.
+    modifiable: override-fields
+  - name: linkset_data
+    type: '((action: number, name: string, value: string) -> ())?'
+    comment: Fires in all scripts in the linkset whenever the datastore has been modified
+      via an llLinksetData function. Passes the action taken, the affected key name,
+      and the new value.
+    modifiable: override-fields
+  - name: listen
+    type: '((channel: number, name: string, id: uuid, message: string) -> ())?'
+    comment: Triggered when a chat message matching active llListen filters is received
+      on channel. Passes the sender's name and UUID key id, along with the spoken
+      message string.
+    modifiable: override-fields
+  - name: money
+    type: '((id: uuid, amount: number) -> ())?'
+    comment: Triggered when a resident specified by id pays an amount of Linden dollars
+      (L$) to the prim.
+    modifiable: override-fields
+  - name: moving_end
+    type: (() -> ())?
+    comment: Triggered whenever the physical or moving object containing the script
+      stops moving.
+    modifiable: override-fields
+  - name: moving_start
+    type: (() -> ())?
+    comment: Triggered whenever the physical or moving object containing the script
+      starts moving.
+    modifiable: override-fields
+  - name: no_sensor
+    type: (() -> ())?
+    comment: Triggered when active sensors (from llSensor or llSensorRepeat) complete
+      a scan without finding any matching targets.
+    modifiable: override-fields
+  - name: not_at_rot_target
+    type: (() -> ())?
+    comment: Triggered continuously while the object's rotation is outside the leeway
+      angle of targets set via llRotTarget.
+    modifiable: override-fields
+  - name: not_at_target
+    type: (() -> ())?
+    comment: Triggered continuously while the object's position has not yet reached
+      the range of targets set via llTarget.
+    modifiable: override-fields
+  - name: object_rez
+    type: '((id: uuid) -> ())?'
+    comment: Triggered when this object successfully rezzes another object from its
+      inventory. Passes the key (UUID) id of the newly rezzed object.
+    modifiable: override-fields
+  - name: on_damage
+    type: LLDetectedEventHandler?
+    comment: Triggered when damage has been inflicted on an avatar or task, but before
+      it is applied or distributed. Collision detected functions (llDetected*), llDetectedDamage,
+      and llAdjustDamage are available. Passes num_detected, representing the number
+      of pending damage events.
+    modifiable: override-fields
+  - name: on_death
+    type: (() -> ())?
+    comment: Triggered on all worn attachments when the wearing avatar's health reaches
+      0.
+    modifiable: override-fields
+  - name: on_rez
+    type: '((start_param: number) -> ())?'
+    comment: Triggered when the object is rezzed into the world (by a script or user).
+      Passes start_param from the rezzing call (or 0 if rezzed from inventory). Also
+      triggers on attachments during login or when attached from inventory.
+    modifiable: override-fields
+  - name: path_update
+    type: '((type: number, reserved: {any}) -> ())?'
+    comment: Triggered to inform the script of changes or failures in the pathfinding
+      character's status.
+    modifiable: override-fields
+  - name: remote_data
+    type: '((event_type: number, channel: uuid, message_id: uuid, sender: string,
+      idata: number, sdata: string) -> ())?'
+    comment: Deprecated. Triggered by incoming XML-RPC calls, passing event_type,
+      channel, message_id, sender, idata, and sdata.
+    modifiable: override-fields
+  - name: run_time_permissions
+    type: '((perm: number) -> ())?'
+    comment: Triggered when an agent grants or denies runtime permissions requested
+      by llRequestPermissions. Passes the active integer permissions bitfield perm
+      (returns 0 if no permissions are currently granted).
+    modifiable: override-fields
+  - name: sensor
+    type: LLDetectedEventHandler?
+    comment: Triggered when objects matching constraints of llSensor or llSensorRepeat
+      are successfully detected. Passes num_detected, representing the number of detected
+      targets.
+    modifiable: override-fields
+  - name: timer
+    type: (() -> ())?
+    comment: Triggered at regular periodic intervals configured by llSetTimerEvent.
+    modifiable: override-fields
+  - name: touch
+    type: LLDetectedEventHandler?
+    comment: Triggered continuously while an avatar touches the object. Passes num_detected,
+      representing the number of touching agents.
+    modifiable: override-fields
+  - name: touch_end
+    type: LLDetectedEventHandler?
+    comment: Triggered when an avatar stops touching the object. Passes num_detected,
+      representing the number of touching agents.
+    modifiable: override-fields
+  - name: touch_start
+    type: LLDetectedEventHandler?
+    comment: Triggered when an avatar first touches the object. Passes num_detected,
+      representing the number of touching agents.
+    modifiable: override-fields
+  - name: transaction_result
+    type: '((id: uuid, success: boolean, data: string) -> ())?'
+    comment: Triggered when an asynchronous L$ transfer (such as llTransferLindenDollars)
+      is completed. Passes transaction info id, success status, and CSV or error data.
+    modifiable: override-fields
+  methods:
+  - parameters:
+    - name: self
+      type: LLEvents
+    - name: event
+      type: LLDetectedEventName
+    - name: callback
+      type: LLDetectedEventHandler
+    return-type: LLDetectedEventHandler
+    comment: Registers a callback for an event. Returns the callback.
+    name: 'on'
+    overloads:
+    - parameters:
+      - name: self
+        type: LLEvents
+      - name: event
+        type: LLNonDetectedEventName
+      - name: callback
+        type: LLEventHandler
+      return-type: LLEventHandler
+      comment: Registers a callback for an event. Returns the callback.
+  - parameters:
+    - name: self
+      type: LLEvents
+    - name: event
+      type: LLDetectedEventName
+    - name: callback
+      type: LLDetectedEventHandler
+    return-type: boolean
+    comment: Unregisters a callback. Returns true if found and removed.
+    name: 'off'
+    overloads:
+    - parameters:
+      - name: self
+        type: LLEvents
+      - name: event
+        type: LLNonDetectedEventName
+      - name: callback
+        type: LLEventHandler
+      return-type: boolean
+      comment: Unregisters a callback. Returns true if found and removed.
+  - parameters:
+    - name: self
+      type: LLEvents
+    - name: event
+      type: LLDetectedEventName
+    - name: callback
+      type: LLDetectedEventHandler
+    return-type: LLDetectedEventHandler
+    comment: Registers a one-time callback. Returns the wrapper function.
+    name: once
+    overloads:
+    - parameters:
+      - name: self
+        type: LLEvents
+      - name: event
+        type: LLNonDetectedEventName
+      - name: callback
+        type: LLEventHandler
+      return-type: LLEventHandler
+      comment: Registers a one-time callback. Returns the wrapper function.
+  - parameters:
+    - name: self
+    - name: event
+      type: LLEventName
+    return-type: '{LLEventHandler}'
+    comment: Returns a list of all handlers for a specific event.
+    name: handlers
+  - parameters:
+    - name: self
+    return-type: '{string}'
+    comment: Returns a list of all event names that have handlers.
+    name: eventNames
+- name: LLTimers
+  comment: Timer management class for scheduling periodic and one-time callbacks
+  methods:
+  - parameters:
+    - name: self
+    - name: seconds
+      type: number
+    - name: callback
+      type: LLTimerEveryCallback
+    return-type: LLTimerCallback
+    comment: Registers a callback to be called every N seconds. Returns the callback.
+    name: every
+  - parameters:
+    - name: self
+    - name: seconds
+      type: number
+    - name: callback
+      type: LLTimerOnceCallback
+    return-type: LLTimerCallback
+    comment: Registers a callback to be called once after N seconds. Returns the callback.
+    name: once
+  - parameters:
+    - name: self
+    - name: callback
+      type: LLTimerCallback
+    return-type: boolean
+    comment: Unregisters a timer callback. Returns true if found and removed.
+    name: 'off'
+- name: PrimParamsSetterType
+  comment: Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast
+  instance-type: '{any}'
+  export: true
+  functions:
+  - return-type: PrimParamsSetterType
+    comment: Create an empty list with PrimParamsSetterTypeMeta as metatable
+    name: new
+  methods:
+  - parameters:
+    - name: self
+      type: PrimParamsSetterType
+    - name: link
+      type: number?
+      comment: Link number to target, or LINK_THIS if not specified
+    comment: Call ll.SetLinkPrimitiveParamsFast with my instance list
+    name: apply
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: link_target
+      type: number
+    return-type: T
+    name: targetLink
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: flag
+      type: number
+    return-type: T
+    name: physicsMaterial
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    return-type: T
+    name: physical
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    return-type: T
+    name: temporary
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    return-type: T
+    name: phantom
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: position
+      type: vector
+    return-type: T
+    name: pos
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: size
+      type: vector
+    return-type: T
+    name: size
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: rot
+      type: quaternion
+    return-type: T
+    name: rot
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: top_size
+      type: vector
+    - name: top_shear
+      type: vector
+    return-type: T
+    name: primTypeBox
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: top_size
+      type: vector
+    - name: top_shear
+      type: vector
+    return-type: T
+    name: primTypeCylinder
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: top_size
+      type: vector
+    - name: top_shear
+      type: vector
+    return-type: T
+    name: primTypePrism
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: dimple
+      type: vector
+    return-type: T
+    name: primTypeSphere
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: hole_size
+      type: vector
+    - name: top_shear
+      type: vector
+    - name: advanced_cut
+      type: vector
+    - name: taper
+      type: vector
+    - name: revolutions
+      type: number
+    - name: radius_offset
+      type: number
+    - name: skew
+      type: number
+    return-type: T
+    name: primTypeTorus
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: hole_size
+      type: vector
+    - name: top_shear
+      type: vector
+    - name: advanced_cut
+      type: vector
+    - name: taper
+      type: vector
+    - name: revolutions
+      type: number
+    - name: radius_offset
+      type: number
+    - name: skew
+      type: number
+    return-type: T
+    name: primTypeTube
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: hole_type
+      type: number
+    - name: cut
+      type: vector
+    - name: hollow
+      type: number
+    - name: twist
+      type: vector
+    - name: hole_size
+      type: vector
+    - name: top_shear
+      type: vector
+    - name: advanced_cut
+      type: vector
+    - name: taper
+      type: vector
+    - name: revolutions
+      type: number
+    - name: radius_offset
+      type: number
+    - name: skew
+      type: number
+    return-type: T
+    name: primTypeRing
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: texture
+      type: (string | uuid)
+    - name: sculpt_type
+      type: number
+    return-type: T
+    name: primTypeSculpt
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid)
+    - name: repeats
+      type: vector
+    - name: offsets
+      type: vector
+    - name: rotation_in_radians
+      type: number
+    return-type: T
+    name: texture
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: color
+      type: vector
+    - name: alpha
+      type: number
+    return-type: T
+    name: color
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: shiny
+      type: number
+    - name: bump
+      type: number
+    return-type: T
+    name: shinyBump
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: enabled
+      type: boolean
+    return-type: T
+    name: fullbright
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    - name: softness
+      type: number
+    - name: gravity
+      type: number
+    - name: friction
+      type: number
+    - name: wind
+      type: number
+    - name: tension
+      type: number
+    - name: force
+      type: vector
+    return-type: T
+    name: flexible
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: mode
+      type: number
+    return-type: T
+    name: texgen
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    - name: linear_color
+      type: vector
+    - name: intensity
+      type: number
+    - name: radius
+      type: number
+    - name: falloff
+      type: number
+    return-type: T
+    name: pointLight
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: intensity
+      type: number
+    return-type: T
+    name: glow
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: text
+      type: string
+    - name: color
+      type: vector
+    - name: alpha
+      type: number
+    return-type: T
+    name: text
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: name
+      type: string
+    return-type: T
+    name: name
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: description
+      type: string
+    return-type: T
+    name: description
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: rot
+      type: quaternion
+    return-type: T
+    name: rotLocal
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: shape_type
+      type: number
+    return-type: T
+    name: physicsShapeType
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: axis
+      type: vector
+    - name: spinrate
+      type: number
+    - name: gain
+      type: number
+    return-type: T
+    name: omega
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: position
+      type: vector
+    return-type: T
+    name: posLocal
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: slice
+      type: vector
+    return-type: T
+    name: slice
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid)
+    - name: repeats
+      type: vector
+    - name: offsets
+      type: vector
+    - name: rotation_in_radians
+      type: number
+    - name: color
+      type: vector
+    - name: glossiness
+      type: number
+    - name: environment
+      type: number
+    return-type: T
+    name: specular
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid)
+    - name: repeats
+      type: vector
+    - name: offsets
+      type: vector
+    - name: rotation_in_radians
+      type: number
+    return-type: T
+    name: normal
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: alpha_mode
+      type: number
+    - name: mask_cutoff
+      type: number
+    return-type: T
+    name: alphaMode
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: allowed
+      type: boolean
+    return-type: T
+    name: allowUnsit
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    return-type: T
+    name: scriptedSitOnly
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: active
+      type: boolean
+    - name: offset
+      type: vector
+    - name: rot
+      type: quaternion
+    return-type: T
+    name: sitTarget
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: texture
+      type: string
+    - name: fov
+      type: number
+    - name: focus
+      type: number
+    - name: ambiance
+      type: number
+    return-type: T
+    name: projector
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: action
+      type: number
+    return-type: T
+    name: clickAction
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: enabled
+      type: boolean
+    - name: ambiance
+      type: number
+    - name: clip_distance
+      type: number
+    - name: flags
+      type: number
+    return-type: T
+    name: reflectionProbe
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid) | ""
+    - name: repeats
+      type: vector | ""
+    - name: offsets
+      type: vector | ""
+    - name: rotation_in_radians
+      type: number | ""
+    return-type: T
+    name: gltfNormal
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid) | ""
+    - name: repeats
+      type: vector | ""
+    - name: offsets
+      type: vector | ""
+    - name: rotation_in_radians
+      type: number | ""
+    - name: linear_emissive_tint
+      type: vector | ""
+    return-type: T
+    name: gltfEmissive
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid) | ""
+    - name: repeats
+      type: vector | ""
+    - name: offsets
+      type: vector | ""
+    - name: rotation_in_radians
+      type: number | ""
+    - name: metallic_factor
+      type: number | ""
+    - name: roughness_factor
+      type: number | ""
+    return-type: T
+    name: gltfMetallicRoughness
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: texture
+      type: (string | uuid) | ""
+    - name: repeats
+      type: vector | ""
+    - name: offsets
+      type: vector | ""
+    - name: rotation_in_radians
+      type: number | ""
+    - name: linear_color
+      type: vector | ""
+    - name: alpha
+      type: number | ""
+    - name: gltf_alpha_mode
+      type: number | ""
+    - name: alpha_mask_cutoff
+      type: number | ""
+    - name: double_sided
+      type: boolean | ""
+    return-type: T
+    name: gltfBaseColor
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: face
+      type: number
+    - name: render_material
+      type: (string | uuid)
+    return-type: T
+    name: renderMaterial
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: flags
+      type: number
+    return-type: T
+    name: sitFlags
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: damage
+      type: number
+    - name: damage_type
+      type: number
+    return-type: T
+    name: damage
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: health
+      type: number
+    return-type: T
+    name: health
+  - type-parameters:
+    - T
+    parameters:
+    - name: self
+      type: T & PrimParamsSetterType
+    - name: sound
+      type: (string | uuid)
+    - name: volume
+      type: number
+    return-type: T
+    name: collisionSound
+global-variables:
+- name: rotation
+  type: typeof(quaternion)
+  comment: rotation is an alias for quaternion.
+- name: LLEvents
+  type: LLEvents
+  comment: Event registration and management singleton for Second Life events.
+- name: LLTimers
+  type: LLTimers
+  comment: Timer management singleton for scheduling periodic and one-time callbacks.
+functions:
+- type-parameters:
+  - T
+  parameters:
+  - name: value
+    type: T?
+    comment: Value to check for truthiness.
+  - name: errorMessage
+    type: string?
+    comment: Error message to display if the value is not truthy.
+    default-value: '"assertion failed!"'
+  return-type: T
+  comment: Checks if the value is truthy; if not, raises an error with the optional
+    message.
+  name: assert
+  typechecker:
+    magic: true
+- parameters:
+  - name: option
+    type: '"collect"?'
+    selene-type: string
+  comment: Run the garbage collector
+  name: collectgarbage
+  overloads:
+  - parameters:
+    - name: option
+      type: '"count"'
+      selene-type: string
+    return-type: number
+    comment: Alias for gcinfo
+  local-only: true
+- parameters:
+  - name: f
+    type: (...any) -> ...any
+  return-type: '...any'
+  comment: Dangerously executes a required module function
+  name: dangerouslyexecuterequiredmodule
+- type-parameters:
+  - T
+  parameters:
+  - name: message
+    type: T
+    comment: Error message to raise.
+  - name: level
+    type: number?
+    comment: Level to attribute the error to in the call stack.
+    default-value: 1
+  return-type: never
+  comment: Raises an error with the specified object and optional call stack level.
+  name: error
+- return-type: number
+  comment: Returns the total heap size in kilobytes.
+  name: gcinfo
+- parameters:
+  - name: target
+    type: ((...any) -> ...any) | number
+    selene-type: function
+  return-type: '{[string]: any}'
+  comment: Get the scoped environment for the given function.
+  name: getfenv
+  slua-removed: true
+- type-parameters:
+  - T
+  parameters:
+  - name: obj
+    type: T
+    comment: Object to get the metatable for.
+    selene-type: table
+  return-type: getmetatable<T>
+  comment: Returns the metatable for the specified object.
+  name: getmetatable
+  typechecker:
+    builtin: true
+- parameters:
+  - name: path
+    type: string
+  comment: Writes the contents of heap to the given file in JSON format. Intended
+    to be used with tools/graphanalyze.py
+  name: graphheap
+  local-only: true
+- parameters:
+  - name: path
+    type: string
+  comment: Writes the contents of user heap to the given file in JSON format. Intended
+    to be used with tools/graphanalyze.py
+  name: graphuserheap
+  local-only: true
+- type-parameters:
+  - V
+  parameters:
+  - name: tab
+    type: '{V}'
+    comment: Table to iterate over.
+  return-type: (({V}, number) -> (number?, V), {V}, number)
+  comment: Returns an iterator for numeric key-value pairs in the table.
+  name: ipairs
+- type-parameters:
+  - A...
+  parameters:
+  - name: src
+    type: string
+  - name: chunkname
+    type: string?
+  return-type: (((A...) -> any)?, string?)
+  comment: Compile Luau code into a function.
+  name: loadstring
+  slua-removed: true
+- parameters:
+  - name: mt
+    type: boolean?
+    comment: Boolean to create a modifiable metatable.
+    default-value: false
+  return-type: any
+  comment: Creates a new untyped userdata object with an optional metatable.
+  name: newproxy
+- type-parameters:
+  - K
+  - V
+  parameters:
+  - name: t
+    type: '{[K]: V}'
+    comment: Table to traverse.
+  - name: i
+    type: K?
+    comment: Key to start traversal after.
+    default-value: nil
+  return-type: (K?, V)
+  comment: Returns the next key-value pair in the table traversal order.
+  name: next
+  typechecker:
+    builtin: true
+- type-parameters:
+  - K
+  - V
+  parameters:
+  - name: t
+    type: '{[K]: V}'
+    comment: Table to iterate over.
+  return-type: '(({[K]: V}, K?) -> (K?, V), {[K]: V}, K)'
+  comment: Returns an iterator for all key-value pairs in the table.
+  name: pairs
+  typechecker:
+    builtin: true
+- type-parameters:
+  - A...
+  - R...
+  parameters:
+  - name: f
+    type: (A...) -> R...
+    comment: A function to be called.
+  - name: '...'
+    type: A...
+    comment: Arguments to pass to the function.
+  return-type: (boolean, R...)
+  comment: Calls function f with parameters args, returning success and function results
+    or an error.
+  name: pcall
+- type-parameters:
+  - T...
+  parameters:
+  - name: '...'
+    type: T...
+    comment: Arguments to print to standard output.
+  comment: Prints all arguments to standard output using Tab as a separator.
+  name: print
+- type-parameters:
+  - T1
+  - T2
+  parameters:
+  - name: a
+    type: T1
+    comment: First object to compare.
+  - name: b
+    type: T2
+    comment: Second object to compare.
+  return-type: boolean
+  comment: Returns true if a and b have the same type and value.
+  name: rawequal
+- type-parameters:
+  - K
+  - V
+  parameters:
+  - name: t
+    type: '{[K]: V}'
+    comment: Table to perform the lookup on.
+  - name: k
+    type: K
+    comment: Key to look up in the table.
+  return-type: V?
+  comment: Performs a table lookup bypassing metatables.
+  name: rawget
+- type-parameters:
+  - K
+  - V
+  parameters:
+  - name: t
+    type: '{[K]: V} | string'
+    comment: Table or string to compute the length of.
+  return-type: number
+  comment: Returns the length of a table or string bypassing metatables.
+  name: rawlen
+- type-parameters:
+  - K
+  - V
+  parameters:
+  - name: t
+    type: '{[K]: V}'
+    comment: Table to assign the value to.
+  - name: k
+    type: K
+    comment: Key to assign the value to.
+  - name: v
+    type: V
+    comment: Value to assign.
+  return-type: '{[K]: V}'
+  comment: Assigns a value to a table field bypassing metatables.
+  name: rawset
+- parameters:
+  - name: target
+    type: any
+    comment: Name of the external module.
+  return-type: any
+  comment: Execute the named external module.
+  name: require
+  typechecker:
+    magic: true
+- type-parameters:
+  - A...
+  parameters:
+  - name: i
+    type: string | number
+    comment: Index or '#' to count arguments.
+  - name: '...'
+    type: A...
+    comment: Arguments to select from.
+  return-type: '...any'
+  comment: Returns a subset of arguments or the number of arguments.
+  name: select
+  typechecker:
+    magic: true
+- type-parameters:
+  - T...
+  - R...
+  parameters:
+  - name: target
+    type: number | (T...) -> R...
+    selene-type: function
+  - name: env
+    type: '{[string]: any}'
+  return-type: ((T...) -> R...)?
+  comment: Set the scoped environment for the given function.
+  name: setfenv
+  slua-removed: true
+- type-parameters:
+  - T
+  - MT
+  parameters:
+  - name: t
+    type: T
+    comment: Table to set the metatable for.
+    selene-type: table
+  - name: mt
+    type: MT
+    comment: Metatable to set.
+    selene-type: table
+  return-type: setmetatable<T, MT>
+  comment: Changes the metatable for the given table.
+  name: setmetatable
+  typechecker:
+    builtin: true
+    magic: true
+- parameters:
+  - name: value
+    type: string? | number
+    comment: String to convert to a number.
+    selene-type: string
+  - name: base
+    type: number?
+    comment: Base for the conversion.
+    default-value: 10
+  return-type: number?
+  comment: Converts the input string to a number in the specified base.
+  name: tonumber
+  must-use: true
+- parameters:
+  - name: value
+    type: string? | quaternion
+    selene-type: string
+  return-type: quaternion?
+  comment: Converts a string to a quaternion, returns nil if invalid
+  name: toquaternion
+  must-use: true
+- parameters:
+  - name: value
+    type: string? | quaternion
+    selene-type: string
+  return-type: quaternion?
+  comment: Converts a string to a rotation (quaternion), returns nil if invalid
+  name: torotation
+  must-use: true
+- type-parameters:
+  - T
+  parameters:
+  - name: value
+    type: T
+    comment: Object to convert to a string.
+  return-type: string
+  comment: Converts the input object to a string.
+  name: tostring
+- parameters:
+  - name: val
+    type: string? | buffer | uuid
+    selene-type: string
+  return-type: uuid?
+  comment: Creates a new uuid from a string, buffer, or existing uuid. Returns nil
+    if the string is not a valid UUID, or the buffer is shorter than 16 bytes.
+  name: touuid
+  must-use: true
+- parameters:
+  - name: val
+    type: string? | vector
+    selene-type: string
+  return-type: vector?
+  comment: Converts a string to a vector, returns nil if invalid
+  name: tovector
+  must-use: true
+- type-parameters:
+  - T
+  parameters:
+  - name: obj
+    type: T
+    comment: Object to get the type of.
+  return-type: string
+  comment: Returns the type of the object as a string.
+  name: type
+  must-use: true
+- type-parameters:
+  - T
+  parameters:
+  - name: obj
+    type: T
+    comment: Object to get the type of.
+  return-type: string
+  comment: Returns the type of the object, including custom userdata types.
+  name: typeof
+  must-use: true
+- type-parameters:
+  - V
+  parameters:
+  - name: tab
+    type: '{V}'
+    comment: Array from which to extract values.
+  - name: i
+    type: number?
+    comment: Starting index.
+    default-value: 1
+  - name: j
+    type: number?
+    comment: Ending index.
+    default-value: '#tab'
+  return-type: '...V'
+  comment: Returns values from an array in the specified index range.
+  name: unpack
+- type-parameters:
+  - E
+  - A...
+  - R1...
+  - R2...
+  parameters:
+  - name: f
+    type: (A...) -> R1...
+    comment: A function to be called.
+  - name: err
+    type: (E) -> R2...
+    comment: Error handler function.
+  - name: '...'
+    type: A...
+    comment: Arguments to pass to the function.
+  return-type: (boolean, R1...)
+  comment: Calls function f with parameters args, handling errors with err if they
+    occur.
+  name: xpcall
+modules:
+- name: bit32
+  comment: Bitwise operations library.
+  functions:
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to shift.
+    - name: i
+      type: number
+      comment: Number of bits to shift.
+    return-type: number
+    comment: 'Shifts n by i bits to the right. If i is negative, a left shift is performed.
+
+      Does an arithmetic shift: The most significant bit of n is propagated during
+      the shift.'
+    name: arshift
+    must-use: true
+  - parameters:
+    - name: '...'
+      type: '...number'
+      comment: Numbers to perform bitwise AND on.
+    return-type: number
+    comment: Performs a bitwise AND operation on input numbers.
+    name: band
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to negate.
+    return-type: number
+    comment: Returns the bitwise negation of the input number.
+    name: bnot
+    must-use: true
+  - parameters:
+    - name: '...'
+      type: '...number'
+      comment: Numbers to perform bitwise OR on.
+    return-type: number
+    comment: Performs a bitwise OR operation on input numbers.
+    name: bor
+    must-use: true
+  - parameters:
+    - name: '...'
+      type: '...number'
+      comment: Numbers to perform bitwise XOR on.
+    return-type: number
+    comment: Performs a bitwise XOR operation on input numbers.
+    name: bxor
+    must-use: true
+  - parameters:
+    - name: '...'
+      type: '...number'
+      comment: Numbers to perform bitwise AND on.
+    return-type: boolean
+    comment: 'Performs a bitwise AND operation on input numbers.
+
+      Returns true if result is non-zero.'
+    name: btest
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+    - name: field
+      type: number
+    - name: width
+      type: number?
+      default-value: 1
+    return-type: number
+    comment: Extracts bits from n at position field with width
+    name: extract
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to rotate.
+    - name: i
+      type: number
+      comment: Number of bits to rotate.
+    return-type: number
+    comment: Rotates n by i bits to the left. If i is negative, a right rotate is
+      performed.
+    name: lrotate
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to shift.
+    - name: i
+      type: number
+      comment: Number of bits to shift.
+    return-type: number
+    comment: Shifts n by i bits to the left. If i is negative, a right shift is performed.
+    name: lshift
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+    - name: v
+      type: number
+    - name: field
+      type: number
+    - name: width
+      type: number?
+      default-value: 1
+    return-type: number
+    comment: Replaces bits in n at position field with width using value v
+    name: replace
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to rotate.
+    - name: i
+      type: number
+      comment: Number of bits to rotate.
+    return-type: number
+    comment: Rotates n by i bits to the right. If i is negative, a left rotate is
+      performed.
+    name: rrotate
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to shift.
+    - name: i
+      type: number
+      comment: Number of bits to shift.
+    return-type: number
+    comment: Shifts n by i bits to the right. If i is negative, a left shift is performed.
+    name: rshift
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Number to truncate.
+    return-type: number
+    comment: Wrap this number from float64 range to signed int32 range and truncate
+      to integer. Makes integer arithmetic compatible with LSL.
+    name: s32
+    must-use: true
+  - parameters:
+    - name: a
+      type: number
+      comment: Left factor.
+    - name: b
+      type: number
+      comment: Right factor.
+    return-type: number
+    comment: Multiplies two signed 32-bit integers. Returns the result as a signed
+      32-bit integer, wrapping as necessary. Avoids precision loss associated with
+      float64 multiplication. Compatible with LSL integer multiplication.
+    name: smul
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+    return-type: number
+    comment: Count leading zeros
+    name: countlz
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+    return-type: number
+    comment: Count trailing zeros
+    name: countrz
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+    return-type: number
+    comment: Swap byte order
+    name: byteswap
+    must-use: true
+- name: buffer
+  comment: Buffer manipulation library for binary data.
+  functions:
+  - parameters:
+    - name: size
+      type: number
+      comment: Size of the buffer to create.
+    return-type: buffer
+    comment: Creates a buffer of the requested size with all bytes initialized to
+      0.
+    name: create
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: String to initialize the buffer with.
+    return-type: buffer
+    comment: Creates a buffer initialized to the contents of the string.
+    name: fromstring
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to convert to a string.
+    return-type: string
+    comment: Returns the buffer data as a string.
+    name: tostring
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads a signed 8-bit integer from the buffer at the given offset.
+    name: readi8
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads an unsigned 8-bit integer from the buffer at the given offset.
+    name: readu8
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads a signed 16-bit integer from the buffer at the given offset.
+    name: readi16
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads an unsigned 16-bit integer from the buffer at the given offset.
+    name: readu16
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads a signed 32-bit integer from the buffer at the given offset.
+    name: readi32
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads an unsigned 32-bit integer from the buffer at the given offset.
+    name: readu32
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads a 32-bit floating-point number from the buffer at the given offset.
+    name: readf32
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to read from.
+    return-type: number
+    comment: Reads a 64-bit floating-point number from the buffer at the given offset.
+    name: readf64
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes a signed 8-bit integer to the buffer at the given offset.
+    name: writei8
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes an unsigned 8-bit integer to the buffer at the given offset.
+    name: writeu8
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes a signed 16-bit integer to the buffer at the given offset.
+    name: writei16
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes an unsigned 16-bit integer to the buffer at the given offset.
+    name: writeu16
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes a signed 32-bit integer to the buffer at the given offset.
+    name: writei32
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes an unsigned 32-bit integer to the buffer at the given offset.
+    name: writeu32
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes a 32-bit floating-point number to the buffer at the given offset.
+    name: writef32
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: number
+      comment: Value to write.
+    comment: Writes a 64-bit floating-point number to the buffer at the given offset.
+    name: writef64
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: offset
+      type: number
+      comment: Byte offset to start reading.
+    - name: count
+      type: number
+      comment: Number of bytes to read.
+    return-type: string
+    comment: Reads a string of the given length from the buffer at the specified offset.
+    name: readstring
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to write at.
+    - name: value
+      type: string
+      comment: String to write.
+    - name: count
+      type: number?
+      comment: Number of bytes to write.
+      default-value: '#value'
+    comment: Writes data from a string into the buffer at the specified offset.
+    name: writestring
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to get the size of.
+    return-type: number
+    comment: Returns the size of the buffer in bytes.
+    name: len
+    must-use: true
+  - parameters:
+    - name: target
+      type: buffer
+      comment: Target buffer to copy into.
+      observes: write
+    - name: targetOffset
+      type: number
+      comment: Offset in target buffer.
+    - name: source
+      type: buffer
+      comment: Source buffer to copy from.
+    - name: sourceOffset
+      type: number?
+      comment: Offset in source buffer.
+      default-value: 0
+    - name: count
+      type: number?
+      comment: Number of bytes to copy.
+      default-value: buffer.len(b) - sourceOffset
+    comment: Copies bytes from the source buffer into the target buffer.
+    name: copy
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to fill.
+      observes: write
+    - name: offset
+      type: number
+      comment: Byte offset to start filling.
+    - name: value
+      type: number
+      comment: Value to fill with.
+    - name: count
+      type: number?
+      comment: Number of bytes to fill.
+      default-value: buffer.len(b) - offset
+    comment: Fills the buffer with the specified value starting at the given offset.
+    name: fill
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to read from.
+    - name: bitOffset
+      type: number
+      comment: Bit offset to read at.
+    - name: bitCount
+      type: number
+      comment: Number of bits to read. Must be in [0, 32] range.
+    return-type: number
+    comment: Reads up to 32 bits from the buffer at the given offset.
+    name: readbits
+    must-use: true
+  - parameters:
+    - name: b
+      type: buffer
+      comment: Buffer to write to.
+      observes: write
+    - name: bitOffset
+      type: number
+      comment: Bit offset to write at.
+    - name: bitCount
+      type: number
+      comment: Number of bits to write. Must be in [0, 32] range.
+    - name: value
+      type: number
+      comment: Source of bits to write.
+    comment: Writes up to 32 bits to the buffer at the given offset.
+    name: writebits
+- name: coroutine
+  comment: Coroutine manipulation library.
+  functions:
+  - parameters:
+    - name: f
+      type: (...any) -> ...any
+      comment: A function to be executed by the new coroutine.
+    return-type: thread
+    comment: Returns a new coroutine that, when resumed, will run function f.
+    name: create
+    must-use: true
+  - parameters:
+    - name: co
+      type: thread
+      comment: Coroutine to resume.
+    - name: '...'
+      type: '...any'
+      comment: Arguments to pass to the coroutine.
+    return-type: (boolean, ...any)
+    comment: Resumes a coroutine, returning true and results if successful, or false
+      and an error.
+    name: resume
+  - return-type: thread?
+    comment: Returns the currently running coroutine, or nil if called from the main
+      coroutine.
+    name: running
+    must-use: true
+  - parameters:
+    - name: co
+      type: thread
+      comment: Coroutine to check status of.
+    return-type: '"running" | "suspended" | "normal" | "dead"'
+    comment: 'Returns the status of the coroutine: "running", "suspended", "normal",
+      or "dead".'
+    name: status
+    must-use: true
+  - parameters:
+    - name: f
+      type: (...any) -> ...any
+      comment: A function to execute in a coroutine.
+    return-type: (...any) -> ...any
+    comment: Creates a coroutine and returns a function that resumes it.
+    name: wrap
+    must-use: true
+  - parameters:
+    - name: '...'
+      type: '...any'
+      comment: Values to pass to the resuming code.
+    return-type: '...any'
+    comment: Yields the current coroutine, passing arguments to the resuming code.
+    name: yield
+  - return-type: boolean
+    comment: Returns true if the currently running coroutine can yield.
+    name: isyieldable
+    must-use: true
+  - parameters:
+    - name: co
+      type: thread
+      comment: Coroutine to close.
+    return-type: (boolean, string?)
+    comment: Closes a coroutine, returning true if successful or false and an error.
+    name: close
+- name: debug
+  comment: Debug library for introspection.
+  functions:
+  - parameters:
+    - name: co
+      type: thread | ((...any) -> ...any) | number
+      comment: Optional thread or function reference.
+    - name: level
+      type: number
+      comment: Stack level or function reference for inspection.
+      optional: true
+    - name: s
+      type: string
+      comment: String specifying requested information.
+    return-type: '...any'
+    comment: Returns information about a stack frame or function based on specified
+      format.
+    name: info
+    overloads:
+    - parameters:
+      - name: level
+        type: number
+        comment: Stack level or function reference for inspection.
+      - name: s
+        type: string
+        comment: String specifying requested information.
+      return-type: '...any'
+      comment: Returns information about a stack level
+    - parameters:
+      - name: func
+        type: (...any) -> ...any
+        comment: Function reference.
+      - name: s
+        type: string
+        comment: String specifying requested information.
+      return-type: '...any'
+      comment: Returns information about a function
+    must-use: true
+  - parameters:
+    - name: co
+      type: thread
+      comment: Optional thread reference for traceback.
+      optional: true
+    - name: msg
+      type: string?
+      comment: Message prepended to the traceback.
+      default-value: nil
+    - name: level
+      type: number?
+      comment: Stack level to start traceback.
+      default-value: 1
+    return-type: string
+    comment: Returns a human-readable call stack starting from the specified level.
+    name: traceback
+    overloads:
+    - parameters:
+      - name: message
+        type: string?
+        comment: Message prepended to the traceback.
+        default-value: nil
+      - name: level
+        type: number?
+        comment: Stack level to start traceback.
+        default-value: 1
+      return-type: string
+      comment: Returns a string with a traceback of the current call stack
+    must-use: true
+- name: llbase64
+  comment: Base64 encoding/decoding library.
+  functions:
+  - parameters:
+    - name: data
+      type: string | buffer
+      selene-type: string
+    return-type: string
+    comment: Encodes a string or buffer to base64
+    name: encode
+    must-use: true
+  - parameters:
+    - name: data
+      type: string
+    - name: asBuffer
+      type: false?
+      selene-type: bool
+      default-value: false
+    return-type: string
+    comment: Decodes a base64 string to a string, or buffer if asBuffer is true. The
+      output is truncated at the first decoding error.
+    name: decode
+    overloads:
+    - parameters:
+      - name: data
+        type: string
+      - name: asBuffer
+        type: 'true'
+      return-type: buffer
+      comment: Decodes a base64 string to a buffer if asBuffer is true
+    must-use: true
+- name: lljson
+  comment: JSON encoding/decoding library for Second Life.
+  constants:
+  - name: 'null'
+    type: any
+    comment: A constant to pass for null to json encode.
+  - name: remove
+    type: any
+    comment: A constant to return from a reviver/replacer replacer function to omit
+      this item.
+  - name: array_mt
+    type: '{__jsonhint: string}'
+    value: '{__jsonhint = "array"}'
+    comment: Metatable for declaring table as an array for json encode.
+  - name: object_mt
+    type: '{__jsonhint: string}'
+    value: '{__jsonhint = "object"}'
+    comment: Metatable for declaring table as an object for json encode.
+  - name: empty_array
+    type: '{}'
+    value: setmetatable({}, lljson.array_mt)
+    comment: A constant to pass for an empty array to json encode.
+  - name: empty_object
+    type: '{}'
+    value: setmetatable({}, lljson.object_mt)
+    comment: A constant to pass for an empty object to json encode.
+  functions:
+  - parameters:
+    - name: value
+      type: any
+    - name: options
+      type: LLJsonEncodeOptions?
+      default-value: '{allow_sparse=false, skip_tojson=false, replacer=nil}'
+    return-type: string
+    comment: Encodes a Lua value as JSON. Raises an error if value contains unsupported
+      types.
+    name: encode
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+    - name: options
+      type: LLJsonDecodeOptions?
+      default-value: '{track_path=false, reviver=nil}'
+    return-type: any
+    comment: Decodes a JSON string to a Lua value. Raises an error if JSON is invalid.
+    name: decode
+    must-use: true
+  - parameters:
+    - name: value
+      type: any
+    - name: options
+      type: LLJsonEncodeOptions?
+      default-value: '{allow_sparse=false, skip_tojson=false, tight=false, replacer=nil}'
+    return-type: string
+    comment: Encodes a Lua value as JSON, preserving SL types. Use tight to encode
+      more compactly. Raises an error if value contains unsupported types.
+    name: slencode
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+    - name: options
+      type: LLJsonDecodeOptions?
+      default-value: '{track_path=false, reviver=nil}'
+    return-type: any
+    comment: Decodes a JSON string to a Lua value, preserving SL types. Raises an
+      error if JSON is invalid.
+    name: sldecode
+    must-use: true
+- name: llprim
+  comment: Utilities for working with prims / objects
+  constants:
+  - name: ParamsSetter
+    type: PrimParamsSetterTypeMeta
+    value: PrimParamsSetterTypeMeta
+    comment: Metatable for building lists to pass to ll.SetLinkPrimitiveParamsFast
+- name: math
+  comment: Mathematical functions library.
+  constants:
+  - name: pi
+    type: number
+    value: '3.141592653589793'
+    comment: Value of pi
+  - name: huge
+    type: number
+    value: inf
+    comment: A value larger than any other numeric value (infinity)
+  functions:
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    return-type: number
+    comment: Returns the absolute value of n.
+    name: abs
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number in the range [-1, 1].
+    return-type: number
+    comment: Returns the arc cosine of n in radians.
+    name: acos
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number in the range [-1, 1].
+    return-type: number
+    comment: Returns the arc sine of n in radians.
+    name: asin
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    return-type: number
+    comment: Returns the arc tangent of n in radians.
+    name: atan
+    must-use: true
+  - parameters:
+    - name: y
+      type: number
+      comment: Y-coordinate.
+    - name: x
+      type: number
+      comment: X-coordinate.
+    return-type: number
+    comment: Returns the arc tangent of y/x in radians, using the signs to determine
+      the quadrant.
+    name: atan2
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to round up.
+    return-type: number
+    comment: Returns the smallest integer larger than or equal to n.
+    name: ceil
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: Value to be clamped.
+    - name: min
+      type: number
+      comment: Minimum allowable value.
+    - name: max
+      type: number
+      comment: Maximum allowable value.
+    return-type: number
+    comment: Returns n clamped between min and max.
+    name: clamp
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: An angle in radians.
+    return-type: number
+    comment: Returns the cosine of n (n is in radians).
+    name: cos
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute the hyperbolic cosine of.
+    return-type: number
+    comment: Returns the hyperbolic cosine of n.
+    name: cosh
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A value in radians.
+    return-type: number
+    comment: Converts n from radians to degrees.
+    name: deg
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute e^n.
+    return-type: number
+    comment: Returns the base-e exponent of n.
+    name: exp
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to round down.
+    return-type: number
+    comment: Returns the largest integer smaller than or equal to n.
+    name: floor
+    must-use: true
+  - parameters:
+    - name: x
+      type: number
+      comment: Dividend.
+    - name: y
+      type: number
+      comment: Divisor.
+    return-type: number
+    comment: Returns the remainder of x modulo y, rounded towards zero.
+    name: fmod
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to split into significand and exponent.
+    return-type: (number, number)
+    comment: Returns m and e such that n = m * 2^e.
+    name: frexp
+    must-use: true
+  - parameters:
+    - name: s
+      type: number
+      comment: Significand.
+    - name: e
+      type: number
+      comment: Exponent.
+    return-type: number
+    comment: Returns s * 2^e.
+    name: ldexp
+    must-use: true
+  - parameters:
+    - name: a
+      type: number
+      comment: Start value.
+    - name: b
+      type: number
+      comment: End value.
+    - name: t
+      type: number
+      comment: Interpolation factor.
+    return-type: number
+    comment: Linearly interpolates between a and b using factor t.
+    name: lerp
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute logarithm.
+    - name: base
+      type: number?
+      comment: Base of the logarithm.
+      default-value: math.e
+    return-type: number
+    comment: Returns the logarithm of n in the given base (default e).
+    name: log
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute base-10 logarithm.
+    return-type: number
+    comment: Returns the base-10 logarithm of n.
+    name: log10
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    - name: inMin
+      type: number
+      comment: A number.
+    - name: inMax
+      type: number
+      comment: A number.
+    - name: outMin
+      type: number
+      comment: A number.
+    - name: outMax
+      type: number
+      comment: A number.
+    return-type: number
+    comment: Maps n from input range to output range.
+    name: map
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    - name: '...'
+      type: '...number'
+      comment: Numbers to find the maximum from.
+      optional: false
+    return-type: number
+    comment: Returns the maximum value from the given numbers.
+    name: max
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    - name: '...'
+      type: '...number'
+      comment: Numbers to find the minimum from.
+      optional: false
+    return-type: number
+    comment: Returns the minimum value from the given numbers.
+    name: min
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to split into integer and fractional parts.
+    return-type: (number, number)
+    comment: Returns the integer and fractional parts of n.
+    name: modf
+    must-use: true
+  - parameters:
+    - name: x
+      type: number
+      comment: X coordinate for the noise function.
+    - name: y
+      type: number?
+      comment: Y coordinate for the noise function.
+      default-value: 0
+    - name: z
+      type: number?
+      comment: Z coordinate for the noise function.
+      default-value: 0
+    return-type: number
+    comment: Returns Perlin noise value for the point (x, y, z).
+    name: noise
+    must-use: true
+  - parameters:
+    - name: base
+      type: number
+      comment: Base value.
+    - name: exponent
+      type: number
+      comment: Exponent value.
+    return-type: number
+    comment: Returns base to the power of exponent.
+    name: pow
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A value in degrees.
+    return-type: number
+    comment: Converts n from degrees to radians.
+    name: rad
+    must-use: true
+  - parameters:
+    - name: min
+      type: number?
+      comment: Minimum value of the range.
+      default-value: nil
+    - name: max
+      type: number?
+      comment: Maximum value of the range.
+      default-value: nil
+    return-type: number
+    comment: Returns a random number within the given range.
+    name: random
+    must-use: true
+  - parameters:
+    - name: seed
+      type: number
+      comment: Seed for the random number generator.
+    comment: Sets the seed for the random number generator.
+    name: randomseed
+    deprecated:
+      reason: Disabled in SLua.
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to round to the nearest integer.
+    return-type: number
+    comment: Rounds n to the nearest integer.
+    name: round
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to get the sign of.
+    return-type: number
+    comment: Returns -1 if n is negative, 1 if positive, and 0 if zero.
+    name: sign
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: An angle in radians.
+    return-type: number
+    comment: Returns the sine of n (n is in radians).
+    name: sin
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute the hyperbolic sine of.
+    return-type: number
+    comment: Returns the hyperbolic sine of n.
+    name: sinh
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute the square root of.
+    return-type: number
+    comment: Returns the square root of n.
+    name: sqrt
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: An angle in radians.
+    return-type: number
+    comment: Returns the tangent of n (n is in radians).
+    name: tan
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number to compute the hyperbolic tangent of.
+    return-type: number
+    comment: Returns the hyperbolic tangent of n.
+    name: tanh
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    return-type: boolean
+    comment: Returns true if n is NaN.
+    name: isnan
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    return-type: boolean
+    comment: Returns true if n is infinite.
+    name: isinf
+    must-use: true
+  - parameters:
+    - name: n
+      type: number
+      comment: A number.
+    return-type: boolean
+    comment: Returns true if n is finite.
+    name: isfinite
+    must-use: true
+- name: os
+  comment: Operating system facilities library.
+  functions:
+  - return-type: number
+    comment: Returns a high-precision timestamp in seconds for measuring durations.
+      Has a resolution of 0.0001s (222 ticks per server frame, 3 ticks per script
+      time slice). 6-11x slower to look up than ll.GetTime.
+    name: clock
+    must-use: true
+  - parameters:
+    - name: formatString
+      type: string?
+      comment: Format string for the date representation.
+      default-value: '"%c"'
+    - name: t
+      type: number?
+      comment: Timestamp to format; defaults to the current time.
+      default-value: os.time()
+    return-type: string
+    comment: Returns a table or string representation of the time based on the provided
+      format.
+    name: date
+    overloads:
+    - parameters:
+      - name: formatString
+        type: '"*t" | "!*t"'
+        comment: Optional format string for the date representation.
+      - name: t
+        type: number?
+        comment: Timestamp to format; defaults to the current time.
+        default-value: os.time()
+      return-type: DateTypeResult
+    must-use: true
+  - parameters:
+    - name: a
+      type: number
+      comment: First timestamp value.
+    - name: b
+      type: number
+      comment: Second timestamp value.
+    return-type: number
+    comment: Returns the difference in seconds between two timestamps. Same as a -
+      b.
+    name: difftime
+    deprecated:
+      reason: Same as a - b
+      selene-replace:
+      - '%1 - %2'
+    must-use: true
+  - parameters:
+    - name: time
+      type: DateTypeArg
+      comment: Optional table with date/time fields; returns the corresponding Unix
+        timestamp.
+      optional: true
+    return-type: number?
+    comment: Returns the current Unix timestamp or the timestamp of the given date.
+    name: time
+    overloads:
+    - return-type: number
+    must-use: true
+- name: quaternion
+  comment: Quaternion manipulation library.
+  callable:
+    parameters:
+    - name: x
+      type: number
+      comment: X component of the quaternion.
+    - name: y
+      type: number
+      comment: Y component of the quaternion.
+    - name: z
+      type: number
+      comment: Z component of the quaternion.
+    - name: s
+      type: number
+      comment: S component of the quaternion.
+    return-type: quaternion
+    comment: Creates a new quaternion with the given component values. Alias of quaternion.create.
+    name: quaternion
+    must-use: true
+  constants:
+  - name: identity
+    type: quaternion
+    value: quaternion(0, 0, 0, 1)
+    comment: Identity quaternion constant.
+  functions:
+  - parameters:
+    - name: x
+      type: number
+      comment: X component of the quaternion.
+    - name: y
+      type: number
+      comment: Y component of the quaternion.
+    - name: z
+      type: number
+      comment: Z component of the quaternion.
+    - name: s
+      type: number
+      comment: S component of the quaternion.
+    return-type: quaternion
+    comment: Creates a new quaternion with the given component values.
+    name: create
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: quaternion
+    comment: Computes the normalized version (unit quaternion) of the quaternion.
+    name: normalize
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: number
+    comment: Computes the magnitude of the quaternion.
+    name: magnitude
+    must-use: true
+  - parameters:
+    - name: a
+      type: quaternion
+      comment: Left input quaternion.
+    - name: b
+      type: quaternion
+      comment: Right input quaternion.
+    return-type: number
+    comment: Computes the dot product of two quaternions.
+    name: dot
+    must-use: true
+  - parameters:
+    - name: a
+      type: quaternion
+      comment: Start quaternion.
+    - name: b
+      type: quaternion
+      comment: End quaternion.
+    - name: t
+      type: number
+      comment: Interpolation factor.
+    return-type: quaternion
+    comment: Spherical linear interpolation from a to b using factor t.
+    name: slerp
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: quaternion
+    comment: Computes the conjugate of the quaternion.
+    name: conjugate
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: vector
+    comment: Computes the forward vector from the quaternion.
+    name: tofwd
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: vector
+    comment: Computes the left vector from the quaternion.
+    name: toleft
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: vector
+    comment: Computes the up vector from the quaternion.
+    name: toup
+    must-use: true
+- name: string
+  comment: String manipulation library.
+  functions:
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    - name: j
+      type: number?
+      comment: Ending index.
+      default-value: i
+    return-type: '...number'
+    comment: Returns the numeric code of every byte in the input string within the
+      given range.
+    name: byte
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: '...'
+      type: '...number'
+      comment: Byte values to convert to string.
+      optional: false
+    return-type: string
+    comment: Returns a string containing characters for the given byte values.
+    name: char
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: pattern
+      type: string
+      comment: Pattern to search for.
+    - name: init
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    - name: plain
+      type: boolean?
+      comment: Perform raw search.
+      default-value: false
+    return-type: (number?, number?, ...string)
+    comment: Finds the first instance of the pattern in the string.
+    name: find
+    must-use: true
+    typechecker:
+      builtin: true
+      magic: true
+  - parameters:
+    - name: formatstring
+      type: string
+      comment: Format string.
+    - name: '...'
+      type: '...any'
+      comment: Values to format.
+      optional: false
+    return-type: string
+    comment: Formats input values into a string using printf-style format specifiers.
+    name: format
+    must-use: true
+    typechecker:
+      builtin: true
+      magic: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: pattern
+      type: string
+      comment: Pattern to search for.
+    return-type: () -> ...string
+    comment: Returns an iterator function for pattern matches
+    name: gmatch
+    must-use: true
+    typechecker:
+      builtin: true
+      magic: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: pattern
+      type: string
+      comment: Pattern to replace.
+    - name: repl
+      type: 'string | { [string]: string } | (...string) -> string'
+      comment: Replacement string, function, or table.
+    - name: maxn
+      type: number?
+      comment: Maximum replacements.
+      default-value: nil
+    return-type: (string, number)
+    comment: Performs pattern-based substitution in a string.
+    name: gsub
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    return-type: number
+    comment: 'Returns the number of bytes in the string. Identical to #s'
+    name: len
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    return-type: string
+    comment: Returns a lowercase version of the input string. Only works with ASCII.
+      Use ll.ToLower for strings that may contain Unicode.
+    name: lower
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: pattern
+      type: string
+      comment: Pattern to match.
+    - name: init
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    return-type: '...string'
+    comment: Finds and returns matches for a pattern in the input string.
+    name: match
+    must-use: true
+    typechecker:
+      builtin: true
+      magic: true
+  - parameters:
+    - name: fmt
+      type: string
+      comment: Pack format string.
+    - name: '...'
+      type: '...any'
+      comment: Values to encode.
+    return-type: string
+    comment: Packs values into a binary string.
+    name: pack
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: fmt
+      type: string
+      comment: Pack format string.
+    return-type: number
+    comment: Returns the size of a packed string for the given format.
+    name: packsize
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: n
+      type: number
+      comment: Number of times to repeat the string.
+    return-type: string
+    comment: Returns the input string repeated a given number of times.
+    name: rep
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    return-type: string
+    comment: Returns the input string with bytes in reverse order.
+    name: reverse
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: separator
+      type: string?
+      comment: Separator to split on.
+      default-value: '","'
+    return-type: '{string}'
+    comment: Splits a string by separator. Returns a list of substrings.
+    name: split
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: i
+      type: number
+      comment: Starting index.
+    - name: j
+      type: number?
+      comment: Ending index.
+      default-value: '#s'
+    return-type: string
+    comment: Returns a substring from the given range.
+    name: sub
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: fmt
+      type: string
+      comment: Pack format string.
+    - name: s
+      type: string
+      comment: Encoded string.
+    - name: init
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    return-type: '...any'
+    comment: Decodes a binary string using a pack format.
+    name: unpack
+    must-use: true
+    typechecker:
+      builtin: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    return-type: string
+    comment: Returns an uppercase version of the input string. Only works with ASCII.
+      Use ll.ToUpper for strings that may contain Unicode.
+    name: upper
+    must-use: true
+    typechecker:
+      builtin: true
+- name: table
+  comment: Table manipulation library. Tables are collections of key-value pairs.
+  functions:
+  - parameters:
+    - name: a
+      type: '{string | number}'
+      comment: Array of strings.
+    - name: sep
+      type: string?
+      comment: Separator string.
+      default-value: '""'
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    - name: j
+      type: number?
+      comment: Ending index.
+      default-value: '#a'
+    return-type: string
+    comment: Joins an array of strings into one string, with an optional separator.
+    name: concat
+    must-use: true
+  - type-parameters:
+    - K
+    - V
+    - R
+    parameters:
+    - name: t
+      type: '{[K]: V}'
+      comment: Table to iterate over.
+    - name: f
+      type: '(key: K, value: V) -> R?'
+      comment: Function applied to each key-value pair.
+      optional: false
+    return-type: R?
+    comment: Iterates over all key-value pairs in the table (deprecated).
+    name: foreach
+    deprecated:
+      reason: Use a for loop instead
+  - type-parameters:
+    - V
+    - R
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to iterate over.
+    - name: f
+      type: '(index: number, value: V) -> R?'
+      comment: Function applied to each index-value pair.
+    return-type: R?
+    comment: Iterates over all index-value pairs in the array (deprecated).
+    name: foreachi
+    deprecated:
+      reason: Use a for loop instead
+  - parameters:
+    - name: a
+      type: '{any}'
+      comment: Array to check.
+    return-type: number
+    comment: 'Returns the length of an array (deprecated; use # instead).'
+    name: getn
+    deprecated:
+      use: '#'
+      selene-replace:
+      - '#%1'
+    must-use: true
+  - parameters:
+    - name: t
+      type: '{any}'
+      comment: Table to check.
+    return-type: number
+    comment: Returns the highest numeric key in the table.
+    name: maxn
+    must-use: true
+  - type-parameters:
+    - V
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to insert into.
+      observes: write
+    - name: i
+      type: number
+      comment: 'Index to insert at (default: at the end).'
+      optional: true
+    - name: v
+      type: V
+      comment: Value to insert.
+    comment: Inserts an element at the specified index, or at the end of the array.
+    name: insert
+    overloads:
+    - type-parameters:
+      - V
+      parameters:
+      - name: a
+        type: '{V}'
+        comment: Array to insert into.
+        observes: write
+      - name: value
+        type: V
+        comment: Value to insert.
+      comment: Inserts an element at the end of a list
+  - type-parameters:
+    - V
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to be appended to.
+      observes: write
+    - name: '...'
+      type: '...V'
+      comment: Values to append.
+    comment: Appends one or more an elements to end of the array.
+    name: append
+  - type-parameters:
+    - V
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to be appended to.
+      observes: write
+    - name: b
+      type: '{V}'
+      comment: Array to append.
+    return-type: '{V}'
+    comment: 'Appends all elements from one array to the end of another. Shorthand
+      for table.move(b, 1, #b, #a+1, a)'
+    name: extend
+  - type-parameters:
+    - V
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to remove from.
+      observes: write
+    - name: i
+      type: number?
+      comment: Index to remove.
+      default-value: '#a'
+    return-type: V?
+    comment: Removes and returns the element at the specified index from the array,
+      or from the end of the array.
+    name: remove
+  - type-parameters:
+    - V
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to be sorted.
+      observes: write
+    - name: f
+      type: '((a: V, b: V) -> boolean)?'
+      comment: Comparison function.
+      default-value: nil
+    comment: Sorts an array in place.
+    name: sort
+  - type-parameters:
+    - V
+    parameters:
+    - name: '...'
+      type: '...V'
+      comment: Array elements.
+    return-type: '{ n: number, [number]: V }'
+    comment: Packs multiple arguments into a new array with length field n.
+    name: pack
+    must-use: true
+    typechecker:
+      magic: true
+  - type-parameters:
+    - V
+    parameters:
+    - name: a
+      type: '{V}'
+      comment: Array to unpack.
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    - name: j
+      type: number?
+      comment: Ending index.
+      default-value: '#a'
+    return-type: '...V'
+    comment: Unpacks array elements into multiple return values.
+    name: unpack
+    must-use: true
+  - type-parameters:
+    - V
+    parameters:
+    - name: src
+      type: '{V}'
+      comment: Source array.
+    - name: i
+      type: number
+      comment: Starting index.
+    - name: j
+      type: number
+      comment: Ending index.
+    - name: d
+      type: number
+      comment: Destination index.
+    - name: dest
+      type: '{V}?'
+      comment: Destination array.
+      observes: write
+      default-value: src
+    return-type: '{V}'
+    comment: Inserts elements [i..j] from src array into dest array at [d].
+    name: move
+  - type-parameters:
+    - V
+    parameters:
+    - name: n
+      type: number
+      comment: Number of elements to allocate.
+    - name: v
+      type: V?
+      comment: Value to prefill elements with.
+      default-value: nil
+    return-type: '{V}'
+    comment: Creates a new table with pre-allocated array capacity, optionally filled.
+    name: create
+    must-use: true
+  - type-parameters:
+    - V
+    parameters:
+    - name: t
+      type: '{V}'
+      comment: Table to search in.
+    - name: v
+      type: V
+      comment: Value to search for.
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    return-type: number?
+    comment: Finds the first occurrence of a value in the array and returns its index.
+    name: find
+    must-use: true
+  - parameters:
+    - name: t
+      type: '{}'
+      comment: Table to clear.
+      observes: write
+    comment: Clears all elements from a table while keeping its capacity.
+    name: clear
+  - type-parameters:
+    - V
+    parameters:
+    - name: t
+      type: '{V}'
+      comment: Table to shrink.
+    - name: shrink_sparse
+      type: boolean?
+      comment: Allow moving sparse array elements to hash table storage.
+      default-value: false
+    return-type: '{V}'
+    comment: Reduces the memory usage of the table to the minimum necessary.
+    name: shrink
+  - type-parameters:
+    - table
+    parameters:
+    - name: t
+      type: table
+      comment: Table to freeze.
+      selene-type: table
+    return-type: table
+    comment: Freezes a table, making it read-only.
+    name: freeze
+    typechecker:
+      magic: true
+  - parameters:
+    - name: t
+      type: '{}'
+      comment: Table to check.
+    return-type: boolean
+    comment: Returns true if a table is frozen.
+    name: isfrozen
+    must-use: true
+  - type-parameters:
+    - table
+    parameters:
+    - name: t
+      type: table
+      comment: Table to clone.
+      selene-type: table
+    return-type: table
+    comment: Creates a shallow copy of the table.
+    name: clone
+    must-use: true
+    typechecker:
+      magic: true
+- name: utf8
+  comment: UTF-8 support library.
+  constants:
+  - name: charpattern
+    type: string
+    value: '"[\x00-\x7F\xC2-\xF4][\x80-\xBF]*"'
+    comment: Pattern that matches exactly one UTF-8 byte sequence
+  functions:
+  - parameters:
+    - name: '...'
+      type: '...number'
+      comment: Unicode codepoints.
+      optional: false
+    return-type: string
+    comment: Creates a string from Unicode codepoints.
+    name: char
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    return-type: ((string, number) -> (number, number), string, number)
+    comment: Returns an iterator that produces the byte offset and Unicode codepoint
+      for each character in the string.
+    name: codes
+    must-use: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    - name: j
+      type: number?
+      comment: Ending index.
+      default-value: i
+    return-type: '...number'
+    comment: Returns the Unicode codepoints in the specified range of the string.
+    name: codepoint
+    must-use: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 1
+    - name: j
+      type: number?
+      comment: Ending index.
+      default-value: '#s'
+    return-type: (number?, number?)
+    comment: Returns the number of Unicode codepoints in the specified range of the
+      string, or nil and error index.
+    name: len
+    must-use: true
+  - parameters:
+    - name: s
+      type: string
+      comment: Input string.
+    - name: n
+      type: number
+      comment: Character position.
+    - name: i
+      type: number?
+      comment: Starting index.
+      default-value: 'if n >= 0 then 1 else #s + 1'
+    return-type: number?
+    comment: Returns the byte offset of the nth Unicode codepoint in the string.
+    name: offset
+    must-use: true
+- name: uuid
+  comment: UUID library.
+  callable:
+    parameters:
+    - name: value
+      type: string? | buffer | uuid
+    return-type: uuid
+    comment: Creates a new uuid from a string, buffer, or existing uuid. Throws an
+      error if the string is not a valid UUID, or the buffer is shorter than 16 bytes.
+      Alias of uuid.create.
+    name: uuid
+    must-use: true
+  functions:
+  - parameters:
+    - name: value
+      type: string? | buffer | uuid
+    return-type: uuid
+    comment: Creates a new uuid from a string, buffer, or existing uuid. Throws an
+      error if the string is not a valid UUID, or the buffer is shorter than 16 bytes.
+    name: create
+    must-use: true
+- name: vector
+  comment: Vector manipuluation library.
+  callable:
+    parameters:
+    - name: x
+      type: number
+      comment: X component of the vector.
+    - name: y
+      type: number
+      comment: Y component of the vector.
+    - name: z
+      type: number?
+      comment: Z component of the vector.
+      default-value: 0
+    return-type: vector
+    comment: Creates a new vector with the given component values. Alias of vector.create.
+    name: vector
+    must-use: true
+  constants:
+  - name: zero
+    type: vector
+    value: vector(0, 0, 0)
+    comment: Constant vector with all components set to 0.
+  - name: one
+    type: vector
+    value: vector(1, 1, 1)
+    comment: Constant vector with all components set to 1.
+  functions:
+  - parameters:
+    - name: x
+      type: number
+      comment: X component of the vector.
+    - name: y
+      type: number
+      comment: Y component of the vector.
+    - name: z
+      type: number?
+      comment: Z component of the vector.
+      default-value: 0
+    return-type: vector
+    comment: Creates a new vector with the given component values.
+    name: create
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    return-type: number
+    comment: Computes the magnitude of the vector.
+    name: magnitude
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    return-type: vector
+    comment: Computes the normalized version (unit vector) of the vector.
+    name: normalize
+    must-use: true
+  - parameters:
+    - name: a
+      type: vector
+      comment: Left input vector.
+    - name: b
+      type: vector
+      comment: Right input vector.
+    return-type: vector
+    comment: Computes the cross product of two vectors.
+    name: cross
+    must-use: true
+  - parameters:
+    - name: a
+      type: vector
+      comment: Left input vector.
+    - name: b
+      type: vector
+      comment: Right input vector.
+    return-type: number
+    comment: Computes the dot product of two vectors.
+    name: dot
+    must-use: true
+  - parameters:
+    - name: a
+      type: vector
+      comment: Left input vector.
+    - name: b
+      type: vector
+      comment: Right input vector.
+    - name: axis
+      type: vector?
+      comment: Axis to determine the sign of the angle.
+      default-value: nil
+    return-type: number
+    comment: Computes the angle between two vectors in radians. The axis, if specified,
+      is used to determine the sign of the angle.
+    name: angle
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    return-type: vector
+    comment: Applies math.floor to each component of the vector.
+    name: floor
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    return-type: vector
+    comment: Applies math.ceil to each component of the vector.
+    name: ceil
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    return-type: vector
+    comment: Applies math.abs to each component of the vector.
+    name: abs
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    return-type: vector
+    comment: Applies math.sign to each component of the vector.
+    name: sign
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector to be clamped.
+    - name: min
+      type: vector
+      comment: Minimum vector value.
+    - name: max
+      type: vector
+      comment: Maximum vector value.
+    return-type: vector
+    comment: Clamps each component of the vector between min and max values.
+    name: clamp
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    - name: '...'
+      type: '...vector'
+      comment: Vectors to find the maximum from.
+    return-type: vector
+    comment: Applies math.max to each component of the vectors.
+    name: max
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Input vector.
+    - name: '...'
+      type: '...vector'
+      comment: Vectors to find the minimum from.
+    return-type: vector
+    comment: Applies math.min to each component of the vectors.
+    name: min
+    must-use: true
+  - parameters:
+    - name: a
+      type: vector
+      comment: Start vector.
+    - name: b
+      type: vector
+      comment: End vector.
+    - name: t
+      type: number
+      comment: Interpolation factor.
+    return-type: vector
+    comment: Linearly interpolates between a and b using factor t.
+    name: lerp
+    must-use: true
+- name: ll
+  comment: Library for functions shared between LSL and SLua.
+  functions:
+  - parameters:
+    - name: val
+      type: number
+      comment: Any integer value.
+    return-type: number
+    comment: Returns an integer representing the absolute (positive) value of val.
+    name: Abs
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.abs
+      selene-replace:
+      - math.abs(%...)
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: A floating-point value falling in the range [-1.0, 1.0].
+    return-type: number
+    comment: Returns a float representing the arc-cosine of val in radians.
+    name: Acos
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.acos
+      selene-replace:
+      - math.acos(%...)
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to add to the ban list.
+    - name: hours
+      type: number
+      comment: Duration, in hours, to ban the avatar for (0 for indefinite).
+    comment: Adds the avatar to the parcel ban list for the specified number of hours.
+      A value of 0 hours adds the avatar indefinitely. Banned users teleporting to
+      the parcel are redirected to a neighboring parcel; the minimum accepted duration
+      is 0.01 hours (approximately 36 seconds).
+    name: AddToLandBanList
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to add to the pass list.
+    - name: hours
+      type: number
+      comment: Duration, in hours, to allow the avatar for (range [0.0, 144.0], 0
+        for indefinite).
+    comment: Adds the avatar to the land pass list for the specified number of hours
+      (or indefinitely if hours is 0).
+    name: AddToLandPassList
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the damage event to modify.
+    - name: new_damage
+      type: number
+      comment: New damage value to be applied or distributed after on_damage processing.
+    comment: Modifies the amount of damage applied by the current on_damage event
+      after it completes processing, specified by the damage event index number.
+    name: AdjustDamage
+    deprecated:
+      use: adjustDamage
+  - parameters:
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Adjusts the volume of the currently playing attached sound (has no effect
+      on sounds started with llTriggerSound).
+    name: AdjustSoundVolume
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the avatar in the same region to query.
+    return-type: boolean
+    comment: Returns TRUE if the specified agent is in the experience and the experience
+      can run in the current region/location; returns FALSE otherwise.
+    name: AgentInExperience
+    must-use: true
+  - parameters:
+    - name: add
+      type: boolean | number
+      comment: Boolean. If TRUE, allows anyone to drop inventory items into the prim
+        (even without modify rights). If FALSE, restricts inventory dropping to those
+        with modify permissions.
+    comment: If add is TRUE, allows users without object modify permissions to drop
+      inventory items into the prim. If FALSE, restricts inventory dropping to users
+      with modify permissions.
+    name: AllowInventoryDrop
+  - parameters:
+    - name: a
+      type: quaternion
+      comment: Starting rotation.
+    - name: b
+      type: quaternion
+      comment: Ending rotation.
+    return-type: number
+    comment: Returns a float representing the angle in radians between rotations a
+      and b.
+    name: AngleBetween
+    must-use: true
+  - parameters:
+    - name: momentum
+      type: vector
+      comment: Linear impulse vector to apply.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, momentum is treated as a local directional vector;
+        if FALSE, it is treated as a global region vector.
+    comment: Applies a linear impulse (momentum) to a physical object. If local is
+      TRUE, the impulse is applied in local coordinates; otherwise, it is applied
+      in global region coordinates.
+    name: ApplyImpulse
+  - parameters:
+    - name: force
+      type: vector
+      comment: Rotational impulse vector to apply.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, the force is treated as a local directional vector;
+        if FALSE, it is treated as a global region vector.
+    comment: Applies a rotational impulse (force) to a physical object. If local is
+      TRUE, the rotational impulse is applied in local coordinates; otherwise, it
+      is applied in global region coordinates.
+    name: ApplyRotationalImpulse
+  - parameters:
+    - name: val
+      type: number
+      comment: A floating-point value falling in the range [-1.0, 1.0].
+    return-type: number
+    comment: Returns a float representing the arc-sine of val in radians.
+    name: Asin
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.asin
+      selene-replace:
+      - math.asin(%...)
+    must-use: true
+  - parameters:
+    - name: y
+      type: number
+      comment: A floating-point value representing the y coordinate.
+    - name: x
+      type: number
+      comment: A floating-point value representing the x coordinate.
+    return-type: number
+    comment: Returns a float representing the arctangent2 of y and x.
+    name: Atan2
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.atan2
+      selene-replace:
+      - math.atan2(%...)
+    must-use: true
+  - parameters:
+    - name: attach_point
+      type: number
+      comment: ATTACH_* constant or integer value representing the target attachment
+        point.
+    comment: Attaches the object to the avatar who has granted the PERMISSION_ATTACH
+      permission. Takes the object into the user's inventory and attaches it at attach_point.
+    name: AttachToAvatar
+  - parameters:
+    - name: attach_point
+      type: number
+      comment: ATTACH_* constant or integer value representing the target attachment
+        point.
+    comment: Attaches the object temporarily to an avatar who has granted the PERMISSION_ATTACH
+      permission. No permanent inventory is created, and the object disappears on
+      detach or disconnect. Can be used on non-owners (changing ownership to the wearer).
+    name: AttachToAvatarTemp
+  - parameters:
+    - name: link
+      type: number
+      comment: Index of the prim in the linkset (1 for root, >1 for children), or
+        a LINK_* flag.
+    return-type: uuid
+    comment: Returns the UUID of the avatar seated on the specified link's sit target,
+      or NULL_KEY if no avatar is sitting there.
+    name: AvatarOnLinkSitTarget
+    must-use: true
+  - return-type: uuid
+    comment: Returns the UUID of the avatar seated on the prim's sit target (defined
+      via llSitTarget), or NULL_KEY if no avatar is sitting there or the prim lacks
+      a sit target.
+    name: AvatarOnSitTarget
+    must-use: true
+  - parameters:
+    - name: fwd
+      type: vector
+      comment: Forward/back directional vector of the rotation.
+    - name: left
+      type: vector
+      comment: Left/right directional vector of the rotation.
+    - name: up
+      type: vector
+      comment: Up/down directional vector of the rotation.
+    return-type: quaternion
+    comment: Returns the rotation defined by the coordinate axes fwd, left, and up.
+    name: Axes2Rot
+    must-use: true
+  - parameters:
+    - name: axis
+      type: vector
+      comment: Axis vector around which the rotation is generated.
+    - name: angle
+      type: number
+      comment: Angle of rotation, expressed in radians.
+    return-type: quaternion
+    comment: Returns the rotation representing a generated angle (in radians) about
+      the specified axis.
+    name: AxisAngle2Rot
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: Base64-encoded string to decode.
+    return-type: number
+    comment: Returns an integer representing the Base64-decoded big-endian value of
+      str. Returns zero if str is longer than 8 characters; the return value is unpredictable
+      if str contains fewer than 6 characters.
+    name: Base64ToInteger
+    deprecated:
+      reason: Use 'llbase64.decode' and 'string.unpack' or 'buffer.readi32' instead.
+      selene-replace:
+      - string.unpack(">i", llbase64.decode(s))
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: Base64-encoded string to decode.
+    return-type: string
+    comment: Decodes the Base64-encoded string str into a conventional string, interpreting
+      the bytes as a UTF-8 character sequence. Unprintable characters are converted
+      to question marks.
+    name: Base64ToString
+    deprecated:
+      use: llbase64.decode
+      selene-replace:
+      - llbase64.decode(%1)
+    must-use: true
+  - comment: Delinks all prims in the linkset. Requires the PERMISSION_CHANGE_LINKS
+      runtime permission, which must be requested and granted by the owner.
+    name: BreakAllLinks
+  - parameters:
+    - name: link
+      type: number
+      comment: 'The link number (0: unlinked, 1: root prim, >1: child prims and seated
+        avatars) to delink.'
+    comment: Delinks the prim specified by the link number link. Requires the PERMISSION_CHANGE_LINKS
+      runtime permission.
+    name: BreakLink
+  - parameters:
+    - name: src
+      type: string
+      comment: String of comma-separated values to parse.
+    return-type: '{string}'
+    comment: Parses the comma-separated string src and returns it as a list.
+    name: CSV2List
+    must-use: true
+  - parameters:
+    - name: start
+      type: vector
+      comment: Starting location vector of the ray.
+    - name: end
+      type: vector
+      comment: Ending location vector of the ray.
+    - name: options
+      type: list
+      comment: A list of option flags and their parameters to configure the raycast.
+    return-type: '{any}'
+    comment: Casts a ray into the physics world from start to end and reports collision
+      data for intersections with objects based on options. Returns a list of strided
+      values [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, ..., status_code].
+      A negative status_code indicates an error; otherwise, it represents the number
+      of hits.
+    name: CastRay
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to round.
+    return-type: number
+    comment: Returns the smallest integer value greater than or equal to val (rounded
+      toward positive infinity).
+    name: Ceil
+    deprecated:
+      reason: Fastcall.
+      use: math.ceil
+      selene-replace:
+      - math.ceil(%...)
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Unicode value to convert into a character string.
+    return-type: string
+    comment: Constructs and returns a single-character string representing the supplied
+      Unicode value val.
+    name: Char
+    must-use: true
+  - comment: Resets all camera parameters to default values and turns off scripted
+      camera control. Requires the PERMISSION_CONTROL_CAMERA runtime permission (automatically
+      granted for attached or sat-on objects).
+    name: ClearCameraParams
+  - parameters:
+    - name: agentid
+      type: uuid
+    - name: experienceid
+      type: uuid
+    name: ClearExperience
+    deprecated: true
+  - parameters:
+    - name: agentid
+      type: uuid
+    name: ClearExperiencePermissions
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: 'The link number (0: unlinked, 1: root prim, >1: child prims) or a
+        LINK_* flag representing the target prim.'
+    - name: face
+      type: number
+      comment: Face number to clear.
+    return-type: number
+    comment: Deletes the media and clears all parameters from the given face on the
+      linked prim. Returns an integer STATUS_* flag detailing the success or failure
+      of the operation.
+    name: ClearLinkMedia
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number (side) to clear.
+    return-type: number
+    comment: Deletes the media and clears all parameters from the specified face.
+      Returns an integer STATUS_* flag detailing the success or failure of the operation.
+    name: ClearPrimMedia
+  - parameters:
+    - name: channel
+      type: uuid
+      comment: XML-RPC channel ID to close.
+    comment: Deprecated. Closes the specified XML-RPC channel.
+    name: CloseRemoteDataChannel
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: number
+    comment: Returns a float representing the cloud density at the prim's position
+      offset by the vector offset.
+    name: Cloud
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Specific object name or avatar legacy name to filter for.
+    - name: id
+      type: uuid
+      comment: Group, avatar, or object UUID to filter by.
+    - name: accept
+      type: boolean | number
+      comment: Boolean. If TRUE, only collisions matching the name and id filters
+        are processed; if FALSE, matching collisions are excluded.
+    comment: Sets the collision filter, either exclusively or inclusively. If accept
+      is TRUE, only collisions matching name and id are processed; if FALSE, matches
+      are excluded. Pass an empty string or NULL_KEY to name or id to skip filtering
+      on that parameter.
+    name: CollisionFilter
+  - parameters:
+    - name: impact_sound
+      type: string | uuid
+      comment: UUID of a sound, the name of a sound in the prim's inventory, or an
+        empty string to suppress sounds.
+    - name: impact_volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Suppresses default collision sounds and replaces default impact sounds
+      with impact_sound at the volume level specified by impact_volume. Supply an
+      empty string to only suppress collision sounds.
+    name: CollisionSound
+  - parameters:
+    - name: impact_sprite
+      type: string | uuid
+      comment: UUID of a texture, the name of a texture in the prim's inventory, or
+        an empty string to suppress sprites.
+    comment: Suppresses default collision sprites and replaces them with impact_sprite
+      (which must be in the prim's inventory). Supply an empty string to only suppress
+      collision sprites.
+    name: CollisionSprite
+    deprecated: true
+  - parameters:
+    - name: message
+      type: string
+      comment: Message string to be hashed.
+    - name: algorithm
+      type: string
+      comment: Cryptographic digest algorithm to use (e.g., md5, sha1, sha224, sha256,
+        sha384, or sha512).
+    return-type: string
+    comment: Returns a hex-encoded hash digest string of message using the specified
+      cryptographic algorithm.
+    name: ComputeHash
+    must-use: true
+  - parameters:
+    - name: theta
+      type: number
+      comment: Angle expressed in radians.
+    return-type: number
+    comment: Returns a float representing the cosine of theta.
+    name: Cos
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.cos
+      selene-replace:
+      - math.cos(%...)
+    must-use: true
+  - parameters:
+    - name: options
+      type: list
+      comment: A list of key-value pairs specifying the character's configuration
+        options.
+    comment: Converts the linkset containing the script into a pathfinding character
+      entity (required to use pathfinding functions) using the specified options.
+    name: CreateCharacter
+  - parameters:
+    - name: k
+      type: string
+      comment: Unique key name for the key-value pair.
+    - name: v
+      type: string
+      comment: Value for the key-value pair (maximum 2047 characters, or 4095 characters
+        if using Mono).
+    return-type: uuid
+    comment: Starts an asynchronous transaction to create a key-value pair (k and
+      v) associated with the script's experience. Returns a key query handle for the
+      dataserver event. Fails with XP_ERROR_STORAGE_EXCEPTION if the key already exists.
+    name: CreateKeyValue
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target prim/object in the same region.
+    - name: parent
+      type: boolean | number
+      comment: Boolean. If TRUE, the script's object becomes the root prim; if FALSE,
+        target becomes the root.
+    comment: Attempts to link the object containing the script with target. Requires
+      the PERMISSION_CHANGE_LINKS runtime permission.
+    name: CreateLink
+  - parameters:
+    - name: target
+      type: uuid
+      comment: Key of the target avatar or task to receive damage.
+    - name: damage
+      type: number
+      comment: Amount of damage to inflict (can exceed 100, unlike collision-based
+        damage).
+    - name: damage_type
+      type: number
+      comment: Type of damage to deliver to the target (can correspond to a DAMAGE_TYPE_*
+        constant).
+    comment: Generates a damage event delivering the specified amount of damage and
+      damage_type to the targeted avatar or task in the same region.
+    name: Damage
+  - return-type: uuid
+    comment: Starts an asynchronous transaction to request the used and total data
+      storage allocated for the experience. Returns a key query handle for the dataserver
+      event.
+    name: DataSizeKeyValue
+  - comment: Converts the linkset back to a standard physical object, removing all
+      pathfinding properties.
+    name: DeleteCharacter
+  - parameters:
+    - name: k
+      type: string
+      comment: Key of the key-value pair to delete.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to delete the key-value pair associated
+      with key k in the experience. Returns a key query handle for the dataserver
+      event.
+    name: DeleteKeyValue
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source list to copy and modify.
+    - name: start
+      type: number
+      comment: Starting index of the slice to remove (inclusive).
+    - name: end
+      type: number
+      comment: Ending index of the slice to remove (inclusive).
+    return-type: '{T}'
+    comment: Returns a copy of the list src with the slice from start to end (inclusive)
+      removed. Negative indices count backward from the end of the list. If start
+      is greater than end, the deletion excludes the specified range.
+    name: DeleteSubList
+    deprecated:
+      reason: Unnecessary table copying.
+      use: table.remove
+      selene-replace:
+      - table.remove(%1, %2)
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to modify.
+    - name: start
+      type: number
+      comment: Starting index of the substring to remove (inclusive).
+    - name: end
+      type: number
+      comment: Ending index of the substring to remove (inclusive).
+    return-type: string
+    comment: Returns a copy of the string src with the characters from start to end
+      (inclusive) removed. Negative indices count backward from the end of the string.
+      If start is greater than end, the deletion excludes the specified range.
+    name: DeleteSubString
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the object in the region to derez.
+    - name: flag
+      type: number
+      comment: Derez behavior flags matching DEREZ_* constants.
+    return-type: boolean
+    comment: Derezzes (deletes or returns) a targeted object in the region previously
+      rezzed by a script in this linkset, returning TRUE on success or FALSE on failure.
+    name: DerezObject
+  - comment: Detaches the object containing the script from the avatar. Requires the
+      PERMISSION_ATTACH runtime permission (automatically granted to attached objects).
+      Note that the detached object is completely removed from the region and not
+      dropped on the ground.
+    name: DetachFromAvatar
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: '{any}'
+    comment: Returns a list containing pending damage information for the event specified
+      by number, including the current damage, the damage type, and the original damage
+      delivered.
+    name: DetectedDamage
+    deprecated:
+      use: getDamage
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns a vector representing the grab offset of the user touching the
+      object. Only works in touch events and returns <0.0, 0.0, 0.0> if number is
+      not a valid index.
+    name: DetectedGrab
+    deprecated:
+      use: getGrab
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: boolean
+    comment: Returns TRUE if the detected object or avatar specified by number has
+      the same active group as the prim containing the script. Returns FALSE if the
+      group is not active or if they are not in the group.
+    name: DetectedGroup
+    deprecated:
+      use: getGroup
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: uuid
+    comment: Returns the key (UUID) of the detected object or avatar specified by
+      number, or NULL_KEY if number is not a valid index.
+    name: DetectedKey
+    deprecated:
+      use: getKey
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: Returns the link number (integer) of the triggered event (touches and
+      collisions only) specified by number. Returns 0 for non-linked objects, 1 for
+      the root prim, and 2+ for child prims. Returns 0 if not supported by the event.
+    name: DetectedLinkNumber
+    deprecated:
+      use: getLinkNumber
+    must-use: true
+  - parameters:
+    - name: item
+      type: number
+      comment: Index of the detection information.
+    return-type: string
+    comment: Returns a string representing the name of the detected object or avatar
+      specified by item. Returns an empty string if item is not a valid index.
+    name: DetectedName
+    deprecated:
+      use: getName
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: uuid
+    comment: Returns the key (UUID) of the owner of the detected object specified
+      by number. Returns an invalid key if number is not a valid index.
+    name: DetectedOwner
+    deprecated:
+      use: getOwner
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the vector position (in region coordinates) of the detected object
+      or avatar specified by number, or <0.0, 0.0, 0.0> if number is not a valid index.
+    name: DetectedPos
+    deprecated:
+      use: getPos
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: uuid
+    comment: Returns the key (UUID) of the object or avatar that rezzed the detected
+      object specified by number.
+    name: DetectedRezzer
+    deprecated:
+      use: getRezzer
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: quaternion
+    comment: Returns the rotation of the detected object or avatar specified by number,
+      or <0.0, 0.0, 0.0, 1.0> if number is not a valid offset index.
+    name: DetectedRot
+    deprecated:
+      use: getRot
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the surface binormal vector (tangent to the surface, pointing
+      along the positive T (V) direction of tangent space) at the touched location
+      specified by index. Can be used with llDetectedTouchNormal to determine the
+      tangent space.
+    name: DetectedTouchBinormal
+    deprecated:
+      use: getTouchBinormal
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: Returns the integer index of the face clicked by the avatar in the touch
+      event specified by index.
+    name: DetectedTouchFace
+    deprecated:
+      use: getTouchFace
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the surface normal vector (perpendicular to the surface) at the
+      touched location specified by index. Can be used with llDetectedTouchBinormal
+      to determine the tangent space.
+    name: DetectedTouchNormal
+    deprecated:
+      use: getTouchNormal
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the vector position where the object was touched (specified by
+      index) in region coordinates, or in screen-space coordinates if the object is
+      attached as a HUD.
+    name: DetectedTouchPos
+    deprecated:
+      use: getTouchPos
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the surface coordinates (<s, t, 0.0>) where the prim was touched,
+      specified by index. X and Y contain the horizontal (s) and vertical (t) face
+      coordinates, typically in the interval [0.0, 1.0]. Returns TOUCH_INVALID_TEXCOORD
+      if coordinates cannot be determined.
+    name: DetectedTouchST
+    deprecated:
+      use: getTouchST
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the texture coordinates (<u, v, 0.0>) where the prim was touched,
+      specified by index. X and Y contain the horizontal (u) and vertical (v) texture
+      coordinates, typically in the interval [0.0, 1.0] (affected by repeats and rotation).
+      Returns TOUCH_INVALID_TEXCOORD if coordinates cannot be determined.
+    name: DetectedTouchUV
+    deprecated:
+      use: getTouchUV
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: Returns an integer bitfield representing the types (AGENT, ACTIVE, PASSIVE,
+      or SCRIPTED) of the detected object or avatar specified by number. Returns 0
+      if number is not a valid index.
+    name: DetectedType
+    deprecated:
+      use: getType
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: Returns the vector velocity of the detected object or avatar specified
+      by number, or <0.0, 0.0, 0.0> if number is not a valid offset index.
+    name: DetectedVel
+    deprecated:
+      use: getVel
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: message
+      type: string
+      comment: Text message to display in the dialog box.
+    - name: buttons
+      type: '{string}'
+      comment: A list of up to 12 strings representing button labels.
+    - name: channel
+      type: number
+      comment: Output chat channel (any integer value) where button clicks are chatted.
+    comment: Shows a dialog box on the screen of the avatar specified by avatar, displaying
+      message along with up to 12 choice buttons. Clicking a button chats its label
+      on channel.
+    name: Dialog
+  - comment: Deletes the entire object containing the script (the object does not
+      go to inventory). Use llBreakLink first to delete only a single prim.
+    name: Die
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list to convert.
+    - name: separator
+      type: string
+      comment: Separator string to place between list entries.
+    return-type: string
+    comment: Returns a string that is the list src converted to a single string, with
+      separator placed between each entry.
+    name: DumpList2String
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates.
+    - name: dir
+      type: vector
+      comment: Direction vector.
+    return-type: boolean
+    comment: Checks if the border reached along the vector dir from the vector pos
+      is the edge of the world (i.e., has no neighboring simulator). Returns TRUE
+      if it hits the edge of the world, or FALSE if there is a neighboring simulator.
+    name: EdgeOfWorld
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    comment: Ejects the specified avatar from land/parcels owned by the object's owner
+      (group or resident).
+    name: EjectFromLand
+  - parameters:
+    - name: address
+      type: string
+      comment: Destination email address.
+    - name: subject
+      type: string
+      comment: Subject of the email.
+    - name: message
+      type: string
+      comment: Message body of the email.
+    comment: Sends an email to address with subject and message.
+    name: Email
+  - parameters:
+    - name: url
+      type: string
+      comment: Unescaped URL string to escape.
+    return-type: string
+    comment: Returns a string representing the escaped/encoded version of url, replacing
+      spaces with '%20' and non-alphanumeric characters with their '%xx' hexadecimal
+      UTF-8 equivalent.
+    name: EscapeURL
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Vector of Euler angles to convert.
+    return-type: quaternion
+    comment: Returns the rotation representation of the Euler angles vector v.
+    name: Euler2Rot
+    must-use: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the group, avatar, or object to evade.
+    - name: options
+      type: list
+      comment: No options currently available (should be empty list).
+    comment: Directs a pathfinding character to evade target, attempting to hide from
+      its pursuer if a hiding spot is available (i.e., no line of sight from the character's
+      head to the pursuer's head, and no direct path on the navmesh).
+    name: Evade
+  - parameters:
+    - name: command
+      type: number
+      comment: Pathfinding command to execute.
+    - name: options
+      type: list
+      comment: A list of options for the command (e.g., jump height for CHARACTER_CMD_JUMP).
+    comment: Sends a command (specified by command) to the pathing system with options.
+      Currently only supports stopping pathfinding or making the character jump.
+    name: ExecCharacterCmd
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to convert.
+    return-type: number
+    comment: Returns a float representing the absolute (positive) value of val.
+    name: Fabs
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.abs
+      selene-replace:
+      - math.abs(%...)
+    must-use: true
+  - parameters:
+    - name: notecardname
+      type: string | uuid
+      comment: Name of the target notecard.
+    - name: pattern
+      type: string
+      comment: Regular expression pattern to search for.
+    - name: options
+      type: list
+      comment: A list of options to control the search (currently unused, should be
+        []).
+    return-type: uuid
+    comment: Searches the text of a cached notecard for lines containing the given
+      pattern and returns the number of matches found through a dataserver event.
+    name: FindNotecardTextCount
+    must-use: true
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of a notecard in the prim's inventory, or a UUID.
+    - name: pattern
+      type: string
+      comment: Regular expression pattern to search for.
+    - name: start
+      type: number
+      comment: Number of match results to skip before returning (0 to start at the
+        first match).
+    - name: count
+      type: number
+      comment: Maximum number of matches to return (if 0, returns the first 64 matches).
+    - name: options
+      type: list
+      comment: A list of options for future expansion (unused, should be []).
+    return-type: '{any}'
+    comment: Synchronously searches a cached notecard name for lines containing pattern,
+      returning a list of line and column numbers. Returns a list containing 'NAK'
+      if the notecard is not cached, or an empty list if no matches are found.
+    name: FindNotecardTextSync
+    must-use: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Position vector in region coordinates from which to flee.
+    - name: distance
+      type: number
+      comment: Distance in meters to keep from the position.
+    - name: options
+      type: list
+      comment: No options currently available (should be empty list).
+    comment: Directs a pathfinding character to keep the specified distance from the
+      target position vector (within the region or adjacent regions).
+    name: FleeFrom
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to round.
+    return-type: number
+    comment: Returns the largest integer value less than or equal to val (rounded
+      toward negative infinity).
+    name: Floor
+    deprecated:
+      reason: Fastcall.
+      use: math.floor
+      selene-replace:
+      - math.floor(%...)
+    must-use: true
+  - parameters:
+    - name: mouselook
+      type: boolean | number
+      comment: Boolean. If TRUE, forces a sitting avatar into mouselook; if FALSE,
+        allows them to keep their current camera mode.
+    comment: Sets whether any avatar sitting on this prim is forced into mouselook
+      mode. Setting mouselook to TRUE forces the mode; FALSE (default) allows the
+      avatar to keep their current camera mode.
+    name: ForceMouselook
+  - parameters:
+    - name: mag
+      type: number
+      comment: Float magnitude of the random range.
+    return-type: number
+    comment: Returns a pseudo-random float in the range [0.0, mag) or (mag, 0.0] depending
+      on the sign of mag. The value is inclusive of 0.0 but exclusive of mag.
+    name: Frand
+    must-use: true
+  - return-type: uuid
+    comment: Generates and returns a unique versioned UUID key (utilizing SHA-1 hashing).
+      Due to being versioned, it will not return NULL_KEY; however, the exact UUID
+      version is an implementation detail that should not be relied upon.
+    name: GenerateKey
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the acceleration of the object in the region's
+      frame of reference.
+    name: GetAccel
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: number
+    comment: Returns an integer bitfield containing status information about the agent
+      specified by id (such as AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SITTING, etc.).
+    name: GetAgentInfo
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: string
+    comment: Returns a string representing the language code of the preferred interface
+      language set by the avatar.
+    name: GetAgentLanguage
+    must-use: true
+  - parameters:
+    - name: scope
+      type: number
+      comment: Scope flag (AGENT_LIST_PARCEL, AGENT_LIST_PARCEL_OWNER, or AGENT_LIST_REGION)
+        to filter the returned agents.
+    - name: options
+      type: list
+      comment: A list of options to apply (currently unused).
+    return-type: '{uuid}'
+    comment: Requests a list of avatar UUID keys for agents currently in the region,
+      limited by scope. Returns a list of keys or a list containing an error message
+      string.
+    name: GetAgentList
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: vector
+    comment: Returns a vector representing the estimated bounding box size of the
+      specified avatar, or ZERO_VECTOR if they are not in the same region.
+    name: GetAgentSize
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: number
+    comment: Returns a float representing the Blinn-Phong alpha (transparency) of
+      face. If face is ALL_SIDES, returns the mean average of all faces.
+    name: GetAlpha
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: string
+    comment: Returns a string representing the name of the currently playing locomotion
+      animation for the avatar specified by id.
+    name: GetAnimation
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: '{uuid}'
+    comment: Returns a list of keys (UUIDs) representing all active animations currently
+      playing on the specified avatar.
+    name: GetAnimationList
+    must-use: true
+  - parameters:
+    - name: anim_state
+      type: string
+      comment: Animation state string to query.
+    return-type: string
+    comment: Returns a string representing the name of the animation currently overriding
+      the specified anim_state. Requires the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION
+      runtime permission.
+    name: GetAnimationOverride
+    must-use: true
+  - return-type: number
+    comment: Returns the integer attachment point (an ATTACH_* constant) that the
+      object is attached to, or 0 if it is unattached or pending detachment.
+    name: GetAttached
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: '{uuid} | {string}'
+    comment: Returns a list of object keys (UUIDs) corresponding to public, visible
+      (non-HUD) attachments worn by the specified avatar, in the order they were attached.
+      Returns a list with an error message string on failure.
+    name: GetAttachedList
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: options
+      type: list
+      comment: A list of options to filter the returned attachments.
+    return-type: '{uuid} | {string}'
+    comment: Retrieves a list of attachment object keys worn by avatar in the order
+      they were attached, filtered by options. Returns a list containing an error
+      message string on failure.
+    name: GetAttachedListFiltered
+    must-use: true
+  - parameters:
+    - name: object
+      type: uuid
+      comment: UUID of the avatar or prim in the same region.
+    return-type: '{vector}'
+    comment: Returns the bounding box of object (including any linked prims) relative
+      to its root prim in local coordinates, formatted as [ (vector) min_corner, (vector)
+      max_corner ].
+    name: GetBoundingBox
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the camera's current aspect ratio (width/height)
+      of the agent who granted PERMISSION_TRACK_CAMERA. Returns 0.0 if permissions
+      are not granted.
+    name: GetCameraAspect
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the camera's current field of view (FOV)
+      in radians of the agent who granted PERMISSION_TRACK_CAMERA. Returns 0.0 if
+      permissions are not granted.
+    name: GetCameraFOV
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the camera's current position in region
+      coordinates of the agent who granted PERMISSION_TRACK_CAMERA. Returns ZERO_VECTOR
+      if permissions are not granted.
+    name: GetCameraPos
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the camera's current orientation of the
+      agent who granted PERMISSION_TRACK_CAMERA. Returns ZERO_ROTATION if permissions
+      are not granted.
+    name: GetCameraRot
+    must-use: true
+  - return-type: vector
+    comment: Returns the vector position (in region coordinates) of the center of
+      mass. Returns the individual child prim's center of mass if called from a child,
+      or the entire linkset's center of mass if called from the root.
+    name: GetCenterOfMass
+    must-use: true
+  - parameters:
+    - name: point
+      type: vector
+      comment: Position vector in region-local coordinates.
+    - name: options
+      type: list
+      comment: A list of GCNP_* flags and parameters to configure the search limits.
+    return-type: '{vector}'
+    comment: Returns a list containing the closest vector position on the navigation
+      mesh (navmesh) to the specified point (expressed in region-local space), or
+      an empty list if none is found. Configured using options.
+    name: GetClosestNavPoint
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: vector
+    comment: Returns the Blinn-Phong RGB color vector of face (values between 0.0
+      and 1.0). If face is ALL_SIDES, returns the mean average of all faces.
+    name: GetColor
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the prim's original creator.
+    name: GetCreator
+    must-use: true
+  - return-type: string
+    comment: Returns a string representing the current date in the UTC time zone in
+      the format 'YYYY-MM-DD'.
+    name: GetDate
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the number of seconds in the environmental
+      day cycle applied to the current parcel.
+    name: GetDayLength
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the offset duration (in seconds) added
+      to calculate the current environmental time on this parcel.
+    name: GetDayOffset
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region or otherwise known to the region.
+    return-type: string
+    comment: Returns the display name string of the avatar specified by id if they
+      are in the region or cached; returns an empty string otherwise (use llRequestDisplayName
+      if the avatar is absent).
+    name: GetDisplayName
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the remaining physics energy of the object
+      as a percentage (0.0 to 1.0) of its maximum capacity.
+    name: GetEnergy
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the regional data to request (unrecognized strings return an
+        empty string).
+    return-type: string
+    comment: Returns a string containing the requested regional data specified by
+      name.
+    name: GetEnv
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (X/Y determine the parcel, or
+        region if X/Y are -1; Z determines the sky track altitude).
+    - name: params
+      type: '{number}'
+      comment: A list of environmental attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list containing the current environment parameters for the
+      parcel or region at pos, retrieved in the order specified by params.
+    name: GetEnvironment
+    must-use: true
+  - parameters:
+    - name: experience_id
+      type: uuid
+      comment: UUID of the experience to query (can be NULL_KEY to retrieve details
+        for the script's own experience).
+    return-type: '{any}'
+    comment: Returns a list of details for the specified experience_id, formatted
+      as [string experience_name, key owner_id, key experience_id, integer state,
+      string state_message, key group_id].
+    name: GetExperienceDetails
+    must-use: true
+  - parameters:
+    - name: error
+      type: number
+      comment: XP_ERROR_* error code constant to translate.
+    return-type: string
+    comment: Returns a text description of the specified experience error code, or
+      a description of XP_ERROR_UNKNOWN_ERROR if the error is invalid.
+    name: GetExperienceErrorMessage
+    must-use: true
+  - parameters:
+    - name: agentid
+      type: uuid
+    return-type: '{uuid}'
+    name: GetExperienceList
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the constant force currently applied to
+      the object (if the object is physical).
+    name: GetForce
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the number of free bytes of memory currently
+      available to the script.
+    name: GetFreeMemory
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the number of available HTTP URLs (remaining
+      for the owner if the object is attached, or for the region if unattached).
+    name: GetFreeURLs
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the time in seconds since midnight GMT (truncated
+      to whole seconds).
+    name: GetGMTclock
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the geometric center of the object relative
+      to its root prim.
+    name: GetGeometricCenter
+    must-use: true
+  - parameters:
+    - name: request_id
+      type: uuid
+      comment: Unique key of the HTTP request.
+    - name: header
+      type: string
+      comment: Lowercase name of the HTTP header to retrieve.
+    return-type: string
+    comment: Returns a string representing the value of the specified header associated
+      with the HTTP request_id.
+    name: GetHTTPHeader
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the agent or object to query.
+    return-type: number
+    comment: Returns a float representing the current health of the avatar or object
+      specified by id.
+    name: GetHealth
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: string
+    comment: Returns a string containing the UTC timestamp (YYYY-MM-DDThh:mm:ssZ)
+      representing when the inventory item was placed inside the prim.
+    name: GetInventoryAcquireTime
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: uuid
+    comment: Returns the key (UUID) of the creator of the specified inventory item.
+    name: GetInventoryCreator
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: string
+    comment: Returns a string containing the description of the specified inventory
+      item.
+    name: GetInventoryDesc
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: uuid
+    comment: Returns the key (UUID) of the specified inventory name.
+    name: GetInventoryKey
+    must-use: true
+  - parameters:
+    - name: type
+      type: number
+      comment: INVENTORY_* type constant of the item.
+    - name: number
+      type: number
+      comment: Index number of the item of that type, starting from 0.
+    return-type: string
+    comment: Returns the name of the inventory item of the specified type (INVENTORY_*)
+      at the index number.
+    name: GetInventoryName
+    must-use: true
+  - parameters:
+    - name: type
+      type: number
+      comment: INVENTORY_* type constant to count.
+    return-type: number
+    comment: Returns an integer representing the quantity of items of the specified
+      type (INVENTORY_*) in the prim's inventory.
+    name: GetInventoryNumber
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    - name: category
+      type: number
+      comment: MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE,
+        or MASK_NEXT).
+    return-type: number
+    comment: Returns an integer bitfield representing the permission category mask
+      of the specified inventory item.
+    name: GetInventoryPermMask
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the inventory item.
+    return-type: number
+    comment: Returns an integer representing the INVENTORY_* type of the named inventory
+      item.
+    name: GetInventoryType
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the prim containing the script.
+    name: GetKey
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates.
+    return-type: uuid
+    comment: Returns the key (UUID) of the land owner at the vector pos, or NULL_KEY
+      if the land is public.
+    name: GetLandOwnerAt
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: uuid
+    comment: Returns the key (UUID) of the linked prim or avatar specified by link.
+    name: GetLinkKey
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_MEDIA_* property constants to retrieve values for.
+    return-type: '{any}'
+    comment: Returns a list containing the media parameters of the specified face
+      on the linked prim link, retrieved in the order requested by params.
+    name: GetLinkMedia
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: string
+    comment: Returns a string containing the name of the linked prim specified by
+      link.
+    name: GetLinkName
+    must-use: true
+  - return-type: number
+    comment: Returns the integer link number of the prim containing the script (0
+      for unlinked, 1 for the root, and 2+ for children).
+    name: GetLinkNumber
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: number
+    comment: Returns an integer representing the number of sides (faces) of the linked
+      prim specified by link.
+    name: GetLinkNumberOfSides
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag to retrieve
+        parameters from.
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list of primitive parameters requested in params for the linked
+      prim specified by link (equivalent to llGetPrimitiveParams).
+    name: GetLinkPrimitiveParams
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: number
+    comment: Returns an integer representing the active sit flags currently set on
+      the linked prim specified by link.
+    name: GetLinkSitFlags
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: number
+    comment: Returns an integer representing the variable type (TYPE_*) of the list
+      entry at index in the list src.
+    name: GetListEntryType
+    deprecated:
+      use: typeof
+      selene-replace:
+      - typeof(%1[%2])
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to measure.
+    return-type: number
+    comment: Returns an integer representing the total number of elements in the list
+      src.
+    name: GetListLength
+    deprecated:
+      reason: Use '#' or 'rawlen' instead. Metatable support.
+      selene-replace:
+      - '#%1'
+      - rawlen(%1)
+    must-use: true
+  - return-type: vector
+    comment: Returns a position vector relative to the root prim. If called from the
+      root prim, it returns the global region position (or the position relative to
+      the attachment point if attached).
+    name: GetLocalPos
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the local orientation of a child prim
+      relative to the root prim, or the object's overall rotation if called from the
+      root.
+    name: GetLocalRot
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the mass of the object (in lindograms).
+      Returns the total linkset mass if called from the root, or the individual prim's
+      mass if called from a child prim. Returns the wearer's mass if inside an attachment.
+    name: GetMass
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the mass of the object in kilograms. Functionally
+      identical to llGetMass except for using MKS (metric) units.
+    name: GetMassMKS
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the maximum scale factor that can be applied
+      to the object via llScaleByFactor without violating size or linkability limits.
+    name: GetMaxScaleFactor
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the maximum memory limit (in bytes) that
+      the script is allowed to allocate.
+    name: GetMemoryLimit
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the minimum scale factor that can be applied
+      to the object via llScaleByFactor without violating size limits.
+    name: GetMinScaleFactor
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      parcel's moon, taking altitude into account. Falls back to the region's moon
+      direction if no custom parcel environment is set.
+    name: GetMoonDirection
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the moon on
+      the current parcel and altitude track. Falls back to the region's moon rotation
+      if no custom parcel environment is set.
+    name: GetMoonRotation
+    must-use: true
+  - parameters:
+    - name: address
+      type: string
+      comment: Sender email address filter.
+    - name: subject
+      type: string
+      comment: Email subject filter.
+    comment: Requests the next queued email matching the specified sender address
+      and subject filters via the email event.
+    name: GetNextEmail
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of the notecard in the prim's inventory, or a UUID.
+    - name: line
+      type: number
+      comment: Zero-based line number to request.
+    return-type: uuid
+    comment: Asynchronously requests the line index line of the notecard name from
+      the dataserver. Returns a key query handle for the dataserver event, which will
+      return 'EOF' when reaching past the end of the notecard.
+    name: GetNotecardLine
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of the notecard in the prim's inventory, or a UUID.
+    - name: line
+      type: number
+      comment: Zero-based line number to request.
+    return-type: string
+    comment: Synchronously reads the line index line of the notecard name from the
+      region's cache, immediately returning its text without raising a dataserver
+      event. Returns 'NAK' if not cached or 'EOF' if out of bounds.
+    name: GetNotecardLineSync
+    must-use: true
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of the notecard in the prim's inventory, or a UUID.
+    return-type: uuid
+    comment: Asynchronously requests the total line count of the notecard name. Returns
+      a key query handle for the dataserver event.
+    name: GetNumberOfNotecardLines
+  - return-type: number
+    comment: Returns an integer representing the total number of prims and seated
+      avatars in the linkset containing the script.
+    name: GetNumberOfPrims
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of sides (faces) of
+      the prim containing the script.
+    name: GetNumberOfSides
+    must-use: true
+  - return-type: '{string}'
+    comment: Returns a list of strings representing the names of all active animations
+      currently playing on the object.
+    name: GetObjectAnimationNames
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the description of the specific prim containing
+      the script.
+    name: GetObjectDesc
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar or prim (in the same or adjacent regions) to query.
+    - name: params
+      type: '{number}'
+      comment: A list of OBJECT_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list containing the requested parameters of the specified avatar
+      or object id, retrieved in the order requested by params.
+    name: GetObjectDetails
+    must-use: true
+  - parameters:
+    - name: object_id
+      type: uuid
+      comment: UUID of the target prim or linkset.
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag of the prim
+        to retrieve.
+    return-type: uuid
+    comment: Returns the key (UUID) of the linked child prim specified by link within
+      the linkset identified by object_id.
+    name: GetObjectLinkKey
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar or object to query.
+    return-type: number
+    comment: Returns a float representing the mass of the avatar or object specified
+      by id.
+    name: GetObjectMass
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the name of the specific prim containing
+      the script.
+    name: GetObjectName
+    must-use: true
+  - parameters:
+    - name: category
+      type: number
+      comment: MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE,
+        or MASK_NEXT).
+    return-type: number
+    comment: Returns an integer bitfield representing the permission mask of the specified
+      category for the object containing the script.
+    name: GetObjectPermMask
+    must-use: true
+  - parameters:
+    - name: prim
+      type: uuid
+      comment: UUID of the prim in the same region.
+    return-type: number
+    comment: Returns an integer representing the total number of prims in the object
+      containing the specified prim.
+    name: GetObjectPrimCount
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the physical rotation (angular velocity)
+      of the object in radians per second.
+    name: GetOmega
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the object's current owner.
+    name: GetOwner
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the prim in the same region.
+    return-type: uuid
+    comment: Returns the key (UUID) of the owner of the prim specified by id.
+    name: GetOwnerKey
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (only the X and Y components
+        are used).
+    - name: params
+      type: '{number}'
+      comment: A list of PARCEL_DETAILS_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list containing the requested parcel details specified by params
+      (retrieved in the same order) for the parcel at the vector pos.
+    name: GetParcelDetails
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (the Z component is ignored).
+    return-type: number
+    comment: Returns an integer bitfield of parcel flags (PARCEL_FLAG_*) for the parcel
+      at the position pos.
+    name: GetParcelFlags
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (the Z component is ignored).
+    - name: sim_wide
+      type: boolean | number
+      comment: Boolean. If TRUE, returns the combined land impact limit for all parcels
+        owned by the parcel owner in the region; if FALSE, returns only the limit
+        for the specified parcel.
+    return-type: number
+    comment: Returns an integer representing the maximum combined land impact (prim
+      limit) allowed for objects on the parcel at pos, determined either for the single
+      parcel or sim-wide based on sim_wide.
+    name: GetParcelMaxPrims
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the parcel's streaming music (audio) URL.
+      The object owner must also be the land owner (or share the same group deeding).
+    name: GetParcelMusicURL
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (the Z component is ignored).
+    - name: category
+      type: number
+      comment: PARCEL_COUNT_* category flag.
+    - name: sim_wide
+      type: boolean | number
+      comment: Boolean. If TRUE, searches all parcels in the region owned by the targeted
+        parcel's owner; if FALSE, searches only the specified parcel.
+    return-type: number
+    comment: Returns an integer representing the total land impact of objects on the
+      parcel at pos in the specified category. If sim_wide is TRUE, returns combined
+      usage for all regional parcels owned by the parcel owner; if FALSE, returns
+      usage for only the specified parcel.
+    name: GetParcelPrimCount
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates.
+    return-type: '{any}'
+    comment: Returns a list of up to 100 strides (formatted as [key owner, integer
+      land_impact]) representing owners of objects on the parcel at pos, sorted by
+      owner key. Requires owner-like permissions for the parcel and the script owner's
+      presence in the region.
+    name: GetParcelPrimOwners
+    must-use: true
+  - return-type: number
+    comment: Returns an integer bitfield representing the permissions (PERMISSION_*)
+      currently granted to the script.
+    name: GetPermissions
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the avatar that last granted or declined permissions
+      to the script, or NULL_KEY if the permissions request was ignored or cancelled.
+    name: GetPermissionsKey
+    must-use: true
+  - return-type: '{number}'
+    comment: Returns a list of the format [float gravity_multiplier, float restitution,
+      float friction, float density] detailing the physical characteristics of the
+      object.
+    name: GetPhysicsMaterial
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the current position of the object in region
+      coordinates.
+    name: GetPos
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_MEDIA_* property constants to retrieve values for.
+    return-type: '{any}'
+    comment: Returns a list containing the media parameters of the specified face,
+      retrieved in the order requested by params. Returns an empty list if no media
+      exists on the face.
+    name: GetPrimMediaParams
+    must-use: true
+  - parameters:
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list of primitive attribute values matching the requested params
+      list.
+    name: GetPrimitiveParams
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the current number of avatars in the
+      region.
+    name: GetRegionAgentCount
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector (in meters) representing the global grid coordinates
+      of the south-west corner of the current region (Z component is always 0.0).
+    name: GetRegionCorner
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of seconds in the region-wide
+      day cycle.
+    name: GetRegionDayLength
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the offset duration (in seconds) added
+      to calculate the current environmental time for the region.
+    name: GetRegionDayOffset
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the average region simulator frames per
+      second (FPS).
+    name: GetRegionFPS
+    must-use: true
+  - return-type: number
+    comment: Returns an integer bitfield representing the region flags (REGION_FLAG_*)
+      currently enabled for the region containing the object.
+    name: GetRegionFlags
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      region's moon, taking altitude into account.
+    name: GetRegionMoonDirection
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the moon at
+      the region level, taking altitude track into account.
+    name: GetRegionMoonRotation
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the name of the current region.
+    name: GetRegionName
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      region's sun, taking altitude into account.
+    name: GetRegionSunDirection
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the sun at
+      the region level, taking altitude track into account.
+    name: GetRegionSunRotation
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the current physics time dilation of the
+      region, ranging from 0.0 (full dilation / slow) to 1.0 (no dilation / real-world
+      speed).
+    name: GetRegionTimeDilation
+    must-use: true
+  - return-type: number
+    comment: Returns a float with subsecond precision representing the elapsed seconds
+      since region environmental midnight or region uptime (whichever is smaller).
+      If the region's sun position is fixed, returns region uptime.
+    name: GetRegionTimeOfDay
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: string
+    comment: Returns a string representing the render material on face (returns the
+      inventory name if it is in the prim's inventory, or its key UUID otherwise).
+    name: GetRenderMaterial
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the position (in region coordinates) of
+      the root prim of the linkset containing the script.
+    name: GetRootPosition
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation (relative to the region)
+      of the root prim of the linkset containing the script.
+    name: GetRootRotation
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the prim's orientation relative to the
+      region's axes.
+    name: GetRot
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the maximum memory (in bytes) used by
+      the script while the memory profiler was last active (only valid after using
+      PROFILE_SCRIPT_MEMORY).
+    name: GetSPMaxMemory
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the physical scale (dimensions in meters)
+      of the prim containing the script.
+    name: GetScale
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the name of the script calling this function.
+    name: GetScriptName
+    must-use: true
+  - parameters:
+    - name: script
+      type: string
+      comment: Name of the script in the prim's inventory.
+    return-type: boolean
+    comment: Returns a boolean integer indicating whether the specified script in
+      the prim's inventory is running (returns TRUE if running, FALSE otherwise).
+    name: GetScriptState
+    must-use: true
+  - parameters:
+    - name: stat_type
+      type: number
+      comment: SIM_STAT_* flag of the statistic to retrieve.
+    return-type: number
+    comment: Returns a float containing the value of the requested region statistic
+      specified by stat_type.
+    name: GetSimStats
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the hostname of the server machine running
+      the script (e.g., 'sim225.agni.lindenlab.com').
+    name: GetSimulatorHostname
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the start/rez parameter passed to the
+      object on creation (returns 0 if rezzed by an agent).
+    name: GetStartParameter
+    must-use: true
+  - return-type: string
+    comment: Returns the initialization string passed to the object's root prim on
+      rez with llRezObjectWithParams (via REZ_PARAM_STRING; returns an empty string
+      if rezzed by an agent).
+    name: GetStartString
+    must-use: true
+  - parameters:
+    - name: start
+      type: vector
+      comment: Starting position vector.
+    - name: end
+      type: vector
+      comment: Target end position vector.
+    - name: radius
+      type: number
+      comment: Radius of the character path, between 0.125m and 5.0m.
+    - name: params
+      type: list
+      comment: A list specifying the CHARACTER_TYPE parameter (defaults to CHARACTER_TYPE_NONE).
+    return-type: '{any}'
+    comment: Returns a list of position vectors representing pathfinding waypoints
+      between start and end on the static navmesh for a character of the specified
+      radius. Ignores movable obstacles and can be used in any region regardless of
+      dynamic pathfinding status.
+    name: GetStaticPath
+    must-use: true
+  - parameters:
+    - name: status
+      type: number
+      comment: Single STATUS_* flag to check.
+    return-type: boolean
+    comment: Returns a boolean integer indicating whether the specified status flag
+      status is enabled for the object.
+    name: GetStatus
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to slice.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    return-type: string
+    comment: Returns a copy of the substring from src within the inclusive range specified
+      by the start and end indices. Negative indices count backward from the end.
+      If start is greater than end, the substring is the excluded range.
+    name: GetSubString
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      parcel's sun, taking altitude into account. Falls back to the region's sun direction
+      if no custom parcel environment is set.
+    name: GetSunDirection
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the sun on
+      the current parcel and altitude track. Falls back to the region's sun rotation
+      if no custom parcel environment is set.
+    name: GetSunRotation
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: string
+    comment: Returns a string representing the Blinn-Phong diffuse texture on face
+      (returns the inventory name if it is a texture in the prim's inventory, or its
+      key UUID otherwise).
+    name: GetTexture
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: vector
+    comment: Returns a vector containing the texture offsets of face in the X (horizontal
+      U) and Y (vertical V) components (Z is unused).
+    name: GetTextureOffset
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: number
+    comment: Returns a float representing the texture rotation angle (in radians)
+      on face.
+    name: GetTextureRot
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: vector
+    comment: Returns a vector containing the texture scales of face in the X and Y
+      components (Z is unused).
+    name: GetTextureScale
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the elapsed script time in seconds with
+      subsecond precision (since the script started, was reset, or since the last
+      call to llResetTime or llGetAndResetTime).
+    name: GetTime
+    must-use: true
+  - return-type: number
+    comment: Returns a float with subsecond precision representing the elapsed seconds
+      since parcel environmental midnight or region uptime (whichever is smaller).
+      If the parcel's sun position is fixed, returns region uptime.
+    name: GetTimeOfDay
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the current date and time in the UTC time
+      zone formatted as an ISO 8601 timestamp ('YYYY-MM-DDThh:mm:ss.ff..fZ').
+    name: GetTimestamp
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the physical torque force currently acting
+      on the object (if the object is physical).
+    name: GetTorque
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the current Unix timestamp (the number
+      of seconds elapsed since 00:00:00 Jan 1, 1970 UTC).
+    name: GetUnixTime
+    deprecated:
+      reason: Int32 will wrap on 2038-01-19
+      use: os.time
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of bytes of memory currently
+      used by the script (non-Mono scripts always return 16,384 bytes).
+    name: GetUsedMemory
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region or otherwise known to the region.
+    return-type: string
+    comment: Returns a string representing the unique username of the avatar specified
+      by id if they are connected to the region or cached; returns an empty string
+      otherwise (use llRequestUsername if the avatar is absent).
+    name: GetUsername
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the velocity of the object (in meters per
+      second) relative to the global region coordinates. For physical objects, returns
+      the velocity of its center of mass.
+    name: GetVel
+    must-use: true
+  - parameters:
+    - name: agentid
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: params
+      type: '{number | string}'
+      comment: A list of visual parameter IDs or names to retrieve values for.
+    return-type: '{number | ""}'
+    comment: Returns a list containing the values of the visual parameters requested
+      in params for the agent specified by agentid.
+    name: GetVisualParams
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the time in seconds since midnight Pacific
+      Time (PST/PDT), which is equivalent to Second Life Time (SLT) truncated to whole
+      seconds.
+    name: GetWallclock
+    must-use: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the receiving agent in the region.
+    - name: folder
+      type: string
+      comment: Name of the destination folder to be created in the agent's inventory.
+    - name: inventory
+      type: '{string}'
+      comment: A list of inventory items to transfer.
+    - name: options
+      type: list
+      comment: A list of options to configure the inventory transfer.
+    return-type: number
+    comment: Gives the specified inventory items to the agent as a new folder named
+      folder, as permitted by the permissions system. Customizes the transfer using
+      options.
+    name: GiveAgentInventory
+  - parameters:
+    - name: destination
+      type: uuid
+      comment: UUID of the destination avatar or prim.
+    - name: inventory
+      type: string
+      comment: Name of the item in the prim's inventory.
+    comment: Gives the specified inventory item to the destination, as permitted by
+      the permissions system. The destination can be any agent, or an object located
+      in the same region.
+    name: GiveInventory
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target avatar or prim in the same region.
+    - name: folder
+      type: string
+      comment: Name of the destination folder to be created (ignored if the target
+        is an object).
+    - name: inventory
+      type: '{string}'
+      comment: A list of names representing items in the prim's inventory.
+    comment: Gives the list of inventory items to target as a new folder named folder.
+      If target is an object, the items are passed directly into its inventory and
+      no folder is created. The target must be an agent or an object in the same region.
+    name: GiveInventoryList
+  - parameters:
+    - name: destination
+      type: uuid
+      comment: UUID of the destination avatar.
+    - name: amount
+      type: number
+      comment: Number of L$ to transfer (must be greater than 0).
+    return-type: number
+    comment: Transfers the specified amount of L$ from the script owner to the destination
+      avatar. Silently fails if the PERMISSION_DEBIT permission has not been granted.
+      Returns 0 (use llTransferLindenDollars to match transactions to transaction_result
+      events).
+    name: GiveMoney
+  - parameters:
+    - name: inventory
+      type: uuid
+      comment: Asset UUID of the object to rez.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates where the object will be rezzed.
+    comment: Rezzes an object directly from a UUID specified by inventory at the position
+      pos, provided the owner has the god-bit set.
+    name: GodLikeRezObject
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: number
+    comment: Returns a float representing the ground height directly below the prim's
+      position offset by the vector offset.
+    name: Ground
+    must-use: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the ground contour direction (the direction
+      with no change in elevation) directly below the prim's position offset by the
+      vector offset.
+    name: GroundContour
+    must-use: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the ground surface normal vector directly
+      below the current position offset by the vector offset.
+    name: GroundNormal
+    must-use: true
+  - parameters:
+    - name: height
+      type: number
+      comment: Target distance in meters above the ground or water.
+    - name: water
+      type: boolean | number
+      comment: Boolean. If TRUE, damp relative to the higher of land and water; if
+        FALSE, damp relative to land only.
+    - name: tau
+      type: number
+      comment: Timescale in seconds to critically damp the movement.
+    comment: Critically damps the object's vertical motion to height (using critical
+      damping timescale tau) if it is within height * 0.5 of the terrain (or water
+      level if water is TRUE). Only works on physics-enabled objects; do not use with
+      vehicles.
+    name: GroundRepel
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the ground slope directly below the prim's
+      position offset by the vector offset.
+    name: GroundSlope
+    must-use: true
+  - parameters:
+    - name: private_key
+      type: string
+      comment: PEM-formatted secret key to use for the HMAC hash.
+    - name: msg
+      type: string
+      comment: Message string to be hashed.
+    - name: algorithm
+      type: string
+      comment: Cryptographic digest algorithm to use.
+    return-type: string
+    comment: Returns a Base64-encoded HMAC hash of msg using the secret key private_key
+      and the specified digest algorithm (md5, sha1, sha224, sha256, sha384, or sha512).
+    name: HMAC
+    must-use: true
+  - parameters:
+    - name: url
+      type: string
+      comment: Destination HTTP or HTTPS URL.
+    - name: parameters
+      type: list
+      comment: A list of HTTP_* configuration flags and value pairs.
+    - name: body
+      type: string
+      comment: String contents of the request body.
+    return-type: uuid
+    comment: Sends an HTTP request to the specified url containing body and configured
+      via parameters. Raises an http_response event and returns a key query handle
+      identifying the request.
+    name: HTTPRequest
+  - parameters:
+    - name: request_id
+      type: uuid
+      comment: Unique key identifying the incoming HTTP request.
+    - name: status
+      type: number
+      comment: Integer HTTP status code (such as 200, 400, or 404) to respond with.
+    - name: body
+      type: string
+      comment: String contents of the response body.
+    comment: Responds to the incoming HTTP request identified by request_id with the
+      HTTP status code status and the payload body.
+    name: HTTPResponse
+  - parameters:
+    - name: val
+      type: string
+      comment: String to hash.
+    return-type: number
+    comment: Returns an integer representing the 32-bit hash value of the string val
+      (returns 0 if the string is empty).
+    name: Hash
+    must-use: true
+  - parameters:
+    - name: dst
+      type: string
+      comment: Target destination string.
+    - name: pos
+      type: number
+      comment: Zero-based position index where insertion starts.
+    - name: src
+      type: string
+      comment: Source string to insert.
+    return-type: string
+    comment: Returns a new string representing dst with src inserted starting at the
+      zero-based index pos. Note that this operation does not modify dst itself.
+    name: InsertString
+    must-use: true
+  - parameters:
+    - name: user
+      type: uuid
+      comment: UUID of the destination user.
+    - name: message
+      type: string
+      comment: Text message string to send.
+    comment: Sends an instant message containing message to the user identified by
+      their key.
+    name: InstantMessage
+  - parameters:
+    - name: number
+      type: number
+      comment: Integer number to encode.
+    return-type: string
+    comment: Returns an 8-character Base64 string representing the big-endian encoded
+      value of number.
+    name: IntegerToBase64
+    must-use: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the agent to check.
+    return-type: boolean
+    comment: Returns TRUE if agent_id and the owner of the script are friends, and
+      FALSE otherwise.
+    name: IsFriend
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (or LINK_* flag) of the prim to inspect.
+    - name: face
+      type: number
+      comment: Face number (or ALL_SIDES) of the prim to inspect.
+    return-type: boolean
+    comment: Checks the specified face on the linked prim link. Returns TRUE if the
+      face material is a PBR render material, or FALSE if it uses Blinn-Phong diffuse
+      textures.
+    name: IsLinkGLTFMaterial
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: JSON string to parse.
+    return-type: '{any}'
+    comment: Parses the JSON string src and returns a list representing its top-level
+      elements.
+    name: Json2List
+    deprecated:
+      use: lljson.decode
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+      comment: JSON string to query.
+    - name: specifiers
+      type: list
+      comment: A list of key names or array indices specifying the path to the desired
+        value.
+    return-type: string
+    comment: Parses the JSON string json and returns the value found by traversing
+      the specified path of specifiers as a string.
+    name: JsonGetValue
+    deprecated:
+      reason: Also, the indices are zero-based.
+      use: lljson.decode
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+      comment: Source JSON string to modify.
+    - name: specifiers
+      type: list
+      comment: A list of key names or array indices specifying the path to add, update,
+        or delete.
+    - name: value
+      type: string
+      comment: New value to set, or the JSON_DELETE constant to delete the targeted
+        element.
+    return-type: string
+    comment: Returns a new JSON string representing json with the target located at
+      specifiers set to value. Supports JSON_APPEND to append elements. Writing JSON_DELETE
+      deletes the target. Overwriting array bounds or setting non-array levels with
+      array indices returns JSON_INVALID.
+    name: JsonSetValue
+    deprecated:
+      reason: Also, the indices are zero-based.
+      use: lljson.encode
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+      comment: JSON string containing the value to query.
+    - name: specifiers
+      type: list
+      comment: A list of key names or array indices specifying the path to the value.
+    return-type: string
+    comment: Parses the JSON string json and returns the JSON type constant (JSON_*)
+      representing the value found at specifiers.
+    name: JsonValueType
+    deprecated:
+      reason: Use 'lljson.decode' and 'typeof' instead. Also, the indices are zero-based.
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the target avatar or prim in the same region.
+    return-type: string
+    comment: Returns a string containing the name of the prim or avatar specified
+      by id. The target must be a valid, rezzed entity in the current region, otherwise
+      an empty string is returned. Avatars return their legacy name.
+    name: Key2Name
+    must-use: true
+  - return-type: uuid
+    comment: Starts an asynchronous transaction requesting the total count of keys
+      in the experience data store. Returns a key query handle for the dataserver
+      event.
+    name: KeyCountKeyValue
+  - parameters:
+    - name: first
+      type: number
+      comment: Zero-based start index of the keys to retrieve.
+    - name: count
+      type: number
+      comment: Number of keys to retrieve.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to retrieve count keys from the experience
+      data store starting at the zero-based index first. Returns a key query handle
+      for the dataserver event. Fails with XP_ERROR_KEY_NOT_FOUND if out of bounds.
+    name: KeysKeyValue
+  - parameters:
+    - name: color
+      type: vector
+      comment: RGB color vector in linear space to convert.
+    return-type: vector
+    comment: Returns a vector representing the conversion of color from the linear
+      RGB colorspace into the sRGB colorspace.
+    name: Linear2sRGB
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag of the prim
+        to adjust.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Adjusts the volume of the currently playing sound attached to the linked
+      prim link (has no effect on sounds started with llTriggerSound).
+    name: LinkAdjustSoundVolume
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: rules
+      type: list
+      comment: A list of particle system rules and data pairs [rule1, data1, ...].
+    comment: Creates or updates a particle system on the linked prim link based on
+      the list of rules. An empty list removes the particle system.
+    name: LinkParticleSystem
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    - name: flags
+      type: number
+      comment: Bitwise flags (combination of SOUND_*) controlling the sound playback.
+    comment: Plays the specified sound on the linked prim link (once or looping) at
+      volume. Only one sound can be attached to a prim at a time; new attachments
+      or calling llStopSound stops previous playback. Controlled by flags.
+    name: LinkPlaySound
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: queue
+      type: boolean | number
+      comment: Boolean. If TRUE, sound queuing is enabled; if FALSE, it is disabled.
+    comment: Enables or disables sound queuing on the linked prim link. When set to
+      TRUE, sounds will queue and play in sequence.
+    name: LinkSetSoundQueueing
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: radius
+      type: number
+      comment: Maximum distance in meters at which the sounds can be heard.
+    comment: Limits the audibility radius of attached and triggered scripted sounds
+      to distance radius (in meters) around the linked prim link.
+    name: LinkSetSoundRadius
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: offset
+      type: vector
+      comment: Offset position vector in local prim coordinates.
+    - name: rot
+      type: quaternion
+      comment: Rotation relative to the prim's rotation.
+    comment: Sets the sit target position (offset) and orientation (rot) for the linked
+      prim link, relative to the prim's own position and rotation. Clear by setting
+      offset to <0.0, 0.0, 0.0>.
+    name: LinkSitTarget
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    comment: Stops the playback of any currently playing attached sound on the linked
+      prim link.
+    name: LinkStopSound
+  - return-type: number
+    comment: Returns an integer representing the number of bytes available/remaining
+      in the linkset's datastore.
+    name: LinksetDataAvailable
+    must-use: true
+  - parameters:
+    - name: pattern
+      type: string
+      comment: A regular expression (regex) search string used to match keys.
+    return-type: number
+    comment: Returns the total count of keys in the linkset datastore that match the
+      regular expression pattern.
+    name: LinksetDataCountFound
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of unique keys stored
+      in the linkset's datastore.
+    name: LinksetDataCountKeys
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the key-value pair to delete.
+    return-type: number
+    comment: Deletes the unprotected key-value pair specified by name from the linkset's
+      datastore, triggering a linkset_data event.
+    name: LinksetDataDelete
+  - parameters:
+    - name: pattern
+      type: string
+      comment: A regular expression (regex) specifying which keys to delete.
+    - name: pass
+      type: string
+      comment: Optional passphrase required to delete matching protected keys.
+    return-type: '{number}'
+    comment: Deletes all keys in the datastore matching the regular expression pattern.
+      Returns a list [num_deleted, num_failed_protected]. Decrypts and deletes protected
+      keys if matching pass is provided.
+    name: LinksetDataDeleteFound
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the protected key-value pair to delete.
+    - name: pass
+      type: string
+      comment: Passphrase required to delete the protected key.
+    return-type: number
+    comment: Deletes the protected key-value pair specified by name from the linkset's
+      datastore using the passphrase pass, triggering a linkset_data event.
+    name: LinksetDataDeleteProtected
+  - parameters:
+    - name: pattern
+      type: string
+      comment: A regular expression (regex) describing which keys to search for.
+    - name: start
+      type: number
+      comment: Zero-based start index of the matching keys to return.
+    - name: count
+      type: number
+      comment: Maximum number of keys to return (or less than 1 to retrieve all matching
+        keys).
+    return-type: '{string}'
+    comment: Returns an alphabetically sorted list of up to count keys from the datastore
+      that match the regular expression pattern, starting at index start (returns
+      all matching keys if count < 1).
+    name: LinksetDataFindKeys
+    must-use: true
+  - parameters:
+    - name: start
+      type: number
+      comment: Zero-based start index of the keys to return.
+    - name: count
+      type: number
+      comment: Maximum number of keys to return (or less than 1 to retrieve all keys).
+    return-type: '{string}'
+    comment: Returns an alphabetically sorted list of up to count keys from the datastore,
+      starting at index start (returns all keys if count < 1).
+    name: LinksetDataListKeys
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key of the key-value pair to read.
+    return-type: string
+    comment: Reads and returns the string value corresponding to key name from the
+      linkset's datastore.
+    name: LinksetDataRead
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key of the protected key-value pair to read.
+    - name: pass
+      type: string
+      comment: Passphrase required to read the protected key.
+    return-type: string
+    comment: Reads and returns the string value of the protected key name from the
+      linkset's datastore using the passphrase pass.
+    name: LinksetDataReadProtected
+    must-use: true
+  - comment: Erases all key-value pairs stored in the linkset's datastore, triggering
+      a linkset_data event (with LINKSETDATA_RESET) in all scripts in the linkset.
+    name: LinksetDataReset
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the key-value pair.
+    - name: value
+      type: string
+      comment: String value to write to the datastore.
+    return-type: number
+    comment: Creates or updates an unprotected key-value pair (name and value) in
+      the linkset's datastore. Returns an integer success or failure code.
+    name: LinksetDataWrite
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the protected key-value pair.
+    - name: value
+      type: string
+      comment: String value to write to the datastore.
+    - name: pass
+      type: string
+      comment: Passphrase used to protect or update the key.
+    return-type: number
+    comment: Creates or updates a protected key-value pair (name and value) in the
+      linkset's datastore using the passphrase pass. Returns an integer success or
+      failure code.
+    name: LinksetDataWriteProtected
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list to convert.
+    return-type: string
+    comment: Returns a string of comma-separated values taken in order from the list
+      src.
+    name: List2CSV
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: number
+    comment: Returns the float value at index in the list src. Returns 0.0 if the
+      index is out of bounds or if the value cannot be type-cast.
+    name: List2Float
+    deprecated:
+      reason: Use '[]' and 'tonumber' instead.
+      selene-replace:
+      - tonumber(%1[%2]) or 0
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: number
+    comment: Returns the integer value at index in the list src. Returns 0 if the
+      index is out of bounds or if the value cannot be type-cast.
+    name: List2Integer
+    deprecated:
+      reason: Use '[]', 'tonumber', and 'math.modf' instead.
+      selene-replace:
+      - math.modf(tonumber(%1[%2]) or 0)
+    must-use: true
+  - parameters:
+    - name: type
+      type: string
+      comment: JSON target type (JSON_ARRAY or JSON_OBJECT).
+    - name: values
+      type: list
+      comment: List of values to serialize.
+    return-type: string
+    comment: Converts the list values into a JSON string of the specified type (either
+      a JSON_ARRAY or a JSON_OBJECT). Returns JSON_INVALID if an error is encountered.
+    name: List2Json
+    deprecated:
+      use: lljson.encode
+      selene-replace:
+      - lljson.encode(%2)
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: uuid
+    comment: Returns the key (UUID) value at index in the list src. Returns a null
+      string/key if the index is out of bounds or if the value cannot be type-cast.
+    name: List2Key
+    deprecated:
+      reason: Use '[]' and 'touuid' instead.
+      selene-replace:
+      - touuid(%1[%2]) or NULL_KEY
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source list to slice.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    return-type: '{T}'
+    comment: Returns a new list containing the subset of entries from src within the
+      inclusive range specified by the start and end indices. Negative indices count
+      backward from the end.
+    name: List2List
+    deprecated:
+      reason: Use 'unpack' (fastcall) or 'table.move' instead. Prefer structured tables
+        over strided lists.
+      selene-replace:
+      - table.pack(unpack(%...))
+      - table.move(%..., 1, {})
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source strided list.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    - name: stride
+      type: number
+      comment: Number of entries per stride (defaults to 1 if less than 1).
+    - name: slice_index
+      type: number
+      comment: Zero-based element index within each stride to extract (negatives count
+        backward from the end of the stride).
+    return-type: '{T}'
+    comment: Returns a list containing the slice_index'th element of every stride
+      within the inclusive range from start to end in the strided list src. Stride
+      must be a positive integer.
+    name: List2ListSlice
+    deprecated:
+      reason: Prefer structured tables over strided lists.
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source strided list.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    - name: stride
+      type: number
+      comment: Number of entries per stride (defaults to 1 if less than 1).
+    return-type: '{T}'
+    comment: Returns a new list containing the first element of every stride in the
+      strided list src within the inclusive range from start to end.
+    name: List2ListStrided
+    deprecated:
+      reason: Prefer structured tables over strided lists.
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: quaternion
+    comment: Returns the rotation value at index in the list src. Returns ZERO_ROTATION
+      if the index is out of bounds or if the value cannot be type-cast.
+    name: List2Rot
+    deprecated:
+      use: '[]'
+      selene-replace:
+      - '%1[%2]'
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: string
+    comment: Returns the string value at index in the list src. Returns an empty string
+      if the index is out of bounds.
+    name: List2String
+    deprecated:
+      reason: Use '[]' and 'tostring' instead.
+      selene-replace:
+      - tostring(%1[%2])
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: vector
+    comment: Returns the vector value at index in the list src. Returns ZERO_VECTOR
+      if the index is out of bounds or if the value cannot be type-cast.
+    name: List2Vector
+    deprecated:
+      use: '[]'
+      selene-replace:
+      - '%1[%2]'
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to search within.
+    - name: test
+      type: list
+      comment: List elements to search for.
+    return-type: number?
+    comment: Returns the integer index of the first instance of list test within the
+      list src (returns nil if not found).
+    name: ListFindList
+    deprecated:
+      reason: Prefer dictionaries or single-item searches.
+      use: table.find
+      selene-replace:
+      - table.find(%1, %2[1])
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to search within.
+    - name: test
+      type: list
+      comment: List elements to search for.
+    - name: instance
+      type: number
+      comment: Zero-based occurrence index of the match to find.
+    return-type: number?
+    comment: Returns the integer index of the specified instance of list test within
+      the list src (returns nil if not found).
+    name: ListFindListNext
+    deprecated:
+      reason: Prefer dictionaries or single-item searches.
+      use: table.find
+      selene-replace:
+      - table.find(%1, %2[1])
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to search within.
+    - name: test
+      type: list
+      comment: List elements to search for.
+    - name: start
+      type: number
+      comment: Zero-based start index of the range to search.
+    - name: end
+      type: number
+      comment: Zero-based end index of the range to search.
+    - name: stride
+      type: number
+      comment: Number of entries per stride in the list.
+    return-type: number?
+    comment: Returns the integer index of the first instance of list test in the strided
+      list src within the range from start to end (stepping through by stride). Returns
+      nil if not found.
+    name: ListFindStrided
+    deprecated:
+      reason: Prefer dictionary lookups over strided list searches.
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: dest
+      type: '{T}'
+      comment: Target destination list.
+    - name: src
+      type: '{T}'
+      comment: Source list to insert.
+    - name: start
+      type: number
+      comment: Zero-based index where insertion begins.
+    return-type: '{T}'
+    comment: Returns a new list containing all elements of dest with the elements
+      of src inserted starting at index start. Does not modify dest itself.
+    name: ListInsertList
+    deprecated:
+      reason: Unnecessary table copying. Fastcall.
+      use: table.insert
+      selene-replace:
+      - table.insert(%1, %3, %2[1])
+      - 'table.move(%2, 1, #%2, %3, %1)'
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source list to randomize.
+    - name: stride
+      type: number
+      comment: Size of each randomized block (defaults to 1 if less than 1).
+    return-type: '{T}'
+    comment: Returns a randomized copy of the list src by blocks of size stride. If
+      the list length is not perfectly divisible by stride, no randomization occurs.
+    name: ListRandomize
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: dest
+      type: '{T}'
+      comment: Target destination list.
+    - name: src
+      type: '{T}'
+      comment: Source list to insert.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive) of the replaced range.
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive) of the replaced range.
+    return-type: '{T}'
+    comment: Returns a copy of the list dest with the inclusive range from start to
+      end removed, and the elements of src inserted in its place at start.
+    name: ListReplaceList
+    deprecated:
+      reason: Unnecessary table copying.
+      use: t[n] = x
+      selene-replace:
+      - '%1[%3] = %2[1]'
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: List to be sorted.
+    - name: stride
+      type: number
+      comment: Number of entries per block/stride (defaults to 1 if less than 1).
+    - name: ascending
+      type: boolean | number
+      comment: Boolean. If TRUE, sorts in ascending order; if FALSE, sorts in descending
+        order.
+    return-type: '{T}'
+    comment: Returns a copy of the list src, sorted into blocks of stride in ascending
+      order (if ascending is TRUE) or descending order (if FALSE). Only works if the
+      first entry of each block shares the same datatype.
+    name: ListSort
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: List to be sorted.
+    - name: stride
+      type: number
+      comment: Number of entries per block/stride (defaults to 1 if less than 1).
+    - name: stride_index
+      type: number
+      comment: Zero-based index of the element within each stride to use as the sort
+        key (negatives count backward from the end of the stride).
+    - name: ascending
+      type: boolean | number
+      comment: Boolean. If TRUE, sorts in ascending order; if FALSE, sorts in descending
+        order.
+    return-type: '{T}'
+    comment: Returns a copy of the list src sorted into blocks of stride by the element
+      at stride_index in each block. Sorted in ascending order (if ascending is TRUE)
+      or descending order (if FALSE).
+    name: ListSortStrided
+    deprecated:
+      reason: Prefer structured tables over strided lists.
+      use: table.sort
+    must-use: true
+  - parameters:
+    - name: operation
+      type: number
+      comment: LIST_STAT_* constant of the statistical operation to perform.
+    - name: src
+      type: list
+      comment: List of floats and integers to analyze.
+    return-type: number
+    comment: Returns a float representing the result of performing the statistical
+      aggregate function operation (a LIST_STAT_* constant) on the numeric list src.
+    name: ListStatistics
+    must-use: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Input chat channel to listen on (any integer from -2147483648 to 2147483647).
+    - name: name
+      type: string
+      comment: Specific prim name or avatar legacy name to filter by (or empty string
+        for no filter).
+    - name: id
+      type: uuid
+      comment: Specific avatar or prim UUID to filter by (or NULL_KEY for no filter).
+    - name: msg
+      type: string
+      comment: Specific chat message string to filter by (or empty string for no filter).
+    return-type: number
+    comment: Creates a listener on channel from name and id for msg. Returns an integer
+      listener handle used to control or remove the listener. Empty strings or NULL_KEY
+      filters do not filter on those parameters.
+    name: Listen
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer listener handle returned by llListen.
+    - name: active
+      type: boolean | number
+      comment: Boolean. If TRUE, activates the listener; if FALSE, deactivates it.
+    comment: Enables or disables the listener specified by the integer handle. If
+      active is TRUE, the listener is activated; if FALSE, it is deactivated.
+    name: ListenControl
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer listener handle returned by llListen to remove.
+    comment: Completely removes the listener specified by the integer handle.
+    name: ListenRemove
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: message
+      type: string
+      comment: Text message to display in the dialog box.
+    - name: url
+      type: string
+      comment: Web URL to open.
+    comment: Shows a dialog box displaying message to the avatar avatar offering to
+      open the specified url. Clicking yes launches the URL in their default web browser.
+    name: LoadURL
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to evaluate.
+    return-type: number
+    comment: Returns a float representing the natural (base e) logarithm of the positive
+      value val (returns 0.0 if val <= 0).
+    name: Log
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.log
+      selene-replace:
+      - math.log(%...)
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to evaluate.
+    return-type: number
+    comment: Returns a float representing the base-10 (common) logarithm of the positive
+      value val (returns 0.0 if val <= 0).
+    name: Log10
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.log10
+      selene-replace:
+      - math.log10(%...)
+    must-use: true
+  - parameters:
+    - name: target
+      type: vector
+      comment: Target position vector in region coordinates to look at.
+    - name: strength
+      type: number
+      comment: Force of rotation (0.0 cancels the tracking; values around half the
+        object's mass are typical).
+    - name: damping
+      type: number
+      comment: Timescale in seconds to critically damp the orientation.
+    comment: Causes the object to orient its positive Z-axis (up axis) toward the
+      target vector, keeping its positive X-axis (forward axis) below the horizon.
+      Tracks target until llStopLookAt is called or strength is set to 0.0.
+    name: LookAt
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound looping indefinitely at the specified volume.
+      Only one sound can be attached to a prim at a time; new loops adjust the volume
+      of the currently playing sound without restarting it.
+    name: LoopSound
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound looping indefinitely at the specified volume
+      and declares it a Sync Master, forcing slave sounds to synchronize with it.
+    name: LoopSoundMaster
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound looping indefinitely at the specified volume,
+      synchronized to the most audible active Sync Master in range.
+    name: LoopSoundSlave
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to hash.
+    - name: nonce
+      type: number
+      comment: Nonce string used as a salt.
+    return-type: string
+    comment: Returns a string of 32 hex characters representing the MD5 checksum of
+      src salted with nonce (formatted as ':' + nonce).
+    name: MD5String
+    must-use: true
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    comment: Deprecated. Generates a circular explosion of particles. Use llParticleSystem
+      instead.
+    name: MakeExplosion
+    deprecated:
+      use: ll.ParticleSystem
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    comment: Deprecated. Generates fire-like particles. Use llParticleSystem instead.
+    name: MakeFire
+    deprecated:
+      use: ll.ParticleSystem
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: bounce
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    - name: bounce_offset
+      type: number
+    comment: Deprecated. Generates a fountain of particles. Use llParticleSystem instead.
+    name: MakeFountain
+    deprecated:
+      use: ll.ParticleSystem
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    comment: Deprecated. Generates smoke-like particles. Use llParticleSystem instead.
+    name: MakeSmoke
+    deprecated:
+      use: ll.ParticleSystem
+  - parameters:
+    - name: action
+      type: number
+      comment: An ESTATE_ACCESS_* action flag specifying the operation to perform.
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar or group to add or remove.
+    return-type: boolean
+    comment: Adds or removes agents from the estate's access or ban lists, or groups
+      from the estate's group access list, specified by the action. Returns TRUE if
+      successful, or FALSE if throttled, if the action/ID is invalid, or if the script
+      owner lacks estate management rights.
+    name: ManageEstateAccess
+  - parameters:
+    - name: region_name
+      type: string
+      comment: Name of the region where the beacon is displayed.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates to highlight.
+    - name: options
+      type: list
+      comment: A list of options to configure the map beacon.
+    comment: Displays an in-world beacon and optionally opens the world map for the
+      avatar touching or wearing the object, centered on region_name with pos highlighted.
+      Only works for attached scripts or during touch events.
+    name: MapBeacon
+  - parameters:
+    - name: simname
+      type: string
+      comment: Name of the target simulator region.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates to highlight.
+    - name: look_at
+      type: vector
+      comment: Position in local coordinates (currently unused/ignored).
+    comment: 'Opens the world map for the avatar touching or wearing the object, centered
+      on simname with pos highlighted. Only works for attached scripts or during touch
+      events. Note: look_at currently has no effect.'
+    name: MapDestination
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag controlling
+        which prim(s) receive the message.
+    - name: num
+      type: number
+      comment: An integer value passed as the second parameter of the link_message
+        event.
+    - name: str
+      type: string | uuid
+      comment: A string value passed as the third parameter of the link_message event.
+    - name: id
+      type: string | uuid
+      comment: A key value passed as the fourth parameter of the link_message event.
+    comment: Triggers a link_message event, sending num, str, and id to the scripts
+      in the prim(s) specified by link to allow scripts within the same object to
+      communicate.
+    name: MessageLinked
+  - parameters:
+    - name: delay
+      type: number
+      comment: Minimum delay duration in seconds.
+    comment: Sets the minimum delay time between events being handled (minimums and
+      defaults vary by event type).
+    name: MinEventDelay
+  - parameters:
+    - name: a
+      type: number
+      comment: Base integer value.
+    - name: b
+      type: number
+      comment: Power exponent (capped at 0xFFFF / 16 bits).
+    - name: c
+      type: number
+      comment: Modulus integer value.
+    return-type: number
+    comment: Returns an integer representing a raised to the power b, modulo c (i.e.,
+      (a**b)%c). The b value is capped at 0xFFFF (16 bits).
+    name: ModPow
+    must-use: true
+  - parameters:
+    - name: action
+      type: number
+      comment: LAND_* action flag to perform (e.g., LAND_LEVEL, LAND_RAISE, LAND_LOWER,
+        LAND_SMOOTH, LAND_NOISE, or LAND_REVERT).
+    - name: brush
+      type: number
+      comment: Brush size (0, 1, or 2, representing 2m x 2m, 4m x 4m, or 8m x 8m).
+    comment: Modifies the terrain using the specified land action and brush size (0,
+      1, or 2, corresponding to 2m x 2m, 4m x 4m, or 8m x 8m).
+    name: ModifyLand
+  - parameters:
+    - name: target
+      type: vector
+      comment: Target position vector in region coordinates.
+    - name: tau
+      type: number
+      comment: Timescale in seconds to critically damp the movement.
+    comment: Critically damps the physical object's motion to position target in tau
+      seconds. Setting tau to 0.0 stops the critical damping; recommended tau values
+      are greater than 0.2.
+    name: MoveToTarget
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the avatar (e.g., 'First Last' or 'first.last').
+    return-type: uuid
+    comment: Requests the key (UUID) of the avatar name in the current region. Returns
+      NULL_KEY if no matching agent is present. Formats are 'First Last' or 'first.last'
+      (assumes 'Resident' if last name is omitted; case-insensitive).
+    name: Name2Key
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Destination position vector in region coordinates.
+    - name: options
+      type: list
+      comment: A list of parameters to configure pathfinding behavior (currently only
+        FORCE_DIRECT_PATH is supported).
+    comment: Directs a pathfinding character to navigate to the position pos (located
+      in the current or adjacent regions) using the parameters specified in options.
+    name: NavigateTo
+  - parameters:
+    - name: u
+      type: number
+      comment: Horizontal (U) offset, typically in the interval [-1.0, 1.0].
+    - name: v
+      type: number
+      comment: Vertical (V) offset, typically in the interval [-1.0, 1.0].
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the texture horizontal (u) and vertical (v) offsets for the chosen
+      face. If face is ALL_SIDES, offsets all faces.
+    name: OffsetTexture
+  - parameters:
+    - name: floater_name
+      type: string
+      comment: Identifier string of the viewer floater to open.
+    - name: url
+      type: string
+      comment: URL to load within the opened floater.
+    - name: params
+      type: list
+      comment: Options or parameters to apply to the opened floater.
+    return-type: number
+    comment: Opens the specified viewer floater_name loaded with url and configured
+      via params. Returns an integer error code, or 0 if successful.
+    name: OpenFloater
+  - comment: Deprecated. Creates a channel to listen for incoming XML-RPC calls, triggering
+      a remote_data event with the channel ID once available.
+    name: OpenRemoteDataChannel
+    deprecated: true
+  - parameters:
+    - name: val
+      type: string
+      comment: Source string containing the character.
+    - name: index
+      type: number
+      comment: Zero-based index of the character to convert.
+    return-type: number
+    comment: Returns the integer Unicode (ordinal) value of the character at index
+      in the string val.
+    name: Ord
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the group, avatar, or object to check.
+    return-type: boolean
+    comment: Returns TRUE if the avatar or object specified by key id is over land
+      owned by the script owner, or FALSE otherwise.
+    name: OverMyLand
+    must-use: true
+  - parameters:
+    - name: msg
+      type: string
+      comment: Text message string to send.
+    comment: Sends the chat message msg privately to the object owner (the owner must
+      be currently in the same region for the message to be received).
+    name: OwnerSay
+    deprecated:
+      use: print
+      selene-replace:
+      - print(%...)
+  - parameters:
+    - name: commandList
+      type: list
+      comment: A list containing integer PARCEL_MEDIA_COMMAND_* flags and their corresponding
+        parameters.
+    comment: Controls the playback of movies and other multimedia resources on a parcel
+      or for an agent, using the PARCEL_MEDIA_COMMAND_* settings specified in commandList.
+    name: ParcelMediaCommandList
+  - parameters:
+    - name: query
+      type: '{number}'
+      comment: A list of PARCEL_MEDIA_COMMAND_* attributes to query.
+    return-type: '{any}'
+    comment: Queries the media properties of the parcel containing the script, returning
+      a list of values in the order requested by query. Only works if the object is
+      owned by the landowner or deeded to the land's group.
+    name: ParcelMediaQuery
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to parse.
+    - name: separators
+      type: '{string}'
+      comment: A list of up to 8 strings representing separators to be discarded.
+    - name: spacers
+      type: '{string}'
+      comment: A list of up to 8 strings representing spacers to be preserved in the
+        list.
+    return-type: '{string}'
+    comment: Breaks the string src into a list of substrings, discarding any separators,
+      keeping spacers, and omitting any empty null values. separators and spacers
+      accept up to 8 string entries each.
+    name: ParseString2List
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to parse.
+    - name: separators
+      type: '{string}'
+      comment: A list of up to 8 strings representing separators to be discarded.
+    - name: spacers
+      type: '{string}'
+      comment: A list of up to 8 strings representing spacers to be preserved in the
+        list.
+    return-type: '{string}'
+    comment: Breaks the string src into a list, discarding separators and keeping
+      spacers, while preserving empty null values (unlike llParseString2List). separators
+      and spacers accept up to 8 string entries each.
+    name: ParseStringKeepNulls
+    must-use: true
+  - parameters:
+    - name: rules
+      type: list
+      comment: A list of particle system rules and data pairs [rule1, data1, ...].
+    comment: Creates or updates a particle system on the prim containing the script
+      based on rules. An empty list removes the particle system.
+    name: ParticleSystem
+  - parameters:
+    - name: pass
+      type: boolean | number
+      comment: A PASS_* flag (e.g., PASS_ALWAYS, PASS_IF_NOT_HANDLED, or PASS_NEVER).
+    comment: Sets the pass-collisions attribute. If pass is TRUE, collision events
+      are passed from child prims to the root; if FALSE (default), they only trigger
+      events in the affected child prim.
+    name: PassCollisions
+  - parameters:
+    - name: pass
+      type: boolean | number
+      comment: A PASS_* flag (e.g., PASS_ALWAYS, PASS_IF_NOT_HANDLED, or PASS_NEVER).
+    comment: Sets the pass-touches attribute. If pass is TRUE, touch events are passed
+      from child prims to the root; if FALSE (default), they only trigger events in
+      the affected child prim.
+    name: PassTouches
+  - parameters:
+    - name: patrolPoints
+      type: '{vector}'
+      comment: A list of at least two position vectors representing the patrol path.
+    - name: options
+      type: list
+      comment: A list of PATROL_* flags and parameters to configure the patrol behavior.
+    comment: Directs a pathfinding character to patrol sequentially through the coordinates
+      specified in patrolPoints, configured by options.
+    name: PatrolPoints
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the specified sound once at volume, attached to the object. Only
+      one sound can be attached to a prim at a time; new sounds or calling llStopSound
+      stops previous playback. A second call with the same sound adjusts the volume
+      without restarting it.
+    name: PlaySound
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound once at volume, synchronized to the next loop
+      point of the most audible active Sync Master.
+    name: PlaySoundSlave
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector to point at.
+    comment: Directs the avatar owning the object to point at the vector pos.
+    name: PointAt
+    deprecated: true
+  - parameters:
+    - name: base
+      type: number
+      comment: Base float value.
+    - name: exponent
+      type: number
+      comment: Exponent float value.
+    return-type: number
+    comment: Returns a float representing base raised to the power exponent. Returns
+      0 and triggers a Math Error for imaginary results.
+    name: Pow
+    deprecated:
+      reason: Double precision; operator.
+      use: ^
+      selene-replace:
+      - '%1 ^ %2'
+      - math.pow(%...)
+      - math.exp(%2)
+    must-use: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of the sound in the prim's inventory, or a UUID.
+    comment: Causes nearby viewers in range to preload the specified sound from the
+      object's inventory to prevent playback delays.
+    name: PreloadSound
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the group, avatar, or object to pursue.
+    - name: options
+      type: list
+      comment: A list of options to configure pursuit behavior.
+    comment: Directs a pathfinding character to pursue and chase target, configured
+      by the parameters specified in options.
+    name: Pursue
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target avatar or object in the same region.
+    - name: impulse
+      type: vector
+      comment: Linear impulse vector representing the direction and force of the push.
+    - name: ang_impulse
+      type: vector
+      comment: Angular impulse vector representing the rotational force.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, forces are applied relative to the target's local
+        axes; if FALSE, relative to region axes.
+    comment: Applies physical impulse (force) and ang_impulse (rotational force) to
+      the specified target avatar or object.
+    name: PushObject
+  - parameters:
+    - name: k
+      type: string
+      comment: Key of the key-value pair to read.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to read the value associated with
+      key k in the experience. Returns a key query handle for the dataserver event.
+      Fails with XP_ERROR_KEY_NOT_FOUND if the key does not exist.
+    name: ReadKeyValue
+  - comment: Legacy function intended to reload the web page displayed on the prim's
+      faces (currently non-functional).
+    name: RefreshPrimURL
+    deprecated:
+      use: ll.SetPrimMediaParams
+  - parameters:
+    - name: channel
+      type: number
+      comment: Output chat channel to broadcast on (must be non-zero).
+    - name: msg
+      type: string
+      comment: Text message string to broadcast.
+    comment: Broadcasts the message msg on channel to the entire region (heard by
+      any script listening on that channel; channel 0 is not permitted).
+    name: RegionSay
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the destination avatar or prim in the same region.
+    - name: channel
+      type: number
+      comment: Output chat channel (any integer value).
+    - name: msg
+      type: string
+      comment: Text message string to send.
+    comment: Sends the message msg on channel privately to the targeted avatar or
+      object (if within the region). If target is an avatar and channel is non-zero,
+      the message can also be heard by any attachments worn by the avatar.
+    name: RegionSayTo
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    comment: Deprecated. Intended to return camera control back to the avatar (use
+      llClearCameraParams instead).
+    name: ReleaseCamera
+    deprecated:
+      use: ll.ClearCameraParams
+      selene-replace:
+      - ll.ClearCameraParams()
+  - comment: Stops taking inputs (previously acquired via llTakeControls) from the
+      avatar, dequeuing any remaining control events and revoking the PERMISSION_TAKE_CONTROLS
+      permission.
+    name: ReleaseControls
+  - parameters:
+    - name: url
+      type: string
+      comment: URL string to release.
+    comment: Releases the specified url (previously obtained via llRequestURL), rendering
+      it no longer usable.
+    name: ReleaseURL
+  - parameters:
+    - name: channel
+      type: uuid
+      comment: XML-RPC channel ID.
+    - name: message_id
+      type: uuid
+      comment: XML-RPC message ID.
+    - name: sdata
+      type: string
+      comment: String payload data to reply with.
+    - name: idata
+      type: number
+      comment: Integer payload data to reply with.
+    comment: Deprecated. Sends an XML-RPC reply on channel to message_id with payload
+      string sdata and integer idata.
+    name: RemoteDataReply
+    deprecated: true
+  - comment: Deprecated. Used with XML-RPC to reregister remote data channels if the
+      object moves to another region.
+    name: RemoteDataSetRegion
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target prim.
+    - name: name
+      type: string
+      comment: Name of the script in the prim's inventory.
+    - name: running
+      type: number
+      comment: Whether the script should start running.
+    - name: start_param
+      type: number
+      comment: Start parameter passed to the script.
+    comment: Deprecated.
+    name: RemoteLoadScript
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target prim in the same region.
+    - name: name
+      type: string
+      comment: Name of the script in the prim's inventory.
+    - name: pin
+      type: number
+      comment: Integer PIN code (must match the PIN set on the target via llSetRemoteScriptAccessPin).
+    - name: running
+      type: boolean | number
+      comment: Boolean. If TRUE, sets the copied script to run immediately; if FALSE,
+        leaves it stopped.
+    - name: start_param
+      type: number
+      comment: Integer start parameter passed to the copied script (readable via llGetStartParameter).
+    comment: Copies the script name into target, setting it running (if running is
+      TRUE) with the start_param, provided the script owner has modify permissions
+      on target and target's PIN matches pin (set via llSetRemoteScriptAccessPin).
+    name: RemoteLoadScriptPin
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to remove.
+    comment: Removes the specified avatar from the land parcel's ban list.
+    name: RemoveFromLandBanList
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to remove.
+    comment: Removes the specified avatar from the land parcel's pass/access list.
+    name: RemoveFromLandPassList
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory to remove.
+    comment: Permanently deletes the named inventory item from the prim's inventory.
+    name: RemoveInventory
+  - parameters:
+    - name: flags
+      type: number
+      comment: A bitwise mask of VEHICLE_FLAG_* constants to disable.
+    comment: Disables the specified vehicle flags (sets them to FALSE) using the bitwise
+      mask flags.
+    name: RemoveVehicleFlags
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of an agent in the region participating in the experience.
+    - name: transition
+      type: number
+      comment: Duration in seconds over which to transition to the new environment.
+    - name: environment
+      type: string | uuid
+      comment: Name of an environmental setting in inventory, or its asset UUID (or
+        empty string/NULL_KEY to clear).
+    return-type: number
+    comment: Replaces the region and parcel environment seen by the specified agent_id
+      as part of an experience, transitioning the settings over transition seconds.
+      Passing NULL_KEY or an empty string for environment restores defaults.
+    name: ReplaceAgentEnvironment
+  - parameters:
+    - name: position
+      type: vector
+      comment: Position vector of the target parcel (the Z component is ignored; use
+        <-1.0, -1.0, -1.0> for the entire region).
+    - name: environment
+      type: string | uuid
+      comment: Name of an environmental setting in inventory, or its asset UUID (or
+        empty string/NULL_KEY to clear).
+    - name: track_no
+      type: number
+      comment: 'The elevation track to change (0: water, 1: ground, 2: 1000m, 3: 2000m,
+        4: 3000m, -1: all tracks).'
+    - name: day_length
+      type: number
+      comment: Day cycle length in seconds (-1 to leave unchanged).
+    - name: day_offset
+      type: number
+      comment: Day cycle offset in seconds from UTC (-1 to leave unchanged).
+    return-type: number
+    comment: Replaces the environment on the parcel containing position (or the entire
+      region if position is <-1.0, -1.0, -1.0>) for the specified track_no. Modifies
+      day_length and day_offset if specified. Requires edit permissions on the parcel
+      or estate management rights.
+    name: ReplaceEnvironment
+  - parameters:
+    - name: src
+      type: string
+      comment: Original source string to search.
+    - name: pattern
+      type: string
+      comment: Substring pattern to find and replace.
+    - name: replacement_pattern
+      type: string
+      comment: New substring used to replace the pattern.
+    - name: count
+      type: number
+      comment: Maximum number of replacements to make (0 for all, positive for left-to-right,
+        negative for right-to-left).
+    return-type: string
+    comment: Returns a new string representing src with count occurrences of pattern
+      replaced by replacement_pattern. Setting count to 0 replaces all occurrences;
+      positive counts process left-to-right, while negative counts process right-to-left.
+    name: ReplaceSubString
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the agent.
+    - name: data
+      type: number
+      comment: DATA_* category flag of the requested information.
+    return-type: uuid
+    comment: Asynchronously requests the specified data category (DATA_*) about the
+      agent id. Triggers a dataserver event with the results and returns a key query
+      handle.
+    name: RequestAgentData
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar to query.
+    return-type: uuid
+    comment: Asynchronously requests the display name of the agent specified by id,
+      triggering a dataserver event with the results. The agent does not need to be
+      online or in the region. Returns a key query handle.
+    name: RequestDisplayName
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the agent to request permissions from.
+    - name: name
+      type: string
+      comment: Deprecated parameter (no longer used).
+    comment: Requests permission from the specified agent to participate in the experience.
+      These permissions are persistent and apply grid-wide across all scripts in the
+      experience, automatically triggering experience_permissions or experience_permissions_denied.
+    name: RequestExperiencePermissions
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: uuid
+    comment: Asynchronously requests data for the inventory item specified by name,
+      triggering a dataserver event. Currently, only landmark items are supported
+      (which return local region coordinates). Returns a key query handle.
+    name: RequestInventoryData
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the agent in the same region.
+    - name: permissions
+      type: number
+      comment: Bitfield containing the PERMISSION_* constants to request.
+    comment: Requests permissions (a bitfield specified by permissions) from the agent
+      in the same region, calling run_time_permissions if granted. This call does
+      not pause script execution.
+    name: RequestPermissions
+  - return-type: uuid
+    comment: Asynchronously requests one secure HTTPS (SSL, port 12043) URL for use
+      by this object, triggering an http_request event. Returns a key query handle.
+    name: RequestSecureURL
+  - parameters:
+    - name: region
+      type: string
+      comment: Case-sensitive region name.
+    - name: data
+      type: number
+      comment: DATA_SIM_* flag of the requested simulator data.
+    return-type: uuid
+    comment: Asynchronously requests data (using a DATA_SIM_* constant) about the
+      region. Triggers a dataserver event and returns a key query handle.
+    name: RequestSimulatorData
+  - return-type: uuid
+    comment: Asynchronously requests one HTTP URL for use by this script, triggering
+      an http_request event. Returns a key query handle.
+    name: RequestURL
+  - parameters:
+    - name: username
+      type: string
+      comment: Current or historical username of the avatar to resolve.
+    return-type: uuid
+    comment: Asynchronously requests the Agent ID key (UUID) for the agent specified
+      by their current or historical username, returning NULL_KEY if not found. Returns
+      a key query handle for the dataserver event.
+    name: RequestUserKey
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar to query.
+    return-type: uuid
+    comment: Asynchronously requests the unique single-word username of the agent
+      identified by id, triggering a dataserver event. The agent does not need to
+      be online or in the region. Returns a key query handle.
+    name: RequestUsername
+  - parameters:
+    - name: anim_state
+      type: string
+      comment: Animation state string (or 'ALL') to reset.
+    comment: Resets the animation override for anim_state to its default value (use
+      'ALL' to reset all states). Requires the PERMISSION_OVERRIDE_ANIMATIONS permission.
+    name: ResetAnimationOverride
+  - comment: Removes all blocked residents from the land parcel's ban list.
+    name: ResetLandBanList
+  - comment: Removes all residents from the land parcel's access/pass list.
+    name: ResetLandPassList
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the target script in the prim's inventory.
+    comment: Resets the script name located in the prim's inventory.
+    name: ResetOtherScript
+  - comment: Resets the current script.
+    name: ResetScript
+  - parameters:
+    - name: objects
+      type: '{uuid}'
+      comment: A list of object UUID keys to return.
+    return-type: number
+    comment: Returns objects specified by the list of UUIDs objects to their owners.
+      Requires the PERMISSION_RETURN_OBJECTS permission, and the script owner must
+      own the parcel or be an estate manager/region owner.
+    name: ReturnObjectsByID
+  - parameters:
+    - name: owner
+      type: uuid
+      comment: UUID of the avatar or group whose objects will be returned.
+    - name: scope
+      type: number
+      comment: OBJECT_RETURN_* scope flag (such as OBJECT_RETURN_PARCEL, OBJECT_RETURN_PARCEL_OWNER,
+        or OBJECT_RETURN_REGION).
+    return-type: number
+    comment: Returns objects owned by owner within the specified scope (parcel, parcel
+      owner, or region). Requires the PERMISSION_RETURN_OBJECTS permission, and the
+      script owner must own the parcel or be an estate manager/region owner.
+    name: ReturnObjectsByOwner
+  - parameters:
+    - name: inventory
+      type: string
+      comment: Name of the object in the prim's inventory.
+    - name: position
+      type: vector
+      comment: Position vector in region coordinates where the root of the object
+        will be placed.
+    - name: velocity
+      type: vector
+      comment: Initial velocity vector for the rezzed object.
+    - name: rot
+      type: quaternion
+      comment: Initial rotation of the rezzed object.
+    - name: param
+      type: number
+      comment: Start parameter passed to the rezzed object's on_rez event (accessible
+        via llGetStartParameter).
+    comment: Instantiates the inventory object at position moving at velocity, rotated
+      to rot with its root prim centered exactly on position, passing param as the
+      on_rez start parameter.
+    name: RezAtRoot
+  - parameters:
+    - name: inventory
+      type: string
+      comment: Name of the object in the prim's inventory.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates where the center of the object
+        will be placed.
+    - name: vel
+      type: vector
+      comment: Initial velocity vector (maximum magnitude ~200m/s).
+    - name: rot
+      type: quaternion
+      comment: Initial rotation of the rezzed object.
+    - name: param
+      type: number
+      comment: Start parameter passed to the rezzed object's on_rez event (accessible
+        via llGetStartParameter).
+    comment: Instantiates the inventory object at pos with velocity vel and rotation
+      rot, passing param as the on_rez start parameter. The vel parameter is ignored
+      if the rezzed object is non-physical.
+    name: RezObject
+  - parameters:
+    - name: inventory
+      type: string
+      comment: Name of the object in the prim's inventory.
+    - name: params
+      type: list
+      comment: A list of REZ_* parameters to configure the rezzed object's attributes.
+    return-type: uuid
+    comment: Instantiates the inventory object (defaulting to the rezzing prim's position
+      unless REZ_POS is specified) using the initial set of parameters specified in
+      params. Returns the key of the rezzed object, or a blank key on failure.
+    name: RezObjectWithParams
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Rotation value.
+    return-type: number
+    comment: Returns a float representing the rotation angle of rot.
+    name: Rot2Angle
+    must-use: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a vector representing the rotation axis of rot.
+    name: Rot2Axis
+    must-use: true
+  - parameters:
+    - name: quat
+      type: quaternion
+      comment: Rotation value to convert.
+    return-type: vector
+    comment: Returns a vector representing the Euler rotation (roll, pitch, yaw) of
+      quat, with each component expressed in radians.
+    name: Rot2Euler
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a unit vector pointing in the local positive X direction (forward)
+      relative to the parent (root prim or region) defined by rotation q.
+    name: Rot2Fwd
+    deprecated:
+      use: quaternion.tofwd
+      selene-replace:
+      - quaternion.tofwd(%1)
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a unit vector pointing in the local positive Y direction (left)
+      relative to the parent (root prim or region) defined by rotation q.
+    name: Rot2Left
+    deprecated:
+      use: quaternion.toleft
+      selene-replace:
+      - quaternion.toleft(%1)
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a unit vector pointing in the local positive Z direction (up)
+      relative to the parent (root prim or region) defined by rotation q.
+    name: Rot2Up
+    deprecated:
+      use: quaternion.toup
+      selene-replace:
+      - quaternion.toup(%1)
+    must-use: true
+  - parameters:
+    - name: start
+      type: vector
+      comment: Starting vector.
+    - name: end
+      type: vector
+      comment: Target ending vector.
+    return-type: quaternion
+    comment: Returns a rotation representing the shortest path rotation from vector
+      start to vector end.
+    name: RotBetween
+    must-use: true
+  - parameters:
+    - name: target_direction
+      type: quaternion
+      comment: Target rotation to align the object with.
+    - name: strength
+      type: number
+      comment: Force of rotation (0.0 cancels the tracking; values around half the
+        object's mass are typical).
+    - name: damping
+      type: number
+      comment: Timescale in seconds to critically damp the rotation.
+    comment: Causes the object to smoothly rotate to target_direction with a force
+      defined by strength and damping. A strength of 0.0 cancels the rotation target.
+      Rotation is maintained until stopped with llStopLookAt.
+    name: RotLookAt
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Target rotation to track.
+    - name: error
+      type: number
+      comment: Tolerance angle in radians defining when the target rotation is considered
+        reached.
+    return-type: number
+    comment: Registers the rotation rot with a leeway tolerance error (in radians)
+      as a target, triggering at_rot_target and not_at_rot_target events. Returns
+      an integer handle to unregister the target via llRotTargetRemove.
+    name: RotTarget
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer target handle returned by llRotTarget to remove.
+    comment: Removes the rotational target specified by the integer handle registered
+      with llRotTarget.
+    name: RotTargetRemove
+  - parameters:
+    - name: angle
+      type: number
+      comment: Rotation angle expressed in radians.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the texture rotation of face to the specified angle (in radians).
+      If face is ALL_SIDES, rotates the texture on all faces.
+    name: RotateTexture
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to round.
+    return-type: number
+    comment: Returns the integer that float val is closest to.
+    name: Round
+    deprecated:
+      reason: Fastcall.
+      use: math.round
+      selene-replace:
+      - math.round(%...)
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to hash.
+    return-type: string
+    comment: Returns a string of 40 hex characters representing the SHA-1 security
+      hash of src.
+    name: SHA1String
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to hash.
+    return-type: string
+    comment: Returns a string of 64 hex characters representing the SHA-256 security
+      hash of src.
+    name: SHA256String
+    must-use: true
+  - parameters:
+    - name: uuid
+      type: uuid
+      comment: UUID of the group, avatar, or prim to check.
+    return-type: boolean
+    comment: Returns TRUE if the agent or object specified by uuid is in the same
+      region (simulator) and shares the same active group as the prim containing the
+      script; returns FALSE otherwise.
+    name: SameGroup
+    must-use: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Integer chat channel to transmit the message on.
+    - name: msg
+      type: string
+      comment: Text message string to transmit.
+    comment: Says the text message msg on the specified channel. The message can be
+      heard up to a 20m radius. Channels other than PUBLIC_CHANNEL (0) and DEBUG_CHANNEL
+      (2147483647) are not visible to avatars and can be used for script-to-script
+      communication.
+    name: Say
+  - parameters:
+    - name: scaling_factor
+      type: number
+      comment: Multiplier scale factor to apply to the prim sizes and their local
+        positions.
+    return-type: boolean
+    comment: Attempts to uniformly resize the entire object by scaling_factor, maintaining
+      size-position ratios of the prims. Fails if the linkset is physical, a pathfinding
+      character, in keyframed motion, would exceed prim scale/linkability limits,
+      or would overflow parcel capacity.
+    name: ScaleByFactor
+  - parameters:
+    - name: u
+      type: number
+      comment: Horizontal (U) texture repeats scale value, in the interval [-100.0,
+        100.0].
+    - name: v
+      type: number
+      comment: Vertical (V) texture repeats scale value, in the interval [-100.0,
+        100.0].
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the diffuse texture horizontal u and vertical v scales (repeats)
+      on the specified face of the prim. Setting face to ALL_SIDES updates all sides.
+      Negative scale values flip the texture.
+    name: ScaleTexture
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates to check.
+    return-type: boolean
+    comment: Returns TRUE if the vector position pos is over public land, sandbox
+      land, land restricting edit/build permissions, or land that disables outside
+      scripts.
+    name: ScriptDanger
+    must-use: true
+  - parameters:
+    - name: flags
+      type: number
+      comment: PROFILE_* flag (such as PROFILE_NONE or PROFILE_SCRIPT_MEMORY) to set
+        the profiling state.
+    comment: Enables or disables the script's profiling state using flags (supports
+      PROFILE_SCRIPT_MEMORY on Mono, or PROFILE_NONE). Active profiling can significantly
+      reduce script performance.
+    name: ScriptProfiler
+  - parameters:
+    - name: channel
+      type: uuid
+      comment: XML-RPC channel ID.
+    - name: dest
+      type: string
+      comment: Destination XML-RPC URL or server.
+    - name: idata
+      type: number
+      comment: Integer payload data.
+    - name: sdata
+      type: string
+      comment: String payload data.
+    return-type: uuid
+    comment: Deprecated. Sends an XML-RPC request to dest on channel, containing the
+      channel ID as a string, integer idata, and string sdata. Returns a key representing
+      the message_id.
+    name: SendRemoteData
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Specific object or avatar name to filter for (or empty string for no
+        filter).
+    - name: id
+      type: uuid
+      comment: UUID of the group, avatar, or object to filter by (or NULL_KEY for
+        no filter).
+    - name: type
+      type: number
+      comment: Integer bitfield type mask containing AGENT, AGENT_BY_LEGACY_NAME,
+        AGENT_BY_USERNAME, ACTIVE, PASSIVE, or SCRIPTED (0 for no filter).
+    - name: radius
+      type: number
+      comment: Maximum distance in meters to scan (range [0.0, 96.0]).
+    - name: arc
+      type: number
+      comment: Maximum angle in radians relative to the local X-axis to scan (range
+        [0.0, PI]).
+    comment: Performs a single scan from the prim's forward vector for name and id
+      of type within radius meters and arc radians. Results trigger a sensor or no_sensor
+      event. Passing empty filters (blank name, 0 type, or NULL_KEY id) disables that
+      filter.
+    name: Sensor
+  - comment: Removes the periodic sensor previously configured by llSensorRepeat.
+    name: SensorRemove
+  - parameters:
+    - name: name
+      type: string
+      comment: Specific object or avatar name to filter for (or empty string for no
+        filter).
+    - name: id
+      type: uuid
+      comment: UUID of the group, avatar, or object to filter by (or NULL_KEY for
+        no filter).
+    - name: type
+      type: number
+      comment: Integer bitfield type mask containing AGENT, AGENT_BY_LEGACY_NAME,
+        AGENT_BY_USERNAME, ACTIVE, PASSIVE, or SCRIPTED (0 for no filter).
+    - name: radius
+      type: number
+      comment: Maximum distance in meters to scan (range [0.0, 96.0]).
+    - name: arc
+      type: number
+      comment: Maximum angle in radians relative to the local X-axis to scan (range
+        [0.0, PI]).
+    - name: rate
+      type: number
+      comment: Interval in seconds between repeated scans.
+    comment: Sets up a repeating periodic scan every rate seconds for name and id
+      of type within radius meters and arc radians of the forward vector. Results
+      trigger sensor or no_sensor events.
+    name: SensorRepeat
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the agent participating in the experience.
+    - name: transition
+      type: number
+      comment: Transition duration in seconds.
+    - name: params
+      type: list
+      comment: A list of environmental parameters to apply.
+    return-type: number
+    comment: Sets an individual agent's environmental settings using the attributes
+      in params over a duration of transition seconds. Must be used as part of an
+      experience; passing an empty list removes overrides.
+    name: SetAgentEnvironment
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Target rotation to turn the avatar to face.
+    - name: flags
+      type: number
+      comment: Flags to configure the rotation behavior.
+    comment: Sets the rotation of the avatar to rot, controlled by flags.
+    name: SetAgentRot
+  - parameters:
+    - name: alpha
+      type: number
+      comment: Transparency value to set, from 0.0 (clear) to 1.0 (solid; clamped
+        to a minimum of 0.1).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the diffuse texture alpha (opacity) of face. If face is ALL_SIDES,
+      applies to all faces. Values are clamped between 0.1 and 1.0 (where 1.0 is fully
+      opaque).
+    name: SetAlpha
+  - parameters:
+    - name: initial_omega
+      type: vector
+      comment: Angular velocity vector to apply (in radians per second).
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, initial_omega is treated as a local vector; if FALSE,
+        as a global region vector.
+    comment: Sets the angular velocity of a physical object to initial_omega (mass-independent).
+      If local is TRUE, applied in local coordinates; if FALSE, applied in global
+      coordinates. Has no effect on non-physical objects.
+    name: SetAngularVelocity
+  - parameters:
+    - name: anim_state
+      type: string
+      comment: Animation state to override.
+    - name: anim
+      type: string
+      comment: Name of an animation in the prim's inventory, or a built-in animation
+        name.
+    comment: Overrides the default animation for anim_state with anim (which must
+      be in the object's inventory or a built-in animation). Requires the PERMISSION_OVERRIDE_ANIMATIONS
+      permission.
+    name: SetAnimationOverride
+  - parameters:
+    - name: buoyancy
+      type: number
+      comment: Float buoyancy value to set.
+    comment: Sets the buoyancy of a physical object (requires physics to be enabled).
+      A value of 0.0 offers no buoyancy, < 1.0 sinks, 1.0 counteracts gravity, and
+      > 1.0 rises.
+    name: SetBuoyancy
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset position vector in local coordinates relative to the prim.
+    comment: Sets the target offset vector (in local coordinates) that a seated avatar's
+      camera will look at.
+    name: SetCameraAtOffset
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset position vector in local coordinates relative to the prim.
+    comment: Sets the eye offset vector (in local coordinates) where a seated avatar's
+      camera is positioned.
+    name: SetCameraEyeOffset
+  - parameters:
+    - name: rules
+      type: list
+      comment: A strided list of rules and data pairs configuring the camera.
+    comment: Sets multiple camera parameters simultaneously using the list of rules.
+      Requires the PERMISSION_CONTROL_CAMERA runtime permission.
+    name: SetCameraParams
+  - parameters:
+    - name: action
+      type: number
+      comment: CLICK_ACTION_* flag representing the action to apply.
+    comment: Sets the action (a CLICK_ACTION_* flag) performed when an avatar left-clicks
+      the prim.
+    name: SetClickAction
+  - parameters:
+    - name: color
+      type: vector
+      comment: Color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the Blinn-Phong diffuse RGB color of face. If face is ALL_SIDES,
+      applies the color to all faces.
+    name: SetColor
+  - parameters:
+    - name: request_id
+      type: uuid
+      comment: Unique key identifying the incoming HTTP request.
+    - name: content_type
+      type: number
+      comment: CONTENT_TYPE_* constant representing the Internet media type to use.
+    comment: Sets the 'Content-Type' header of subsequent HTTP server responses (via
+      llHTTPResponse) for request_id using the specified content_type (a CONTENT_TYPE_*
+      constant).
+    name: SetContentType
+  - parameters:
+    - name: damage
+      type: number
+      comment: Float damage value to set (range -100.0 for full heal to 100.0 for
+        instant kill).
+    comment: Sets the amount of damage delivered when this object hits an avatar.
+      The object is immediately destroyed upon inflicting damage, and no collision
+      event is triggered.
+    name: SetDamage
+  - parameters:
+    - name: position
+      type: vector
+      comment: Position vector in region coordinates to specify the target parcel,
+        or <-1.0, -1.0, z> for the entire region (where z specifies the sky track,
+        or -1 for all tracks).
+    - name: params
+      type: list
+      comment: A list of environmental attributes and values to apply (or empty to
+        clear).
+    return-type: number
+    comment: Overrides the environmental settings at position for a parcel (or region
+      if position is <-1.0, -1.0, z>) using the parameters in params. Passing an empty
+      params list removes previous overrides.
+    name: SetEnvironment
+  - parameters:
+    - name: experienceid
+      type: uuid
+    return-type: number
+    name: SetExperienceKey
+    deprecated: true
+  - parameters:
+    - name: force
+      type: vector
+      comment: Directional force vector to apply.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, force is treated as a local vector; if FALSE, as
+        a global region vector.
+    comment: Applies a constant linear force to a physical object. If local is TRUE,
+      force is applied relative to local coordinates; if FALSE, applied relative to
+      region coordinates.
+    name: SetForce
+  - parameters:
+    - name: force
+      type: vector
+      comment: Directional linear force vector.
+    - name: torque
+      type: vector
+      comment: Torque rotational force vector.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, force and torque are treated as local vectors; if
+        FALSE, as global region vectors.
+    comment: Sets both the constant linear force and constant torque acting on a physical
+      object. If local is TRUE, forces are applied in local coordinates; if FALSE,
+      in global coordinates.
+    name: SetForceAndTorque
+  - parameters:
+    - name: changes
+      type: list
+      comment: A list of terrain detail properties and values to change.
+    return-type: number
+    comment: Changes the painted terrain textures on the region based on changes.
+      The script owner must have estate management rights. Returns an integer status.
+    name: SetGroundTexture
+  - parameters:
+    - name: height
+      type: number
+      comment: Distance to hover above the ground or water.
+    - name: water
+      type: boolean | number
+      comment: Boolean. If TRUE, hovers above water too; if FALSE, water is ignored.
+    - name: tau
+      type: number
+      comment: Timescale in seconds to critically damp the movement.
+    comment: Critically damps the physical object's vertical movement to hover at
+      height (above ground, or above water if water is TRUE) in tau seconds. Do not
+      use with vehicles; call llStopHover to cancel.
+    name: SetHoverHeight
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    - name: category
+      type: number
+      comment: MASK_* category flag (such as MASK_NEXT, MASK_OWNER, etc.).
+    - name: value
+      type: number
+      comment: Bitfield of permissions (PERM_* flags) to set.
+    comment: Sets the specified permission category of the inventory item to the value
+      permissions mask.
+    name: SetInventoryPermMask
+  - parameters:
+    - name: keyframes
+      type: list
+      comment: A strided list of the form [vector position, rotation orientation,
+        float time] representing sequential relative keyframes (minimum time is 1/9s).
+    - name: options
+      type: list
+      comment: A list of options (KFM_* constants) to modify playback behavior.
+    comment: Smoothly moves a non-physical object between the positions, orientations,
+      and times specified in the keyframes list, configured via options. Collisions
+      with keyframed objects are ignored. An empty keyframes list terminates the motion.
+    name: SetKeyframedMotion
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: alpha
+      type: number
+      comment: Transparency value to set, from 0.0 (clear) to 1.0 (solid).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the Blinn-Phong alpha (transparency) of face on the linked prim
+      link.
+    name: SetLinkAlpha
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: eye
+      type: vector
+      comment: Eye offset position vector in local coordinates relative to the prim.
+    - name: at
+      type: vector
+      comment: Look-at offset position vector in local coordinates relative to the
+        prim.
+    comment: Sets the camera eye position offset eye and looking-at position offset
+      at for avatars who sit on the linked prim link.
+    name: SetLinkCamera
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: color
+      type: vector
+      comment: Color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the Blinn-Phong diffuse RGB color of face on the linked prim link.
+    name: SetLinkColor
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    - name: params
+      type: list
+      comment: A list of overrides and their corresponding values to set.
+    comment: Sets or removes individual GLTF override parameters specified by params
+      on face of the linked prim link.
+    name: SetLinkGLTFOverrides
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: list
+      comment: A set of property-value pairs (in no particular order) specifying media
+        parameters.
+    return-type: number
+    comment: Sets the media parameters specified by params on face of the linked prim
+      link without a script delay. Returns an integer STATUS_* flag detailing success
+      or failure.
+    name: SetLinkMedia
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: rules
+      type: list
+      comment: A list of PRIM_* rules and data to apply.
+    comment: Deprecated (use llSetLinkPrimitiveParamsFast instead). Sets primitive
+      parameters for the linked prim link according to rules.
+    name: SetLinkPrimitiveParams
+    deprecated:
+      use: ll.SetLinkPrimitiveParamsFast
+      selene-replace:
+      - ll.SetLinkPrimitiveParamsFast(%...)
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: rules
+      type: list
+      comment: A list of PRIM_* rules and data to apply.
+    comment: Sets primitive parameters for the linked prim link according to rules
+      with no built-in script sleep delay.
+    name: SetLinkPrimitiveParamsFast
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: material
+      type: string | uuid
+      comment: Name of a material in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: 'Applies material (UUID or inventory name) to face of the linked prim
+      link. Note: This clears most PRIM_GLTF_* properties on the face except for repeats,
+      offsets, and rotation.'
+    name: SetLinkRenderMaterial
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: flags
+      type: number
+      comment: A bitfield of sit flags (SIT_FLAG_*) to apply.
+    comment: Sets the sit target flags for the linked prim link inside the linkset.
+    name: SetLinkSitFlags
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Applies texture (UUID or inventory name) to face of the linked prim link.
+    name: SetLinkTexture
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag to animate.
+    - name: mode
+      type: number
+      comment: Bitfield of texture animation mode flags (ANIM_ON, LOOP, etc.).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    - name: sizex
+      type: number
+      comment: Number of horizontal frames (ignored for ROTATE and SCALE).
+    - name: sizey
+      type: number
+      comment: Number of vertical frames (ignored for ROTATE and SCALE).
+    - name: start
+      type: number
+      comment: Start frame number (or radians for ROTATE).
+    - name: length
+      type: number
+      comment: Number of frames to display (or radians for ROTATE).
+    - name: rate
+      type: number
+      comment: Playback rate in frames per second (or radians/sec for ROTATE, UV coords/sec
+        for SMOOTH). Must not be zero.
+    comment: Animates the texture on face of the linked prim link by setting the scale
+      and offset according to mode. Parameters sizex/sizey define frames, start defines
+      the start frame/angle, length defines duration, and rate defines playback speed.
+    name: SetLinkTextureAnim
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Local rotation to set.
+    comment: Sets the rotation of a child prim relative to its root prim using rot.
+    name: SetLocalRot
+  - parameters:
+    - name: description
+      type: string
+      comment: New description string (up to 127 characters).
+    comment: Sets the description of the prim containing the script to description
+      (limited to 127 characters).
+    name: SetObjectDesc
+  - parameters:
+    - name: name
+      type: string
+      comment: New name string.
+    comment: Sets the name of the prim containing the script to name.
+    name: SetObjectName
+  - parameters:
+    - name: mask
+      type: number
+      comment: MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, etc.).
+    - name: value
+      type: number
+      comment: Bitfield of permissions (PERM_* flags) to set.
+    comment: Sets the specified permission mask category to value on the root object
+      containing the script.
+    name: SetObjectPermMask
+  - parameters:
+    - name: ForSale
+      type: boolean | number
+      comment: Boolean. If TRUE, puts the parcel up for sale; if FALSE, removes it
+        from sale.
+    - name: Options
+      type: list
+      comment: A list of options to configure the sale (e.g., price, authorized buyer,
+        and object inclusion).
+    return-type: number
+    comment: Sets the parcel the object is on for sale. If ForSale is TRUE, puts the
+      land up for sale using Options (price, buyer, objects included). Setting ForSale
+      to FALSE removes the parcel from sale. Requires parcel ownership and the PERMISSION_PRIVILEGED_LAND_ACCESS
+      permission. Returns an error code or 0 if successful.
+    name: SetParcelForSale
+  - parameters:
+    - name: url
+      type: string
+      comment: Streaming audio URL string.
+    comment: Sets the streaming audio (music) URL for the parcel containing the object.
+      The object owner must match the landowner or land group.
+    name: SetParcelMusicURL
+  - parameters:
+    - name: price
+      type: number
+      comment: Default price integer shown in the text field (can accept PAY_* constants
+        or positive values).
+    - name: quick_pay_buttons
+      type: '{number}'
+      comment: A list of four integer values or PAY_* constants specifying the button
+        payment choices.
+    comment: Suggests default amounts for the pay text input field price and the four
+      payment dialog quick_pay_buttons when an avatar pays this object.
+    name: SetPayPrice
+  - parameters:
+    - name: mask
+      type: number
+      comment: Bitwise mask combination specifying which of the floats (DENSITY, FRICTION,
+        RESTITUTION, or GRAVITY_MULTIPLIER) to apply.
+    - name: gravity_multiplier
+      type: number
+      comment: Gravity multiplier float value (range [-1.0, +28.0], default is 1.0).
+    - name: restitution
+      type: number
+      comment: Elasticity restitution float value (range [0.0, 1.0]).
+    - name: friction
+      type: number
+      comment: Friction coefficient float value (range [0.0, 255.0]).
+    - name: density
+      type: number
+      comment: "Density float value in kg/m\xB3 (range [1.0, 22587.0])."
+    comment: Configures the physical characteristics of an object. The mask bitfield
+      specifies which of the other parameters (gravity_multiplier, restitution, friction,
+      or density) should be applied to the object.
+    name: SetPhysicsMaterial
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector to move to (in region coordinates, or local coordinates
+        if in a child prim).
+    comment: Moves the non-physical object or prim toward the vector pos (up to 10m).
+      If called in a child prim, pos is treated as root-relative; if called from the
+      root prim, the entire object is moved.
+    name: SetPos
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: list
+      comment: A set of property-value pairs (in no particular order) specifying media
+        parameters.
+    return-type: number
+    comment: Sets the media parameters specified by params on the designated face
+      of the prim. Returns an integer STATUS_* flag detailing success or failure.
+    name: SetPrimMediaParams
+  - parameters:
+    - name: url
+      type: string
+      comment: Web URL to display.
+    comment: Deprecated (use llSetPrimMediaParams instead). Updates the URL displayed
+      on the prim's faces.
+    name: SetPrimURL
+    deprecated:
+      use: ll.SetPrimMediaParams
+      selene-replace:
+      - ll.SetPrimMediaParams(ALL_SIDES, {PRIM_MEDIA_CURRENT_URL, %1})
+  - parameters:
+    - name: rules
+      type: list
+      comment: A list of PRIM_* rules and data to apply.
+    comment: Deprecated (use llSetLinkPrimitiveParamsFast instead). Sets the prim's
+      attributes according to rules.
+    name: SetPrimitiveParams
+    deprecated:
+      use: ll.SetLinkPrimitiveParamsFast
+      selene-replace:
+      - ll.SetLinkPrimitiveParamsFast(%...)
+  - parameters:
+    - name: position
+      type: vector
+      comment: Target position vector in region coordinates (can cross up to 10m over
+        a region border).
+    return-type: boolean
+    comment: Tries to move the entire object so that its root prim is within 0.1m
+      of the vector position (underground positions are set to ground level). Returns
+      TRUE on success or FALSE on failure.
+    name: SetRegionPos
+  - parameters:
+    - name: pin
+      type: number
+      comment: Integer PIN code (non-zero enables, zero disables).
+    comment: Sets the prim's remote script access PIN to pin (a non-zero value enables
+      loading via llRemoteLoadScriptPin, while zero disables it).
+    name: SetRemoteScriptAccessPin
+  - parameters:
+    - name: material
+      type: string | uuid
+      comment: Name of a material in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: 'Applies material (UUID or inventory name) to face of the prim. Note:
+      This clears most PRIM_GLTF_* properties on the face except for repeats, offsets,
+      and rotation.'
+    name: SetRenderMaterial
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Target rotation.
+    comment: Sets the rotation of the prim to rot. If in a child prim, rot is treated
+      as root-relative; if in the root prim of a non-physical object, rotates the
+      entire object.
+    name: SetRot
+  - parameters:
+    - name: size
+      type: vector
+      comment: Target size vector.
+    comment: Sets the physical scale (dimensions) of the prim containing the script
+      to size.
+    name: SetScale
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the script in the prim's inventory.
+    - name: running
+      type: boolean | number
+      comment: Boolean. If TRUE, enables the script; if FALSE, disables it.
+    comment: Sets the running state of the script name in the prim's inventory. If
+      running is TRUE, the script is enabled; if FALSE, it is disabled.
+    name: SetScriptState
+  - parameters:
+    - name: text
+      type: string
+      comment: Context menu text to display.
+    comment: Displays the string text instead of 'Sit' (or 'Sit Here') in the viewer's
+      right-click context menu.
+    name: SetSitText
+  - parameters:
+    - name: queue
+      type: boolean | number
+      comment: Boolean. If TRUE, sound queuing is enabled; if FALSE, it is disabled.
+    comment: Sets whether attached sounds wait for the current sound to end before
+      playing (enables queuing if queue is TRUE, disables if FALSE). The queue is
+      one level deep.
+    name: SetSoundQueueing
+  - parameters:
+    - name: radius
+      type: number
+      comment: Maximum distance in meters at which the sounds can be heard.
+    comment: Limits the audibility radius of attached and triggered scripted sounds
+      to distance radius.
+    name: SetSoundRadius
+  - parameters:
+    - name: status
+      type: number
+      comment: Bitmask representing the STATUS_* flag(s) to change.
+    - name: value
+      type: boolean | number
+      comment: Boolean. If TRUE, enables the status; if FALSE, disables it.
+    comment: Sets the object status attributes specified by status to value.
+    name: SetStatus
+  - parameters:
+    - name: text
+      type: string
+      comment: Floating text string to display.
+    - name: color
+      type: vector
+      comment: Color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+    - name: alpha
+      type: number
+      comment: Transparency value to set, from 0.0 (clear) to 1.0 (solid).
+    comment: Displays floating text above the prim with the specified color vector
+      and transparency alpha.
+    name: SetText
+  - parameters:
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Applies the Blinn-Phong diffuse texture to face of the prim.
+    name: SetTexture
+  - parameters:
+    - name: mode
+      type: number
+      comment: Bitfield of texture animation mode flags (ANIM_ON, LOOP, etc.).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    - name: sizex
+      type: number
+      comment: Number of horizontal frames (ignored for ROTATE and SCALE).
+    - name: sizey
+      type: number
+      comment: Number of vertical frames (ignored for ROTATE and SCALE).
+    - name: start
+      type: number
+      comment: Start frame number (or radians for ROTATE).
+    - name: length
+      type: number
+      comment: Number of frames to display (or radians for ROTATE).
+    - name: rate
+      type: number
+      comment: Playback rate in frames per second (or radians/sec for ROTATE, UV coords/sec
+        for SMOOTH). Must not be zero.
+    comment: Animates the texture on face of the prim by setting its scale and offset.
+      mode defines options, sizex/sizey define frames, start defines the start frame/angle,
+      length defines duration, and rate defines playback speed.
+    name: SetTextureAnim
+  - parameters:
+    - name: torque
+      type: vector
+      comment: Torque rotational force vector.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, torque is treated as a local vector; if FALSE, as
+        a global region vector.
+    comment: Applies a constant torque rotational force to a physical object. If local
+      is TRUE, torque is applied in local coordinates; if FALSE, applied in global
+      coordinates.
+    name: SetTorque
+  - parameters:
+    - name: text
+      type: string
+      comment: Context menu text to display.
+    comment: Displays the string text instead of 'Touch' in the right-click context
+      menu.
+    name: SetTouchText
+  - parameters:
+    - name: flags
+      type: number
+      comment: A bitwise mask of VEHICLE_FLAG_* constants to enable.
+    comment: Enables the vehicle flags specified in the Flags bitmask.
+    name: SetVehicleFlags
+  - parameters:
+    - name: param
+      type: number
+      comment: VEHICLE_* float parameter constant to set.
+    - name: value
+      type: number
+      comment: Float value to set.
+    comment: Sets the specified vehicle float parameter param to value.
+    name: SetVehicleFloatParam
+  - parameters:
+    - name: param
+      type: number
+      comment: VEHICLE_* rotation parameter constant to set.
+    - name: rot
+      type: quaternion
+      comment: Rotation value to set.
+    comment: Sets the specified vehicle rotation parameter param to rot.
+    name: SetVehicleRotationParam
+  - parameters:
+    - name: type
+      type: number
+      comment: VEHICLE_TYPE_* constant to set.
+    comment: Sets the vehicle physics preset type to one of the default vehicle types.
+    name: SetVehicleType
+  - parameters:
+    - name: param
+      type: number
+      comment: VEHICLE_* vector parameter constant to set.
+    - name: vec
+      type: vector
+      comment: Vector value to set.
+    comment: Sets the specified vehicle vector parameter param to vec.
+    name: SetVehicleVectorParam
+  - parameters:
+    - name: velocity
+      type: vector
+      comment: Linear velocity vector to apply (in meters per second).
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, velocity is treated as a local directional vector;
+        if FALSE, as a global region vector.
+    comment: Sets the linear velocity of a physical object to velocity. If local is
+      TRUE, velocity is treated as a local directional vector; if FALSE, as a global
+      region directional vector. Has no effect on non-physical objects.
+    name: SetVelocity
+  - parameters:
+    - name: channel
+      type: number
+      comment: Integer chat channel to shout the message on.
+    - name: msg
+      type: string
+      comment: Text message string to transmit.
+    comment: Shouts the text message msg on the specified channel. The message can
+      be heard up to a 100m radius. All channels other than PUBLIC_CHANNEL (0) and
+      DEBUG_CHANNEL (2147483647) are not sent to avatars and are used to communicate
+      with scripts.
+    name: Shout
+  - parameters:
+    - name: private_key
+      type: string
+      comment: PEM-formatted private key.
+    - name: msg
+      type: string
+      comment: Message contents to sign.
+    - name: algorithm
+      type: string
+      comment: Digest algorithm to use (sha1, sha224, sha256, sha384, or sha512).
+    return-type: string
+    comment: Returns the Base64-encoded RSA signature of msg using the PEM-formatted
+      private_key and the specified digest algorithm (sha1, sha224, sha256, sha384,
+      or sha512). Can be paired with llVerifyRSA to pass verifiable messages.
+    name: SignRSA
+    must-use: true
+  - parameters:
+    - name: theta
+      type: number
+      comment: Angle expressed in radians.
+    return-type: number
+    comment: Returns a float representing the sine of theta.
+    name: Sin
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.sin
+      selene-replace:
+      - math.sin(%...)
+    must-use: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the avatar being forced to sit.
+    - name: link
+      type: number
+      comment: Link number for the prim containing the desired sit target.
+    return-type: number
+    comment: Forces the avatar specified by agent_id (who must be participating in
+      the experience) to sit on the sit target of the prim indicated by link. If occupied,
+      searches down the linkset for an available sit target. Returns an integer.
+    name: SitOnLink
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Target position vector in local prim coordinates.
+    - name: rot
+      type: quaternion
+      comment: Target rotation relative to the prim's rotation.
+    comment: Sets the sit target position (offset) and rotation (rot) relative to
+      the prim's position and orientation. Clears the sit target if offset is ZERO_VECTOR.
+    name: SitTarget
+  - parameters:
+    - name: sec
+      type: number
+      comment: Duration in seconds to put the script to sleep.
+    comment: Puts the script to sleep for sec seconds (at least until the next server-frame,
+      ~0.02222 seconds). The script is inactive during this time. If sec is 0.0 or
+      less, the script does not sleep.
+    name: Sleep
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    - name: queue
+      type: boolean | number
+      comment: Boolean. If TRUE, queues the sound; if FALSE, interrupts the currently
+        playing sound.
+    - name: loop
+      type: boolean | number
+      comment: Boolean. If TRUE, loops the sound.
+    comment: Deprecated (use llPlaySound instead). Plays the specified sound at volume,
+      with options to loop or queue the sound.
+    name: Sound
+    deprecated:
+      use: ll.PlaySound
+      selene-replace:
+      - ll.PlaySound(%1, %2)
+      - ll.LoopSound(%1, %2)
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    comment: Deprecated (use llPreloadSound instead). Preloads the specified sound
+      on viewers within range.
+    name: SoundPreload
+    deprecated:
+      use: ll.PreloadSound
+      selene-replace:
+      - ll.PreloadSound(%1)
+  - parameters:
+    - name: val
+      type: number
+      comment: Positive float value (must be >= 0.0).
+    return-type: number
+    comment: Returns a float representing the square root of the positive value val.
+      Triggers a math runtime error if val is less than 0.0 (imaginary results).
+    name: Sqrt
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.sqrt
+      selene-replace:
+      - math.sqrt(%...)
+    must-use: true
+  - parameters:
+    - name: anim
+      type: string
+      comment: Name of an animation in the prim's inventory, or a built-in animation.
+    comment: Starts the animation anim (inventory or built-in) on the avatar who granted
+      the script the PERMISSION_TRIGGER_ANIMATION permission (automatically granted
+      for attached or sat-on objects).
+    name: StartAnimation
+  - parameters:
+    - name: anim
+      type: string
+      comment: Name of an animation in the current object's inventory.
+    comment: Starts the specified animation anim (inventory or built-in) on the rigged
+      mesh object associated with the current script.
+    name: StartObjectAnimation
+  - parameters:
+    - name: anim
+      type: string | uuid
+      comment: Name of an animation in the prim's inventory, a UUID of an animation,
+        or a built-in animation name.
+    comment: Stops the specified animation anim (inventory, built-in, or UUID) on
+      the avatar who granted the script the PERMISSION_TRIGGER_ANIMATION permission
+      (automatically granted for attached or sat-on objects).
+    name: StopAnimation
+  - comment: Stops the hover behavior (such as that initiated by llSetHoverHeight).
+    name: StopHover
+  - comment: Stops causing the object to look at or point toward a target (canceling
+      llLookAt or llRotLookAt).
+    name: StopLookAt
+  - comment: Stops the critically damped movement of the object toward a target (canceling
+      llMoveToTarget). Use llStopLookAt to stop rotational tracking.
+    name: StopMoveToTarget
+  - parameters:
+    - name: anim
+      type: string | uuid
+      comment: Name of an animation in the current object's inventory, or an animation
+        UUID.
+    comment: Stops the specified animation anim (inventory, built-in, or UUID) on
+      the rigged mesh object associated with the current script.
+    name: StopObjectAnimation
+  - comment: Stops the avatar who owns the object from pointing.
+    name: StopPointAt
+    deprecated: true
+  - comment: Stops playback of the currently playing attached sound.
+    name: StopSound
+  - parameters:
+    - name: str
+      type: string
+      comment: String to measure.
+    return-type: number
+    comment: Returns an integer representing the number of characters in the string
+      str (excluding the null terminator).
+    name: StringLength
+    deprecated:
+      reason: Use 'utf8.len' or '#' or 'string.len' instead.
+      selene-replace:
+      - utf8.len(%1)
+      - '#%1'
+      - string.len(%1)
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: Source string to encode.
+    return-type: string
+    comment: Returns the Base64 representation string of str, interpreting it as a
+      UTF-8 byte sequence.
+    name: StringToBase64
+    deprecated:
+      use: llbase64.encode
+      selene-replace:
+      - llbase64.encode(%1)
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: String to trim.
+    - name: type
+      type: number
+      comment: Trim type flag (STRING_TRIM_HEAD, STRING_TRIM_TAIL, or STRING_TRIM).
+    return-type: string
+    comment: Returns a copy of the string src with leading, trailing, or both types
+      of whitespace (including spaces, tabs, and line feeds) eliminated, according
+      to the specified trim type.
+    name: StringTrim
+    must-use: true
+  - parameters:
+    - name: source
+      type: string
+      comment: Source string to search within.
+    - name: pattern
+      type: string
+      comment: Substring pattern to search for.
+    return-type: number?
+    comment: Returns the zero-based index of the first instance of the pattern substring
+      inside the string source. Returns nil if not found.
+    name: SubStringIndex
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    comment: Deprecated (use llSetCameraParams instead). Formerly used to take control
+      of the agent's camera.
+    name: TakeCamera
+    deprecated:
+      use: ll.SetCameraParams
+  - parameters:
+    - name: controls
+      type: number
+      comment: Bitfield of CONTROL_* flags to intercept.
+    - name: accept
+      type: boolean | number
+      comment: Boolean. Determines whether control events are generated to trigger
+        script handlers.
+    - name: pass_on
+      type: boolean | number
+      comment: Boolean. If TRUE, the keys also perform their default functions; if
+        FALSE, default actions are suppressed.
+    comment: Intercepts inputs (keyboard/mouse clicks) from the agent, specifically
+      those specified by controls. The boolean accept determines if events are generated,
+      and pass_on determines if inputs also perform their default functions. Requires
+      the PERMISSION_TAKE_CONTROLS runtime permission.
+    name: TakeControls
+  - parameters:
+    - name: theta
+      type: number
+      comment: Angle expressed in radians.
+    return-type: number
+    comment: Returns a float representing the tangent of theta.
+    name: Tan
+    deprecated:
+      reason: Double precision; fastcall.
+      use: math.tan
+      selene-replace:
+      - math.tan(%...)
+    must-use: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Target position vector in region coordinates.
+    - name: range
+      type: number
+      comment: Radius tolerance in meters surrounding the target position.
+    return-type: number
+    comment: Registers a positional target at position with a leeway radius range.
+      This triggers at_target and not_at_target events. Returns an integer handle
+      to unregister the target via llTargetRemove.
+    name: Target
+  - parameters:
+    - name: axis
+      type: vector
+      comment: Local axis vector around which the object rotates.
+    - name: spinrate
+      type: number
+      comment: Rotation rate multiplier in radians per second.
+    - name: gain
+      type: number
+      comment: A float modulating the rotational strength (disables the rotation if
+        set to 0.0).
+    comment: Applies a smooth client-side rotation around the local axis at a rate
+      equal to spinrate multiplied by the magnitude of axis (in radians per second)
+      with a force defined by gain. Set spinrate to 0.0 to cancel.
+    name: TargetOmega
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer target handle returned by llTarget to remove.
+    comment: Removes the positional target specified by the integer handle registered
+      with llTarget.
+    name: TargetRemove
+  - parameters:
+    - name: target
+      type: number
+      comment: Target constant (e.g., TARGETED_EMAIL_OBJECT_OWNER or TARGETED_EMAIL_ROOT_CREATOR).
+    - name: subject
+      type: string
+      comment: Subject of the email.
+    - name: message
+      type: string
+      comment: Email message body.
+    comment: Sends an email containing subject and message to the target (which can
+      designate the owner or creator of the object).
+    name: TargetedEmail
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the owning avatar to teleport.
+    - name: landmark
+      type: string
+      comment: Name of the landmark in the prim's inventory, or an empty string to
+        teleport locally.
+    - name: position
+      type: vector
+      comment: Position vector in local region coordinates to teleport to if landmark
+        is empty.
+    - name: look_at
+      type: vector
+      comment: Position vector (or direction unit vector if teleporting out of region)
+        the agent faces upon landing.
+    comment: Teleports the owning agent (who must grant PERMISSION_TELEPORT) to a
+      landmark in the object's inventory. If landmark is empty, teleports them to
+      position within the current region. Upon arrival, the agent is turned to face
+      look_at. Can only teleport the owner.
+    name: TeleportAgent
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the owning avatar to teleport.
+    - name: global_coordinates
+      type: vector
+      comment: Global coordinates vector of the target region (obtained via llRequestSimulatorData).
+    - name: region_coordinates
+      type: vector
+      comment: Target coordinates vector within the destination region.
+    - name: look_at
+      type: vector
+      comment: Position vector within the region (or unit direction vector if out
+        of region) that the agent faces upon landing.
+    comment: Teleports the owning agent (who must grant PERMISSION_TELEPORT) to region_coordinates
+      within a target region specified by global_coordinates. Upon landing, the agent
+      faces the direction look_at. Can only teleport the owner.
+    name: TeleportAgentGlobalCoords
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to teleport.
+    comment: Teleports the avatar (who must be standing on land owned by the script
+      owner) directly to their designated home location without warning (similar to
+      a God Summons).
+    name: TeleportAgentHome
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: message
+      type: string
+      comment: Text message to display in the text box.
+    - name: channel
+      type: number
+      comment: Output chat channel (any integer value) where the input text is chatted.
+    comment: Opens an input text box dialog displaying message to the avatar. Submitting
+      text chats the input string on channel as if said by the avatar.
+    name: TextBox
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to convert.
+    return-type: string
+    comment: Returns a copy of the string src converted entirely to lowercase.
+    name: ToLower
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to convert.
+    return-type: string
+    comment: Returns a copy of the string src converted entirely to uppercase.
+    name: ToUpper
+    must-use: true
+  - parameters:
+    - name: destination
+      type: uuid
+      comment: UUID of the destination avatar.
+    - name: amount
+      type: number
+      comment: Quantity of L$ to transfer (must be greater than 0).
+    return-type: uuid
+    comment: Transfers amount of L$ from the script owner to the destination avatar,
+      requiring the PERMISSION_DEBIT permission. Returns a key query handle matching
+      the resulting transaction_result event.
+    name: TransferLindenDollars
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the avatar to receive ownership of the object.
+    - name: flags
+      type: number
+      comment: Flags controlling the transfer type (such as TRANSFER_FLAG_COPY or
+        TRANSFER_FLAG_TAKE).
+    - name: options
+      type: list
+      comment: Extra options applied to the transfer (currently unused).
+    return-type: number
+    comment: Transfers ownership of the object (or a copy of it, depending on flags)
+      to the avatar agent_id. Returns an integer indicating the success or failure
+      of the transfer.
+    name: TransferOwnership
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays specified sound once at volume, centered at the object's current
+      position but not attached (does not move with the object and cannot be stopped
+      or adjusted). Does not affect attached sounds.
+    name: TriggerSound
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    - name: top_north_east
+      type: vector
+      comment: Top-north-east boundary position vector in region coordinates.
+    - name: bottom_south_west
+      type: vector
+      comment: Bottom-south-west boundary position vector in region coordinates.
+    comment: Plays the specified sound once at volume, centered at the object but
+      not attached, restricted to the axis-aligned bounding box defined by the coordinates
+      top_north_east and bottom_south_west.
+    name: TriggerSoundLimited
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar to unsit.
+    comment: Forces the agent specified by id to stand up if they are sitting on the
+      object containing the script, or are currently over land owned by the object's
+      owner.
+    name: UnSit
+  - parameters:
+    - name: url
+      type: string
+      comment: Escaped URL string to decode.
+    return-type: string
+    comment: Returns a string representing the unescaped/decoded version of url, replacing
+      '%20' with spaces and decoding raw UTF-8 characters.
+    name: UnescapeURL
+    must-use: true
+  - parameters:
+    - name: options
+      type: list
+      comment: A list of key-value pairs specifying the character's new configuration
+        options (takes same constants as llCreateCharacter).
+    comment: Updates settings for a pathfinding character using the parameters specified
+      in options.
+    name: UpdateCharacter
+  - parameters:
+    - name: k
+      type: string
+      comment: Key of the key-value pair to update.
+    - name: v
+      type: string
+      comment: New value for the key-value pair.
+    - name: checked
+      type: boolean | number
+      comment: Boolean. If TRUE, requires the existing value to match original_value
+        to complete the update; if FALSE, creates the key if needed.
+    - name: original_value
+      type: string
+      comment: String value to compare against the existing value in the datastore.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to update the key k to value v inside
+      the experience datastore. If checked is TRUE, the update fails with XP_ERROR_RETRY_UPDATE
+      unless the existing value matches original_value.
+    name: UpdateKeyValue
+  - parameters:
+    - name: vec_a
+      type: vector
+      comment: First vector.
+    - name: vec_b
+      type: vector
+      comment: Second vector.
+    return-type: number
+    comment: Returns a float representing the undirected, non-negative distance between
+      vectors vec_a and vec_b.
+    name: VecDist
+    deprecated:
+      reason: It's a fastcall.
+      use: vector.magnitude
+      selene-replace:
+      - vector.magnitude(%1 - %2)
+    must-use: true
+  - parameters:
+    - name: vec
+      type: vector
+      comment: Vector to evaluate.
+    return-type: number
+    comment: Returns a float representing the magnitude (geometric length) of the
+      vector vec.
+    name: VecMag
+    deprecated:
+      reason: It's a fastcall.
+      use: vector.magnitude
+      selene-replace:
+      - vector.magnitude(%1)
+    must-use: true
+  - parameters:
+    - name: vec
+      type: vector
+      comment: Vector to normalize.
+    return-type: vector
+    comment: Returns a normalized unit vector sharing the same direction as vec.
+    name: VecNorm
+    deprecated:
+      reason: It's a fastcall.
+      use: vector.normalize
+      selene-replace:
+      - vector.normalize(%1)
+    must-use: true
+  - parameters:
+    - name: public_key
+      type: string
+      comment: PEM-formatted public key to use for signature verification.
+    - name: msg
+      type: string
+      comment: Message string that was signed.
+    - name: signature
+      type: string
+      comment: Base64-encoded signature to verify.
+    - name: algorithm
+      type: string
+      comment: Cryptographic digest algorithm to use.
+    return-type: boolean
+    comment: Returns TRUE if the Base64-formatted signature is verified as valid for
+      the message msg when using the digest algorithm and public_key. Returns FALSE
+      otherwise.
+    name: VerifyRSA
+    must-use: true
+  - parameters:
+    - name: detect
+      type: boolean | number
+      comment: Boolean. If TRUE, enables VolumeDetect; if FALSE (default), disables
+        it.
+    comment: If detect is TRUE, enables VolumeDetect (object becomes phantom and physical
+      objects/avatars can pass through it). Triggers collision_start on initial intersection
+      and collision_end when intersection stops (standard collision events are suppressed
+      while intersecting).
+    name: VolumeDetect
+  - parameters:
+    - name: origin
+      type: vector
+      comment: Center coordinate position vector to wander about.
+    - name: dist
+      type: vector
+      comment: A vector specifying the maximum distance limits (half-extents) along
+        each world-aligned axis from the origin.
+    - name: options
+      type: list
+      comment: A list of WANDER_* flags and parameters to configure the wander behavior.
+    comment: Directs a pathfinding character to wander around a central coordinate
+      origin, restricted within the bounding distance limits of dist and configured
+      by options.
+    name: WanderWithin
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: number
+    comment: Returns a float representing the water height directly below the prim's
+      position offset by the vector offset.
+    name: Water
+    must-use: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Integer chat channel to whisper the message on.
+    - name: msg
+      type: string
+      comment: Text message string to transmit.
+    comment: Whispers the text message msg on the specified channel. The message can
+      be heard up to a 10m radius. All channels other than PUBLIC_CHANNEL (0) and
+      DEBUG_CHANNEL (2147483647) are not sent to avatars and are used to communicate
+      with scripts.
+    name: Whisper
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the wind velocity at the prim's position
+      offset by the vector offset.
+    name: Wind
+    must-use: true
+  - parameters:
+    - name: world_pos
+      type: vector
+      comment: World-frame position vector to project into HUD space.
+    return-type: vector
+    comment: Returns the local position vector that places the center of the HUD object
+      directly over the world coordinate world_pos as viewed by the current camera.
+      Requires the PERMISSION_TRACK_CAMERA runtime permission.
+    name: WorldPosToHUD
+    must-use: true
+  - parameters:
+    - name: str1
+      type: string
+      comment: First Base64 string.
+    - name: str2
+      type: string
+      comment: Second Base64 string (will repeat if shorter than str1).
+    return-type: string
+    comment: Correctly performs a bitwise exclusive OR (XOR) on Base64 strings str1
+      and str2, returning the result as a Base64 string. The string str2 repeats if
+      it is shorter than str1.
+    name: XorBase64
+    must-use: true
+  - parameters:
+    - name: str1
+      type: string
+      comment: First Base64 string.
+    - name: str2
+      type: string
+      comment: Second Base64 string (will repeat if shorter than str1).
+    return-type: string
+    comment: Deprecated (use llXorBase64 instead). Retained for backwards compatibility.
+      Incorrectly performs a bitwise exclusive OR (XOR) on Base64 strings str1 and
+      str2.
+    name: XorBase64Strings
+    deprecated:
+      use: ll.XorBase64
+      selene-replace:
+      - ll.XorBase64(%1, %2)
+    must-use: true
+  - parameters:
+    - name: str1
+      type: string
+      comment: First Base64 string.
+    - name: str2
+      type: string
+      comment: Second Base64 string (will repeat if shorter than str1).
+    return-type: string
+    comment: Deprecated (use llXorBase64 instead). Correctly performs (unless nulls
+      are present) a bitwise exclusive OR (XOR) on Base64 strings str1 and str2.
+    name: XorBase64StringsCorrect
+    deprecated:
+      use: ll.XorBase64
+      selene-replace:
+      - ll.XorBase64(%1, %2)
+    must-use: true
+  - parameters:
+    - name: srgb
+      type: vector
+      comment: Color vector in the sRGB colorspace to convert.
+    return-type: vector
+    comment: Returns a vector representing the conversion of the color srgb from the
+      sRGB colorspace into the linear RGB colorspace.
+    name: sRGB2Linear
+    must-use: true
+- name: llcompat
+  comment: Like ll, but exactly matches LSL semantics.
+  functions:
+  - parameters:
+    - name: val
+      type: number
+      comment: Any integer value.
+    return-type: number
+    comment: Returns an integer representing the absolute (positive) value of val.
+    name: Abs
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: A floating-point value falling in the range [-1.0, 1.0].
+    return-type: number
+    comment: Returns a float representing the arc-cosine of val in radians.
+    name: Acos
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to add to the ban list.
+    - name: hours
+      type: number
+      comment: Duration, in hours, to ban the avatar for (0 for indefinite).
+    comment: Adds the avatar to the parcel ban list for the specified number of hours.
+      A value of 0 hours adds the avatar indefinitely. Banned users teleporting to
+      the parcel are redirected to a neighboring parcel; the minimum accepted duration
+      is 0.01 hours (approximately 36 seconds).
+    name: AddToLandBanList
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to add to the pass list.
+    - name: hours
+      type: number
+      comment: Duration, in hours, to allow the avatar for (range [0.0, 144.0], 0
+        for indefinite).
+    comment: Adds the avatar to the land pass list for the specified number of hours
+      (or indefinitely if hours is 0).
+    name: AddToLandPassList
+    deprecated: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the damage event to modify.
+    - name: new_damage
+      type: number
+      comment: New damage value to be applied or distributed after on_damage processing.
+    comment: (Index semantics) Modifies the amount of damage applied by the current
+      on_damage event after it completes processing, specified by the damage event
+      index number.
+    name: AdjustDamage
+    deprecated: true
+  - parameters:
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Adjusts the volume of the currently playing attached sound (has no effect
+      on sounds started with llTriggerSound).
+    name: AdjustSoundVolume
+    deprecated: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the avatar in the same region to query.
+    return-type: number
+    comment: Returns TRUE if the specified agent is in the experience and the experience
+      can run in the current region/location; returns FALSE otherwise.
+    name: AgentInExperience
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: add
+      type: boolean | number
+      comment: Boolean. If TRUE, allows anyone to drop inventory items into the prim
+        (even without modify rights). If FALSE, restricts inventory dropping to those
+        with modify permissions.
+    comment: If add is TRUE, allows users without object modify permissions to drop
+      inventory items into the prim. If FALSE, restricts inventory dropping to users
+      with modify permissions.
+    name: AllowInventoryDrop
+    deprecated: true
+  - parameters:
+    - name: a
+      type: quaternion
+      comment: Starting rotation.
+    - name: b
+      type: quaternion
+      comment: Ending rotation.
+    return-type: number
+    comment: Returns a float representing the angle in radians between rotations a
+      and b.
+    name: AngleBetween
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: momentum
+      type: vector
+      comment: Linear impulse vector to apply.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, momentum is treated as a local directional vector;
+        if FALSE, it is treated as a global region vector.
+    comment: Applies a linear impulse (momentum) to a physical object. If local is
+      TRUE, the impulse is applied in local coordinates; otherwise, it is applied
+      in global region coordinates.
+    name: ApplyImpulse
+    deprecated: true
+  - parameters:
+    - name: force
+      type: vector
+      comment: Rotational impulse vector to apply.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, the force is treated as a local directional vector;
+        if FALSE, it is treated as a global region vector.
+    comment: Applies a rotational impulse (force) to a physical object. If local is
+      TRUE, the rotational impulse is applied in local coordinates; otherwise, it
+      is applied in global region coordinates.
+    name: ApplyRotationalImpulse
+    deprecated: true
+  - parameters:
+    - name: val
+      type: number
+      comment: A floating-point value falling in the range [-1.0, 1.0].
+    return-type: number
+    comment: Returns a float representing the arc-sine of val in radians.
+    name: Asin
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: y
+      type: number
+      comment: A floating-point value representing the y coordinate.
+    - name: x
+      type: number
+      comment: A floating-point value representing the x coordinate.
+    return-type: number
+    comment: Returns a float representing the arctangent2 of y and x.
+    name: Atan2
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: attach_point
+      type: number
+      comment: ATTACH_* constant or integer value representing the target attachment
+        point.
+    comment: Attaches the object to the avatar who has granted the PERMISSION_ATTACH
+      permission. Takes the object into the user's inventory and attaches it at attach_point.
+    name: AttachToAvatar
+    deprecated: true
+  - parameters:
+    - name: attach_point
+      type: number
+      comment: ATTACH_* constant or integer value representing the target attachment
+        point.
+    comment: Attaches the object temporarily to an avatar who has granted the PERMISSION_ATTACH
+      permission. No permanent inventory is created, and the object disappears on
+      detach or disconnect. Can be used on non-owners (changing ownership to the wearer).
+    name: AttachToAvatarTemp
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Index of the prim in the linkset (1 for root, >1 for children), or
+        a LINK_* flag.
+    return-type: uuid
+    comment: Returns the UUID of the avatar seated on the specified link's sit target,
+      or NULL_KEY if no avatar is sitting there.
+    name: AvatarOnLinkSitTarget
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Returns the UUID of the avatar seated on the prim's sit target (defined
+      via llSitTarget), or NULL_KEY if no avatar is sitting there or the prim lacks
+      a sit target.
+    name: AvatarOnSitTarget
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: fwd
+      type: vector
+      comment: Forward/back directional vector of the rotation.
+    - name: left
+      type: vector
+      comment: Left/right directional vector of the rotation.
+    - name: up
+      type: vector
+      comment: Up/down directional vector of the rotation.
+    return-type: quaternion
+    comment: Returns the rotation defined by the coordinate axes fwd, left, and up.
+    name: Axes2Rot
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: axis
+      type: vector
+      comment: Axis vector around which the rotation is generated.
+    - name: angle
+      type: number
+      comment: Angle of rotation, expressed in radians.
+    return-type: quaternion
+    comment: Returns the rotation representing a generated angle (in radians) about
+      the specified axis.
+    name: AxisAngle2Rot
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: Base64-encoded string to decode.
+    return-type: number
+    comment: Returns an integer representing the Base64-decoded big-endian value of
+      str. Returns zero if str is longer than 8 characters; the return value is unpredictable
+      if str contains fewer than 6 characters.
+    name: Base64ToInteger
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: Base64-encoded string to decode.
+    return-type: string
+    comment: Decodes the Base64-encoded string str into a conventional string, interpreting
+      the bytes as a UTF-8 character sequence. Unprintable characters are converted
+      to question marks.
+    name: Base64ToString
+    deprecated: true
+    must-use: true
+  - comment: Delinks all prims in the linkset. Requires the PERMISSION_CHANGE_LINKS
+      runtime permission, which must be requested and granted by the owner.
+    name: BreakAllLinks
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: 'The link number (0: unlinked, 1: root prim, >1: child prims and seated
+        avatars) to delink.'
+    comment: Delinks the prim specified by the link number link. Requires the PERMISSION_CHANGE_LINKS
+      runtime permission.
+    name: BreakLink
+    deprecated: true
+  - parameters:
+    - name: src
+      type: string
+      comment: String of comma-separated values to parse.
+    return-type: '{string}'
+    comment: Parses the comma-separated string src and returns it as a list.
+    name: CSV2List
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: start
+      type: vector
+      comment: Starting location vector of the ray.
+    - name: end
+      type: vector
+      comment: Ending location vector of the ray.
+    - name: options
+      type: list
+      comment: A list of option flags and their parameters to configure the raycast.
+    return-type: '{any}'
+    comment: Casts a ray into the physics world from start to end and reports collision
+      data for intersections with objects based on options. Returns a list of strided
+      values [UUID_1, {link_number_1}, hit_position_1, {hit_normal_1}, ..., status_code].
+      A negative status_code indicates an error; otherwise, it represents the number
+      of hits.
+    name: CastRay
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to round.
+    return-type: number
+    comment: Returns the smallest integer value greater than or equal to val (rounded
+      toward positive infinity).
+    name: Ceil
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Unicode value to convert into a character string.
+    return-type: string
+    comment: Constructs and returns a single-character string representing the supplied
+      Unicode value val.
+    name: Char
+    deprecated: true
+    must-use: true
+  - comment: Resets all camera parameters to default values and turns off scripted
+      camera control. Requires the PERMISSION_CONTROL_CAMERA runtime permission (automatically
+      granted for attached or sat-on objects).
+    name: ClearCameraParams
+    deprecated: true
+  - parameters:
+    - name: agentid
+      type: uuid
+    - name: experienceid
+      type: uuid
+    name: ClearExperience
+    deprecated: true
+  - parameters:
+    - name: agentid
+      type: uuid
+    name: ClearExperiencePermissions
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: 'The link number (0: unlinked, 1: root prim, >1: child prims) or a
+        LINK_* flag representing the target prim.'
+    - name: face
+      type: number
+      comment: Face number to clear.
+    return-type: number
+    comment: Deletes the media and clears all parameters from the given face on the
+      linked prim. Returns an integer STATUS_* flag detailing the success or failure
+      of the operation.
+    name: ClearLinkMedia
+    deprecated: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number (side) to clear.
+    return-type: number
+    comment: Deletes the media and clears all parameters from the specified face.
+      Returns an integer STATUS_* flag detailing the success or failure of the operation.
+    name: ClearPrimMedia
+    deprecated: true
+  - parameters:
+    - name: channel
+      type: uuid
+      comment: XML-RPC channel ID to close.
+    comment: Deprecated. Closes the specified XML-RPC channel.
+    name: CloseRemoteDataChannel
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: number
+    comment: Returns a float representing the cloud density at the prim's position
+      offset by the vector offset.
+    name: Cloud
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Specific object name or avatar legacy name to filter for.
+    - name: id
+      type: uuid
+      comment: Group, avatar, or object UUID to filter by.
+    - name: accept
+      type: boolean | number
+      comment: Boolean. If TRUE, only collisions matching the name and id filters
+        are processed; if FALSE, matching collisions are excluded.
+    comment: Sets the collision filter, either exclusively or inclusively. If accept
+      is TRUE, only collisions matching name and id are processed; if FALSE, matches
+      are excluded. Pass an empty string or NULL_KEY to name or id to skip filtering
+      on that parameter.
+    name: CollisionFilter
+    deprecated: true
+  - parameters:
+    - name: impact_sound
+      type: string | uuid
+      comment: UUID of a sound, the name of a sound in the prim's inventory, or an
+        empty string to suppress sounds.
+    - name: impact_volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Suppresses default collision sounds and replaces default impact sounds
+      with impact_sound at the volume level specified by impact_volume. Supply an
+      empty string to only suppress collision sounds.
+    name: CollisionSound
+    deprecated: true
+  - parameters:
+    - name: impact_sprite
+      type: string | uuid
+      comment: UUID of a texture, the name of a texture in the prim's inventory, or
+        an empty string to suppress sprites.
+    comment: Suppresses default collision sprites and replaces them with impact_sprite
+      (which must be in the prim's inventory). Supply an empty string to only suppress
+      collision sprites.
+    name: CollisionSprite
+    deprecated: true
+  - parameters:
+    - name: message
+      type: string
+      comment: Message string to be hashed.
+    - name: algorithm
+      type: string
+      comment: Cryptographic digest algorithm to use (e.g., md5, sha1, sha224, sha256,
+        sha384, or sha512).
+    return-type: string
+    comment: Returns a hex-encoded hash digest string of message using the specified
+      cryptographic algorithm.
+    name: ComputeHash
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: theta
+      type: number
+      comment: Angle expressed in radians.
+    return-type: number
+    comment: Returns a float representing the cosine of theta.
+    name: Cos
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: options
+      type: list
+      comment: A list of key-value pairs specifying the character's configuration
+        options.
+    comment: Converts the linkset containing the script into a pathfinding character
+      entity (required to use pathfinding functions) using the specified options.
+    name: CreateCharacter
+    deprecated: true
+  - parameters:
+    - name: k
+      type: string
+      comment: Unique key name for the key-value pair.
+    - name: v
+      type: string
+      comment: Value for the key-value pair (maximum 2047 characters, or 4095 characters
+        if using Mono).
+    return-type: uuid
+    comment: Starts an asynchronous transaction to create a key-value pair (k and
+      v) associated with the script's experience. Returns a key query handle for the
+      dataserver event. Fails with XP_ERROR_STORAGE_EXCEPTION if the key already exists.
+    name: CreateKeyValue
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target prim/object in the same region.
+    - name: parent
+      type: boolean | number
+      comment: Boolean. If TRUE, the script's object becomes the root prim; if FALSE,
+        target becomes the root.
+    comment: Attempts to link the object containing the script with target. Requires
+      the PERMISSION_CHANGE_LINKS runtime permission.
+    name: CreateLink
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: Key of the target avatar or task to receive damage.
+    - name: damage
+      type: number
+      comment: Amount of damage to inflict (can exceed 100, unlike collision-based
+        damage).
+    - name: damage_type
+      type: number
+      comment: Type of damage to deliver to the target (can correspond to a DAMAGE_TYPE_*
+        constant).
+    comment: Generates a damage event delivering the specified amount of damage and
+      damage_type to the targeted avatar or task in the same region.
+    name: Damage
+    deprecated: true
+  - return-type: uuid
+    comment: Starts an asynchronous transaction to request the used and total data
+      storage allocated for the experience. Returns a key query handle for the dataserver
+      event.
+    name: DataSizeKeyValue
+    deprecated: true
+  - comment: Converts the linkset back to a standard physical object, removing all
+      pathfinding properties.
+    name: DeleteCharacter
+    deprecated: true
+  - parameters:
+    - name: k
+      type: string
+      comment: Key of the key-value pair to delete.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to delete the key-value pair associated
+      with key k in the experience. Returns a key query handle for the dataserver
+      event.
+    name: DeleteKeyValue
+    deprecated: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source list to copy and modify.
+    - name: start
+      type: number
+      comment: Starting index of the slice to remove (inclusive).
+    - name: end
+      type: number
+      comment: Ending index of the slice to remove (inclusive).
+    return-type: '{T}'
+    comment: Returns a copy of the list src with the slice from start to end (inclusive)
+      removed. Negative indices count backward from the end of the list. If start
+      is greater than end, the deletion excludes the specified range.
+    name: DeleteSubList
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to modify.
+    - name: start
+      type: number
+      comment: Starting index of the substring to remove (inclusive).
+    - name: end
+      type: number
+      comment: Ending index of the substring to remove (inclusive).
+    return-type: string
+    comment: Returns a copy of the string src with the characters from start to end
+      (inclusive) removed. Negative indices count backward from the end of the string.
+      If start is greater than end, the deletion excludes the specified range.
+    name: DeleteSubString
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the object in the region to derez.
+    - name: flag
+      type: number
+      comment: Derez behavior flags matching DEREZ_* constants.
+    return-type: number
+    comment: Derezzes (deletes or returns) a targeted object in the region previously
+      rezzed by a script in this linkset, returning TRUE on success or FALSE on failure.
+    name: DerezObject
+    deprecated: true
+  - comment: Detaches the object containing the script from the avatar. Requires the
+      PERMISSION_ATTACH runtime permission (automatically granted to attached objects).
+      Note that the detached object is completely removed from the region and not
+      dropped on the ground.
+    name: DetachFromAvatar
+    deprecated: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: '{any}'
+    comment: (Index semantics) Returns a list containing pending damage information
+      for the event specified by number, including the current damage, the damage
+      type, and the original damage delivered.
+    name: DetectedDamage
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns a vector representing the grab offset of the
+      user touching the object. Only works in touch events and returns <0.0, 0.0,
+      0.0> if number is not a valid index.
+    name: DetectedGrab
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: (Index semantics) Returns TRUE if the detected object or avatar specified
+      by number has the same active group as the prim containing the script. Returns
+      FALSE if the group is not active or if they are not in the group.
+    name: DetectedGroup
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: uuid
+    comment: (Index semantics) Returns the key (UUID) of the detected object or avatar
+      specified by number, or NULL_KEY if number is not a valid index.
+    name: DetectedKey
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: (Index semantics) Returns the link number (integer) of the triggered
+      event (touches and collisions only) specified by number. Returns 0 for non-linked
+      objects, 1 for the root prim, and 2+ for child prims. Returns 0 if not supported
+      by the event.
+    name: DetectedLinkNumber
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: item
+      type: number
+      comment: Index of the detection information.
+    return-type: string
+    comment: (Index semantics) Returns a string representing the name of the detected
+      object or avatar specified by item. Returns an empty string if item is not a
+      valid index.
+    name: DetectedName
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: uuid
+    comment: (Index semantics) Returns the key (UUID) of the owner of the detected
+      object specified by number. Returns an invalid key if number is not a valid
+      index.
+    name: DetectedOwner
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the vector position (in region coordinates)
+      of the detected object or avatar specified by number, or <0.0, 0.0, 0.0> if
+      number is not a valid index.
+    name: DetectedPos
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: uuid
+    comment: (Index semantics) Returns the key (UUID) of the object or avatar that
+      rezzed the detected object specified by number.
+    name: DetectedRezzer
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: quaternion
+    comment: (Index semantics) Returns the rotation of the detected object or avatar
+      specified by number, or <0.0, 0.0, 0.0, 1.0> if number is not a valid offset
+      index.
+    name: DetectedRot
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the surface binormal vector (tangent to the
+      surface, pointing along the positive T (V) direction of tangent space) at the
+      touched location specified by index. Can be used with llDetectedTouchNormal
+      to determine the tangent space.
+    name: DetectedTouchBinormal
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: (Index semantics) Returns the integer index of the face clicked by the
+      avatar in the touch event specified by index.
+    name: DetectedTouchFace
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the surface normal vector (perpendicular to
+      the surface) at the touched location specified by index. Can be used with llDetectedTouchBinormal
+      to determine the tangent space.
+    name: DetectedTouchNormal
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the vector position where the object was touched
+      (specified by index) in region coordinates, or in screen-space coordinates if
+      the object is attached as a HUD.
+    name: DetectedTouchPos
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the surface coordinates (<s, t, 0.0>) where
+      the prim was touched, specified by index. X and Y contain the horizontal (s)
+      and vertical (t) face coordinates, typically in the interval [0.0, 1.0]. Returns
+      TOUCH_INVALID_TEXCOORD if coordinates cannot be determined.
+    name: DetectedTouchST
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: index
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the texture coordinates (<u, v, 0.0>) where
+      the prim was touched, specified by index. X and Y contain the horizontal (u)
+      and vertical (v) texture coordinates, typically in the interval [0.0, 1.0] (affected
+      by repeats and rotation). Returns TOUCH_INVALID_TEXCOORD if coordinates cannot
+      be determined.
+    name: DetectedTouchUV
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: number
+    comment: (Index semantics) Returns an integer bitfield representing the types
+      (AGENT, ACTIVE, PASSIVE, or SCRIPTED) of the detected object or avatar specified
+      by number. Returns 0 if number is not a valid index.
+    name: DetectedType
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Index of the detection information.
+    return-type: vector
+    comment: (Index semantics) Returns the vector velocity of the detected object
+      or avatar specified by number, or <0.0, 0.0, 0.0> if number is not a valid offset
+      index.
+    name: DetectedVel
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: message
+      type: string
+      comment: Text message to display in the dialog box.
+    - name: buttons
+      type: '{string}'
+      comment: A list of up to 12 strings representing button labels.
+    - name: channel
+      type: number
+      comment: Output chat channel (any integer value) where button clicks are chatted.
+    comment: Shows a dialog box on the screen of the avatar specified by avatar, displaying
+      message along with up to 12 choice buttons. Clicking a button chats its label
+      on channel.
+    name: Dialog
+    deprecated: true
+  - comment: Deletes the entire object containing the script (the object does not
+      go to inventory). Use llBreakLink first to delete only a single prim.
+    name: Die
+    deprecated: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list to convert.
+    - name: separator
+      type: string
+      comment: Separator string to place between list entries.
+    return-type: string
+    comment: Returns a string that is the list src converted to a single string, with
+      separator placed between each entry.
+    name: DumpList2String
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates.
+    - name: dir
+      type: vector
+      comment: Direction vector.
+    return-type: number
+    comment: Checks if the border reached along the vector dir from the vector pos
+      is the edge of the world (i.e., has no neighboring simulator). Returns TRUE
+      if it hits the edge of the world, or FALSE if there is a neighboring simulator.
+    name: EdgeOfWorld
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    comment: Ejects the specified avatar from land/parcels owned by the object's owner
+      (group or resident).
+    name: EjectFromLand
+    deprecated: true
+  - parameters:
+    - name: address
+      type: string
+      comment: Destination email address.
+    - name: subject
+      type: string
+      comment: Subject of the email.
+    - name: message
+      type: string
+      comment: Message body of the email.
+    comment: Sends an email to address with subject and message.
+    name: Email
+    deprecated: true
+  - parameters:
+    - name: url
+      type: string
+      comment: Unescaped URL string to escape.
+    return-type: string
+    comment: Returns a string representing the escaped/encoded version of url, replacing
+      spaces with '%20' and non-alphanumeric characters with their '%xx' hexadecimal
+      UTF-8 equivalent.
+    name: EscapeURL
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: v
+      type: vector
+      comment: Vector of Euler angles to convert.
+    return-type: quaternion
+    comment: Returns the rotation representation of the Euler angles vector v.
+    name: Euler2Rot
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the group, avatar, or object to evade.
+    - name: options
+      type: list
+      comment: No options currently available (should be empty list).
+    comment: Directs a pathfinding character to evade target, attempting to hide from
+      its pursuer if a hiding spot is available (i.e., no line of sight from the character's
+      head to the pursuer's head, and no direct path on the navmesh).
+    name: Evade
+    deprecated: true
+  - parameters:
+    - name: command
+      type: number
+      comment: Pathfinding command to execute.
+    - name: options
+      type: list
+      comment: A list of options for the command (e.g., jump height for CHARACTER_CMD_JUMP).
+    comment: Sends a command (specified by command) to the pathing system with options.
+      Currently only supports stopping pathfinding or making the character jump.
+    name: ExecCharacterCmd
+    deprecated: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to convert.
+    return-type: number
+    comment: Returns a float representing the absolute (positive) value of val.
+    name: Fabs
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: notecardname
+      type: string | uuid
+      comment: Name of the target notecard.
+    - name: pattern
+      type: string
+      comment: Regular expression pattern to search for.
+    - name: options
+      type: list
+      comment: A list of options to control the search (currently unused, should be
+        []).
+    return-type: uuid
+    comment: Searches the text of a cached notecard for lines containing the given
+      pattern and returns the number of matches found through a dataserver event.
+    name: FindNotecardTextCount
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of a notecard in the prim's inventory, or a UUID.
+    - name: pattern
+      type: string
+      comment: Regular expression pattern to search for.
+    - name: start
+      type: number
+      comment: Number of match results to skip before returning (0 to start at the
+        first match).
+    - name: count
+      type: number
+      comment: Maximum number of matches to return (if 0, returns the first 64 matches).
+    - name: options
+      type: list
+      comment: A list of options for future expansion (unused, should be []).
+    return-type: '{any}'
+    comment: (Index semantics) Synchronously searches a cached notecard name for lines
+      containing pattern, returning a list of line and column numbers. Returns a list
+      containing 'NAK' if the notecard is not cached, or an empty list if no matches
+      are found.
+    name: FindNotecardTextSync
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Position vector in region coordinates from which to flee.
+    - name: distance
+      type: number
+      comment: Distance in meters to keep from the position.
+    - name: options
+      type: list
+      comment: No options currently available (should be empty list).
+    comment: Directs a pathfinding character to keep the specified distance from the
+      target position vector (within the region or adjacent regions).
+    name: FleeFrom
+    deprecated: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to round.
+    return-type: number
+    comment: Returns the largest integer value less than or equal to val (rounded
+      toward negative infinity).
+    name: Floor
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: mouselook
+      type: boolean | number
+      comment: Boolean. If TRUE, forces a sitting avatar into mouselook; if FALSE,
+        allows them to keep their current camera mode.
+    comment: Sets whether any avatar sitting on this prim is forced into mouselook
+      mode. Setting mouselook to TRUE forces the mode; FALSE (default) allows the
+      avatar to keep their current camera mode.
+    name: ForceMouselook
+    deprecated: true
+  - parameters:
+    - name: mag
+      type: number
+      comment: Float magnitude of the random range.
+    return-type: number
+    comment: Returns a pseudo-random float in the range [0.0, mag) or (mag, 0.0] depending
+      on the sign of mag. The value is inclusive of 0.0 but exclusive of mag.
+    name: Frand
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Generates and returns a unique versioned UUID key (utilizing SHA-1 hashing).
+      Due to being versioned, it will not return NULL_KEY; however, the exact UUID
+      version is an implementation detail that should not be relied upon.
+    name: GenerateKey
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the acceleration of the object in the region's
+      frame of reference.
+    name: GetAccel
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: number
+    comment: Returns an integer bitfield containing status information about the agent
+      specified by id (such as AGENT_FLYING, AGENT_ATTACHMENTS, AGENT_SITTING, etc.).
+    name: GetAgentInfo
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: string
+    comment: Returns a string representing the language code of the preferred interface
+      language set by the avatar.
+    name: GetAgentLanguage
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: scope
+      type: number
+      comment: Scope flag (AGENT_LIST_PARCEL, AGENT_LIST_PARCEL_OWNER, or AGENT_LIST_REGION)
+        to filter the returned agents.
+    - name: options
+      type: list
+      comment: A list of options to apply (currently unused).
+    return-type: '{uuid}'
+    comment: Requests a list of avatar UUID keys for agents currently in the region,
+      limited by scope. Returns a list of keys or a list containing an error message
+      string.
+    name: GetAgentList
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: vector
+    comment: Returns a vector representing the estimated bounding box size of the
+      specified avatar, or ZERO_VECTOR if they are not in the same region.
+    name: GetAgentSize
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: number
+    comment: Returns a float representing the Blinn-Phong alpha (transparency) of
+      face. If face is ALL_SIDES, returns the mean average of all faces.
+    name: GetAlpha
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns the elapsed script time in seconds as a float, then resets the
+      script timer to zero.
+    name: GetAndResetTime
+    deprecated: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: string
+    comment: Returns a string representing the name of the currently playing locomotion
+      animation for the avatar specified by id.
+    name: GetAnimation
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: '{uuid}'
+    comment: Returns a list of keys (UUIDs) representing all active animations currently
+      playing on the specified avatar.
+    name: GetAnimationList
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: anim_state
+      type: string
+      comment: Animation state string to query.
+    return-type: string
+    comment: Returns a string representing the name of the animation currently overriding
+      the specified anim_state. Requires the PERMISSION_OVERRIDE_ANIMATIONS or PERMISSION_TRIGGER_ANIMATION
+      runtime permission.
+    name: GetAnimationOverride
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns the integer attachment point (an ATTACH_* constant) that the
+      object is attached to, or 0 if it is unattached or pending detachment.
+    name: GetAttached
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    return-type: '{uuid} | {string}'
+    comment: Returns a list of object keys (UUIDs) corresponding to public, visible
+      (non-HUD) attachments worn by the specified avatar, in the order they were attached.
+      Returns a list with an error message string on failure.
+    name: GetAttachedList
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: options
+      type: list
+      comment: A list of options to filter the returned attachments.
+    return-type: '{uuid} | {string}'
+    comment: Retrieves a list of attachment object keys worn by avatar in the order
+      they were attached, filtered by options. Returns a list containing an error
+      message string on failure.
+    name: GetAttachedListFiltered
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: object
+      type: uuid
+      comment: UUID of the avatar or prim in the same region.
+    return-type: '{vector}'
+    comment: Returns the bounding box of object (including any linked prims) relative
+      to its root prim in local coordinates, formatted as [ (vector) min_corner, (vector)
+      max_corner ].
+    name: GetBoundingBox
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the camera's current aspect ratio (width/height)
+      of the agent who granted PERMISSION_TRACK_CAMERA. Returns 0.0 if permissions
+      are not granted.
+    name: GetCameraAspect
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the camera's current field of view (FOV)
+      in radians of the agent who granted PERMISSION_TRACK_CAMERA. Returns 0.0 if
+      permissions are not granted.
+    name: GetCameraFOV
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the camera's current position in region
+      coordinates of the agent who granted PERMISSION_TRACK_CAMERA. Returns ZERO_VECTOR
+      if permissions are not granted.
+    name: GetCameraPos
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the camera's current orientation of the
+      agent who granted PERMISSION_TRACK_CAMERA. Returns ZERO_ROTATION if permissions
+      are not granted.
+    name: GetCameraRot
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns the vector position (in region coordinates) of the center of
+      mass. Returns the individual child prim's center of mass if called from a child,
+      or the entire linkset's center of mass if called from the root.
+    name: GetCenterOfMass
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: point
+      type: vector
+      comment: Position vector in region-local coordinates.
+    - name: options
+      type: list
+      comment: A list of GCNP_* flags and parameters to configure the search limits.
+    return-type: '{vector}'
+    comment: Returns a list containing the closest vector position on the navigation
+      mesh (navmesh) to the specified point (expressed in region-local space), or
+      an empty list if none is found. Configured using options.
+    name: GetClosestNavPoint
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: vector
+    comment: Returns the Blinn-Phong RGB color vector of face (values between 0.0
+      and 1.0). If face is ALL_SIDES, returns the mean average of all faces.
+    name: GetColor
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the prim's original creator.
+    name: GetCreator
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string representing the current date in the UTC time zone in
+      the format 'YYYY-MM-DD'.
+    name: GetDate
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the number of seconds in the environmental
+      day cycle applied to the current parcel.
+    name: GetDayLength
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the offset duration (in seconds) added
+      to calculate the current environmental time on this parcel.
+    name: GetDayOffset
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region or otherwise known to the region.
+    return-type: string
+    comment: Returns the display name string of the avatar specified by id if they
+      are in the region or cached; returns an empty string otherwise (use llRequestDisplayName
+      if the avatar is absent).
+    name: GetDisplayName
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the remaining physics energy of the object
+      as a percentage (0.0 to 1.0) of its maximum capacity.
+    name: GetEnergy
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the regional data to request (unrecognized strings return an
+        empty string).
+    return-type: string
+    comment: Returns a string containing the requested regional data specified by
+      name.
+    name: GetEnv
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (X/Y determine the parcel, or
+        region if X/Y are -1; Z determines the sky track altitude).
+    - name: params
+      type: '{number}'
+      comment: A list of environmental attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list containing the current environment parameters for the
+      parcel or region at pos, retrieved in the order specified by params.
+    name: GetEnvironment
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: experience_id
+      type: uuid
+      comment: UUID of the experience to query (can be NULL_KEY to retrieve details
+        for the script's own experience).
+    return-type: '{any}'
+    comment: Returns a list of details for the specified experience_id, formatted
+      as [string experience_name, key owner_id, key experience_id, integer state,
+      string state_message, key group_id].
+    name: GetExperienceDetails
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: error
+      type: number
+      comment: XP_ERROR_* error code constant to translate.
+    return-type: string
+    comment: Returns a text description of the specified experience error code, or
+      a description of XP_ERROR_UNKNOWN_ERROR if the error is invalid.
+    name: GetExperienceErrorMessage
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: agentid
+      type: uuid
+    return-type: '{uuid}'
+    name: GetExperienceList
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the constant force currently applied to
+      the object (if the object is physical).
+    name: GetForce
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the number of free bytes of memory currently
+      available to the script.
+    name: GetFreeMemory
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the number of available HTTP URLs (remaining
+      for the owner if the object is attached, or for the region if unattached).
+    name: GetFreeURLs
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the time in seconds since midnight GMT (truncated
+      to whole seconds).
+    name: GetGMTclock
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the geometric center of the object relative
+      to its root prim.
+    name: GetGeometricCenter
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: request_id
+      type: uuid
+      comment: Unique key of the HTTP request.
+    - name: header
+      type: string
+      comment: Lowercase name of the HTTP header to retrieve.
+    return-type: string
+    comment: Returns a string representing the value of the specified header associated
+      with the HTTP request_id.
+    name: GetHTTPHeader
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the agent or object to query.
+    return-type: number
+    comment: Returns a float representing the current health of the avatar or object
+      specified by id.
+    name: GetHealth
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: string
+    comment: Returns a string containing the UTC timestamp (YYYY-MM-DDThh:mm:ssZ)
+      representing when the inventory item was placed inside the prim.
+    name: GetInventoryAcquireTime
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: uuid
+    comment: Returns the key (UUID) of the creator of the specified inventory item.
+    name: GetInventoryCreator
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: string
+    comment: Returns a string containing the description of the specified inventory
+      item.
+    name: GetInventoryDesc
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: uuid
+    comment: Returns the key (UUID) of the specified inventory name.
+    name: GetInventoryKey
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: type
+      type: number
+      comment: INVENTORY_* type constant of the item.
+    - name: number
+      type: number
+      comment: Index number of the item of that type, starting from 0.
+    return-type: string
+    comment: Returns the name of the inventory item of the specified type (INVENTORY_*)
+      at the index number.
+    name: GetInventoryName
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: type
+      type: number
+      comment: INVENTORY_* type constant to count.
+    return-type: number
+    comment: Returns an integer representing the quantity of items of the specified
+      type (INVENTORY_*) in the prim's inventory.
+    name: GetInventoryNumber
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    - name: category
+      type: number
+      comment: MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE,
+        or MASK_NEXT).
+    return-type: number
+    comment: Returns an integer bitfield representing the permission category mask
+      of the specified inventory item.
+    name: GetInventoryPermMask
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the inventory item.
+    return-type: number
+    comment: Returns an integer representing the INVENTORY_* type of the named inventory
+      item.
+    name: GetInventoryType
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the prim containing the script.
+    name: GetKey
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates.
+    return-type: uuid
+    comment: Returns the key (UUID) of the land owner at the vector pos, or NULL_KEY
+      if the land is public.
+    name: GetLandOwnerAt
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: uuid
+    comment: Returns the key (UUID) of the linked prim or avatar specified by link.
+    name: GetLinkKey
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_MEDIA_* property constants to retrieve values for.
+    return-type: '{any}'
+    comment: Returns a list containing the media parameters of the specified face
+      on the linked prim link, retrieved in the order requested by params.
+    name: GetLinkMedia
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: string
+    comment: Returns a string containing the name of the linked prim specified by
+      link.
+    name: GetLinkName
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns the integer link number of the prim containing the script (0
+      for unlinked, 1 for the root, and 2+ for children).
+    name: GetLinkNumber
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: number
+    comment: Returns an integer representing the number of sides (faces) of the linked
+      prim specified by link.
+    name: GetLinkNumberOfSides
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag to retrieve
+        parameters from.
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list of primitive parameters requested in params for the linked
+      prim specified by link (equivalent to llGetPrimitiveParams).
+    name: GetLinkPrimitiveParams
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    return-type: number
+    comment: Returns an integer representing the active sit flags currently set on
+      the linked prim specified by link.
+    name: GetLinkSitFlags
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: number
+    comment: Returns an integer representing the variable type (TYPE_*) of the list
+      entry at index in the list src.
+    name: GetListEntryType
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to measure.
+    return-type: number
+    comment: Returns an integer representing the total number of elements in the list
+      src.
+    name: GetListLength
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a position vector relative to the root prim. If called from the
+      root prim, it returns the global region position (or the position relative to
+      the attachment point if attached).
+    name: GetLocalPos
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the local orientation of a child prim
+      relative to the root prim, or the object's overall rotation if called from the
+      root.
+    name: GetLocalRot
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the mass of the object (in lindograms).
+      Returns the total linkset mass if called from the root, or the individual prim's
+      mass if called from a child prim. Returns the wearer's mass if inside an attachment.
+    name: GetMass
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the mass of the object in kilograms. Functionally
+      identical to llGetMass except for using MKS (metric) units.
+    name: GetMassMKS
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the maximum scale factor that can be applied
+      to the object via llScaleByFactor without violating size or linkability limits.
+    name: GetMaxScaleFactor
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the maximum memory limit (in bytes) that
+      the script is allowed to allocate.
+    name: GetMemoryLimit
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the minimum scale factor that can be applied
+      to the object via llScaleByFactor without violating size limits.
+    name: GetMinScaleFactor
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      parcel's moon, taking altitude into account. Falls back to the region's moon
+      direction if no custom parcel environment is set.
+    name: GetMoonDirection
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the moon on
+      the current parcel and altitude track. Falls back to the region's moon rotation
+      if no custom parcel environment is set.
+    name: GetMoonRotation
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: address
+      type: string
+      comment: Sender email address filter.
+    - name: subject
+      type: string
+      comment: Email subject filter.
+    comment: Requests the next queued email matching the specified sender address
+      and subject filters via the email event.
+    name: GetNextEmail
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of the notecard in the prim's inventory, or a UUID.
+    - name: line
+      type: number
+      comment: Zero-based line number to request.
+    return-type: uuid
+    comment: Asynchronously requests the line index line of the notecard name from
+      the dataserver. Returns a key query handle for the dataserver event, which will
+      return 'EOF' when reaching past the end of the notecard.
+    name: GetNotecardLine
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of the notecard in the prim's inventory, or a UUID.
+    - name: line
+      type: number
+      comment: Zero-based line number to request.
+    return-type: string
+    comment: Synchronously reads the line index line of the notecard name from the
+      region's cache, immediately returning its text without raising a dataserver
+      event. Returns 'NAK' if not cached or 'EOF' if out of bounds.
+    name: GetNotecardLineSync
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string | uuid
+      comment: Name of the notecard in the prim's inventory, or a UUID.
+    return-type: uuid
+    comment: Asynchronously requests the total line count of the notecard name. Returns
+      a key query handle for the dataserver event.
+    name: GetNumberOfNotecardLines
+    deprecated: true
+  - return-type: number
+    comment: Returns an integer representing the total number of prims and seated
+      avatars in the linkset containing the script.
+    name: GetNumberOfPrims
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of sides (faces) of
+      the prim containing the script.
+    name: GetNumberOfSides
+    deprecated: true
+    must-use: true
+  - return-type: '{string}'
+    comment: Returns a list of strings representing the names of all active animations
+      currently playing on the object.
+    name: GetObjectAnimationNames
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the description of the specific prim containing
+      the script.
+    name: GetObjectDesc
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar or prim (in the same or adjacent regions) to query.
+    - name: params
+      type: '{number}'
+      comment: A list of OBJECT_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list containing the requested parameters of the specified avatar
+      or object id, retrieved in the order requested by params.
+    name: GetObjectDetails
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: object_id
+      type: uuid
+      comment: UUID of the target prim or linkset.
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag of the prim
+        to retrieve.
+    return-type: uuid
+    comment: Returns the key (UUID) of the linked child prim specified by link within
+      the linkset identified by object_id.
+    name: GetObjectLinkKey
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar or object to query.
+    return-type: number
+    comment: Returns a float representing the mass of the avatar or object specified
+      by id.
+    name: GetObjectMass
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the name of the specific prim containing
+      the script.
+    name: GetObjectName
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: category
+      type: number
+      comment: MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, MASK_GROUP, MASK_EVERYONE,
+        or MASK_NEXT).
+    return-type: number
+    comment: Returns an integer bitfield representing the permission mask of the specified
+      category for the object containing the script.
+    name: GetObjectPermMask
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: prim
+      type: uuid
+      comment: UUID of the prim in the same region.
+    return-type: number
+    comment: Returns an integer representing the total number of prims in the object
+      containing the specified prim.
+    name: GetObjectPrimCount
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the physical rotation (angular velocity)
+      of the object in radians per second.
+    name: GetOmega
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the object's current owner.
+    name: GetOwner
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the prim in the same region.
+    return-type: uuid
+    comment: Returns the key (UUID) of the owner of the prim specified by id.
+    name: GetOwnerKey
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (only the X and Y components
+        are used).
+    - name: params
+      type: '{number}'
+      comment: A list of PARCEL_DETAILS_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list containing the requested parcel details specified by params
+      (retrieved in the same order) for the parcel at the vector pos.
+    name: GetParcelDetails
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (the Z component is ignored).
+    return-type: number
+    comment: Returns an integer bitfield of parcel flags (PARCEL_FLAG_*) for the parcel
+      at the position pos.
+    name: GetParcelFlags
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (the Z component is ignored).
+    - name: sim_wide
+      type: boolean | number
+      comment: Boolean. If TRUE, returns the combined land impact limit for all parcels
+        owned by the parcel owner in the region; if FALSE, returns only the limit
+        for the specified parcel.
+    return-type: number
+    comment: Returns an integer representing the maximum combined land impact (prim
+      limit) allowed for objects on the parcel at pos, determined either for the single
+      parcel or sim-wide based on sim_wide.
+    name: GetParcelMaxPrims
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the parcel's streaming music (audio) URL.
+      The object owner must also be the land owner (or share the same group deeding).
+    name: GetParcelMusicURL
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates (the Z component is ignored).
+    - name: category
+      type: number
+      comment: PARCEL_COUNT_* category flag.
+    - name: sim_wide
+      type: boolean | number
+      comment: Boolean. If TRUE, searches all parcels in the region owned by the targeted
+        parcel's owner; if FALSE, searches only the specified parcel.
+    return-type: number
+    comment: Returns an integer representing the total land impact of objects on the
+      parcel at pos in the specified category. If sim_wide is TRUE, returns combined
+      usage for all regional parcels owned by the parcel owner; if FALSE, returns
+      usage for only the specified parcel.
+    name: GetParcelPrimCount
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates.
+    return-type: '{any}'
+    comment: Returns a list of up to 100 strides (formatted as [key owner, integer
+      land_impact]) representing owners of objects on the parcel at pos, sorted by
+      owner key. Requires owner-like permissions for the parcel and the script owner's
+      presence in the region.
+    name: GetParcelPrimOwners
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer bitfield representing the permissions (PERMISSION_*)
+      currently granted to the script.
+    name: GetPermissions
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Returns the key (UUID) of the avatar that last granted or declined permissions
+      to the script, or NULL_KEY if the permissions request was ignored or cancelled.
+    name: GetPermissionsKey
+    deprecated: true
+    must-use: true
+  - return-type: '{number}'
+    comment: Returns a list of the format [float gravity_multiplier, float restitution,
+      float friction, float density] detailing the physical characteristics of the
+      object.
+    name: GetPhysicsMaterial
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the current position of the object in region
+      coordinates.
+    name: GetPos
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_MEDIA_* property constants to retrieve values for.
+    return-type: '{any}'
+    comment: Returns a list containing the media parameters of the specified face,
+      retrieved in the order requested by params. Returns an empty list if no media
+      exists on the face.
+    name: GetPrimMediaParams
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: params
+      type: '{number}'
+      comment: A list of PRIM_* flags specifying the attributes to retrieve.
+    return-type: '{any}'
+    comment: Returns a list of primitive attribute values matching the requested params
+      list.
+    name: GetPrimitiveParams
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the current number of avatars in the
+      region.
+    name: GetRegionAgentCount
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector (in meters) representing the global grid coordinates
+      of the south-west corner of the current region (Z component is always 0.0).
+    name: GetRegionCorner
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of seconds in the region-wide
+      day cycle.
+    name: GetRegionDayLength
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the offset duration (in seconds) added
+      to calculate the current environmental time for the region.
+    name: GetRegionDayOffset
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the average region simulator frames per
+      second (FPS).
+    name: GetRegionFPS
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer bitfield representing the region flags (REGION_FLAG_*)
+      currently enabled for the region containing the object.
+    name: GetRegionFlags
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      region's moon, taking altitude into account.
+    name: GetRegionMoonDirection
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the moon at
+      the region level, taking altitude track into account.
+    name: GetRegionMoonRotation
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the name of the current region.
+    name: GetRegionName
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      region's sun, taking altitude into account.
+    name: GetRegionSunDirection
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the sun at
+      the region level, taking altitude track into account.
+    name: GetRegionSunRotation
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the current physics time dilation of the
+      region, ranging from 0.0 (full dilation / slow) to 1.0 (no dilation / real-world
+      speed).
+    name: GetRegionTimeDilation
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float with subsecond precision representing the elapsed seconds
+      since region environmental midnight or region uptime (whichever is smaller).
+      If the region's sun position is fixed, returns region uptime.
+    name: GetRegionTimeOfDay
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: string
+    comment: Returns a string representing the render material on face (returns the
+      inventory name if it is in the prim's inventory, or its key UUID otherwise).
+    name: GetRenderMaterial
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the position (in region coordinates) of
+      the root prim of the linkset containing the script.
+    name: GetRootPosition
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation (relative to the region)
+      of the root prim of the linkset containing the script.
+    name: GetRootRotation
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the prim's orientation relative to the
+      region's axes.
+    name: GetRot
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the maximum memory (in bytes) used by
+      the script while the memory profiler was last active (only valid after using
+      PROFILE_SCRIPT_MEMORY).
+    name: GetSPMaxMemory
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the physical scale (dimensions in meters)
+      of the prim containing the script.
+    name: GetScale
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the name of the script calling this function.
+    name: GetScriptName
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: script
+      type: string
+      comment: Name of the script in the prim's inventory.
+    return-type: number
+    comment: Returns a boolean integer indicating whether the specified script in
+      the prim's inventory is running (returns TRUE if running, FALSE otherwise).
+    name: GetScriptState
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: stat_type
+      type: number
+      comment: SIM_STAT_* flag of the statistic to retrieve.
+    return-type: number
+    comment: Returns a float containing the value of the requested region statistic
+      specified by stat_type.
+    name: GetSimStats
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the hostname of the server machine running
+      the script (e.g., 'sim225.agni.lindenlab.com').
+    name: GetSimulatorHostname
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the start/rez parameter passed to the
+      object on creation (returns 0 if rezzed by an agent).
+    name: GetStartParameter
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns the initialization string passed to the object's root prim on
+      rez with llRezObjectWithParams (via REZ_PARAM_STRING; returns an empty string
+      if rezzed by an agent).
+    name: GetStartString
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: start
+      type: vector
+      comment: Starting position vector.
+    - name: end
+      type: vector
+      comment: Target end position vector.
+    - name: radius
+      type: number
+      comment: Radius of the character path, between 0.125m and 5.0m.
+    - name: params
+      type: list
+      comment: A list specifying the CHARACTER_TYPE parameter (defaults to CHARACTER_TYPE_NONE).
+    return-type: '{any}'
+    comment: Returns a list of position vectors representing pathfinding waypoints
+      between start and end on the static navmesh for a character of the specified
+      radius. Ignores movable obstacles and can be used in any region regardless of
+      dynamic pathfinding status.
+    name: GetStaticPath
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: status
+      type: number
+      comment: Single STATUS_* flag to check.
+    return-type: number
+    comment: Returns a boolean integer indicating whether the specified status flag
+      status is enabled for the object.
+    name: GetStatus
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to slice.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    return-type: string
+    comment: Returns a copy of the substring from src within the inclusive range specified
+      by the start and end indices. Negative indices count backward from the end.
+      If start is greater than end, the substring is the excluded range.
+    name: GetSubString
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a normalized vector representing the current direction of the
+      parcel's sun, taking altitude into account. Falls back to the region's sun direction
+      if no custom parcel environment is set.
+    name: GetSunDirection
+    deprecated: true
+    must-use: true
+  - return-type: quaternion
+    comment: Returns a rotation representing the orientation applied to the sun on
+      the current parcel and altitude track. Falls back to the region's sun rotation
+      if no custom parcel environment is set.
+    name: GetSunRotation
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: string
+    comment: Returns a string representing the Blinn-Phong diffuse texture on face
+      (returns the inventory name if it is a texture in the prim's inventory, or its
+      key UUID otherwise).
+    name: GetTexture
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: vector
+    comment: Returns a vector containing the texture offsets of face in the X (horizontal
+      U) and Y (vertical V) components (Z is unused).
+    name: GetTextureOffset
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: number
+    comment: Returns a float representing the texture rotation angle (in radians)
+      on face.
+    name: GetTextureRot
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    return-type: vector
+    comment: Returns a vector containing the texture scales of face in the X and Y
+      components (Z is unused).
+    name: GetTextureScale
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the elapsed script time in seconds with
+      subsecond precision (since the script started, was reset, or since the last
+      call to llResetTime or llGetAndResetTime).
+    name: GetTime
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float with subsecond precision representing the elapsed seconds
+      since parcel environmental midnight or region uptime (whichever is smaller).
+      If the parcel's sun position is fixed, returns region uptime.
+    name: GetTimeOfDay
+    deprecated: true
+    must-use: true
+  - return-type: string
+    comment: Returns a string containing the current date and time in the UTC time
+      zone formatted as an ISO 8601 timestamp ('YYYY-MM-DDThh:mm:ss.ff..fZ').
+    name: GetTimestamp
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the physical torque force currently acting
+      on the object (if the object is physical).
+    name: GetTorque
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the current Unix timestamp (the number
+      of seconds elapsed since 00:00:00 Jan 1, 1970 UTC).
+    name: GetUnixTime
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of bytes of memory currently
+      used by the script (non-Mono scripts always return 16,384 bytes).
+    name: GetUsedMemory
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar in the same region or otherwise known to the region.
+    return-type: string
+    comment: Returns a string representing the unique username of the avatar specified
+      by id if they are connected to the region or cached; returns an empty string
+      otherwise (use llRequestUsername if the avatar is absent).
+    name: GetUsername
+    deprecated: true
+    must-use: true
+  - return-type: vector
+    comment: Returns a vector representing the velocity of the object (in meters per
+      second) relative to the global region coordinates. For physical objects, returns
+      the velocity of its center of mass.
+    name: GetVel
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: agentid
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: params
+      type: '{number | string}'
+      comment: A list of visual parameter IDs or names to retrieve values for.
+    return-type: '{number | ""}'
+    comment: Returns a list containing the values of the visual parameters requested
+      in params for the agent specified by agentid.
+    name: GetVisualParams
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns a float representing the time in seconds since midnight Pacific
+      Time (PST/PDT), which is equivalent to Second Life Time (SLT) truncated to whole
+      seconds.
+    name: GetWallclock
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the receiving agent in the region.
+    - name: folder
+      type: string
+      comment: Name of the destination folder to be created in the agent's inventory.
+    - name: inventory
+      type: '{string}'
+      comment: A list of inventory items to transfer.
+    - name: options
+      type: list
+      comment: A list of options to configure the inventory transfer.
+    return-type: number
+    comment: Gives the specified inventory items to the agent as a new folder named
+      folder, as permitted by the permissions system. Customizes the transfer using
+      options.
+    name: GiveAgentInventory
+    deprecated: true
+  - parameters:
+    - name: destination
+      type: uuid
+      comment: UUID of the destination avatar or prim.
+    - name: inventory
+      type: string
+      comment: Name of the item in the prim's inventory.
+    comment: Gives the specified inventory item to the destination, as permitted by
+      the permissions system. The destination can be any agent, or an object located
+      in the same region.
+    name: GiveInventory
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target avatar or prim in the same region.
+    - name: folder
+      type: string
+      comment: Name of the destination folder to be created (ignored if the target
+        is an object).
+    - name: inventory
+      type: '{string}'
+      comment: A list of names representing items in the prim's inventory.
+    comment: Gives the list of inventory items to target as a new folder named folder.
+      If target is an object, the items are passed directly into its inventory and
+      no folder is created. The target must be an agent or an object in the same region.
+    name: GiveInventoryList
+    deprecated: true
+  - parameters:
+    - name: destination
+      type: uuid
+      comment: UUID of the destination avatar.
+    - name: amount
+      type: number
+      comment: Number of L$ to transfer (must be greater than 0).
+    return-type: number
+    comment: Transfers the specified amount of L$ from the script owner to the destination
+      avatar. Silently fails if the PERMISSION_DEBIT permission has not been granted.
+      Returns 0 (use llTransferLindenDollars to match transactions to transaction_result
+      events).
+    name: GiveMoney
+    deprecated: true
+  - parameters:
+    - name: inventory
+      type: uuid
+      comment: Asset UUID of the object to rez.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates where the object will be rezzed.
+    comment: Rezzes an object directly from a UUID specified by inventory at the position
+      pos, provided the owner has the god-bit set.
+    name: GodLikeRezObject
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: number
+    comment: Returns a float representing the ground height directly below the prim's
+      position offset by the vector offset.
+    name: Ground
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the ground contour direction (the direction
+      with no change in elevation) directly below the prim's position offset by the
+      vector offset.
+    name: GroundContour
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the ground surface normal vector directly
+      below the current position offset by the vector offset.
+    name: GroundNormal
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: height
+      type: number
+      comment: Target distance in meters above the ground or water.
+    - name: water
+      type: boolean | number
+      comment: Boolean. If TRUE, damp relative to the higher of land and water; if
+        FALSE, damp relative to land only.
+    - name: tau
+      type: number
+      comment: Timescale in seconds to critically damp the movement.
+    comment: Critically damps the object's vertical motion to height (using critical
+      damping timescale tau) if it is within height * 0.5 of the terrain (or water
+      level if water is TRUE). Only works on physics-enabled objects; do not use with
+      vehicles.
+    name: GroundRepel
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the ground slope directly below the prim's
+      position offset by the vector offset.
+    name: GroundSlope
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: private_key
+      type: string
+      comment: PEM-formatted secret key to use for the HMAC hash.
+    - name: msg
+      type: string
+      comment: Message string to be hashed.
+    - name: algorithm
+      type: string
+      comment: Cryptographic digest algorithm to use.
+    return-type: string
+    comment: Returns a Base64-encoded HMAC hash of msg using the secret key private_key
+      and the specified digest algorithm (md5, sha1, sha224, sha256, sha384, or sha512).
+    name: HMAC
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: url
+      type: string
+      comment: Destination HTTP or HTTPS URL.
+    - name: parameters
+      type: list
+      comment: A list of HTTP_* configuration flags and value pairs.
+    - name: body
+      type: string
+      comment: String contents of the request body.
+    return-type: uuid
+    comment: Sends an HTTP request to the specified url containing body and configured
+      via parameters. Raises an http_response event and returns a key query handle
+      identifying the request.
+    name: HTTPRequest
+    deprecated: true
+  - parameters:
+    - name: request_id
+      type: uuid
+      comment: Unique key identifying the incoming HTTP request.
+    - name: status
+      type: number
+      comment: Integer HTTP status code (such as 200, 400, or 404) to respond with.
+    - name: body
+      type: string
+      comment: String contents of the response body.
+    comment: Responds to the incoming HTTP request identified by request_id with the
+      HTTP status code status and the payload body.
+    name: HTTPResponse
+    deprecated: true
+  - parameters:
+    - name: val
+      type: string
+      comment: String to hash.
+    return-type: number
+    comment: Returns an integer representing the 32-bit hash value of the string val
+      (returns 0 if the string is empty).
+    name: Hash
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: dst
+      type: string
+      comment: Target destination string.
+    - name: pos
+      type: number
+      comment: Zero-based position index where insertion starts.
+    - name: src
+      type: string
+      comment: Source string to insert.
+    return-type: string
+    comment: Returns a new string representing dst with src inserted starting at the
+      zero-based index pos. Note that this operation does not modify dst itself.
+    name: InsertString
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: user
+      type: uuid
+      comment: UUID of the destination user.
+    - name: message
+      type: string
+      comment: Text message string to send.
+    comment: Sends an instant message containing message to the user identified by
+      their key.
+    name: InstantMessage
+    deprecated: true
+  - parameters:
+    - name: number
+      type: number
+      comment: Integer number to encode.
+    return-type: string
+    comment: Returns an 8-character Base64 string representing the big-endian encoded
+      value of number.
+    name: IntegerToBase64
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the agent to check.
+    return-type: number
+    comment: Returns TRUE if agent_id and the owner of the script are friends, and
+      FALSE otherwise.
+    name: IsFriend
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (or LINK_* flag) of the prim to inspect.
+    - name: face
+      type: number
+      comment: Face number (or ALL_SIDES) of the prim to inspect.
+    return-type: number
+    comment: Checks the specified face on the linked prim link. Returns TRUE if the
+      face material is a PBR render material, or FALSE if it uses Blinn-Phong diffuse
+      textures.
+    name: IsLinkGLTFMaterial
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: JSON string to parse.
+    return-type: '{any}'
+    comment: Parses the JSON string src and returns a list representing its top-level
+      elements.
+    name: Json2List
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+      comment: JSON string to query.
+    - name: specifiers
+      type: list
+      comment: A list of key names or array indices specifying the path to the desired
+        value.
+    return-type: string
+    comment: Parses the JSON string json and returns the value found by traversing
+      the specified path of specifiers as a string.
+    name: JsonGetValue
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+      comment: Source JSON string to modify.
+    - name: specifiers
+      type: list
+      comment: A list of key names or array indices specifying the path to add, update,
+        or delete.
+    - name: value
+      type: string
+      comment: New value to set, or the JSON_DELETE constant to delete the targeted
+        element.
+    return-type: string
+    comment: Returns a new JSON string representing json with the target located at
+      specifiers set to value. Supports JSON_APPEND to append elements. Writing JSON_DELETE
+      deletes the target. Overwriting array bounds or setting non-array levels with
+      array indices returns JSON_INVALID.
+    name: JsonSetValue
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: json
+      type: string
+      comment: JSON string containing the value to query.
+    - name: specifiers
+      type: list
+      comment: A list of key names or array indices specifying the path to the value.
+    return-type: string
+    comment: Parses the JSON string json and returns the JSON type constant (JSON_*)
+      representing the value found at specifiers.
+    name: JsonValueType
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the target avatar or prim in the same region.
+    return-type: string
+    comment: Returns a string containing the name of the prim or avatar specified
+      by id. The target must be a valid, rezzed entity in the current region, otherwise
+      an empty string is returned. Avatars return their legacy name.
+    name: Key2Name
+    deprecated: true
+    must-use: true
+  - return-type: uuid
+    comment: Starts an asynchronous transaction requesting the total count of keys
+      in the experience data store. Returns a key query handle for the dataserver
+      event.
+    name: KeyCountKeyValue
+    deprecated: true
+  - parameters:
+    - name: first
+      type: number
+      comment: Zero-based start index of the keys to retrieve.
+    - name: count
+      type: number
+      comment: Number of keys to retrieve.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to retrieve count keys from the experience
+      data store starting at the zero-based index first. Returns a key query handle
+      for the dataserver event. Fails with XP_ERROR_KEY_NOT_FOUND if out of bounds.
+    name: KeysKeyValue
+    deprecated: true
+  - parameters:
+    - name: color
+      type: vector
+      comment: RGB color vector in linear space to convert.
+    return-type: vector
+    comment: Returns a vector representing the conversion of color from the linear
+      RGB colorspace into the sRGB colorspace.
+    name: Linear2sRGB
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag of the prim
+        to adjust.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Adjusts the volume of the currently playing sound attached to the linked
+      prim link (has no effect on sounds started with llTriggerSound).
+    name: LinkAdjustSoundVolume
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: rules
+      type: list
+      comment: A list of particle system rules and data pairs [rule1, data1, ...].
+    comment: Creates or updates a particle system on the linked prim link based on
+      the list of rules. An empty list removes the particle system.
+    name: LinkParticleSystem
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    - name: flags
+      type: number
+      comment: Bitwise flags (combination of SOUND_*) controlling the sound playback.
+    comment: Plays the specified sound on the linked prim link (once or looping) at
+      volume. Only one sound can be attached to a prim at a time; new attachments
+      or calling llStopSound stops previous playback. Controlled by flags.
+    name: LinkPlaySound
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: queue
+      type: boolean | number
+      comment: Boolean. If TRUE, sound queuing is enabled; if FALSE, it is disabled.
+    comment: Enables or disables sound queuing on the linked prim link. When set to
+      TRUE, sounds will queue and play in sequence.
+    name: LinkSetSoundQueueing
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: radius
+      type: number
+      comment: Maximum distance in meters at which the sounds can be heard.
+    comment: Limits the audibility radius of attached and triggered scripted sounds
+      to distance radius (in meters) around the linked prim link.
+    name: LinkSetSoundRadius
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: offset
+      type: vector
+      comment: Offset position vector in local prim coordinates.
+    - name: rot
+      type: quaternion
+      comment: Rotation relative to the prim's rotation.
+    comment: Sets the sit target position (offset) and orientation (rot) for the linked
+      prim link, relative to the prim's own position and rotation. Clear by setting
+      offset to <0.0, 0.0, 0.0>.
+    name: LinkSitTarget
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    comment: Stops the playback of any currently playing attached sound on the linked
+      prim link.
+    name: LinkStopSound
+    deprecated: true
+  - return-type: number
+    comment: Returns an integer representing the number of bytes available/remaining
+      in the linkset's datastore.
+    name: LinksetDataAvailable
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pattern
+      type: string
+      comment: A regular expression (regex) search string used to match keys.
+    return-type: number
+    comment: Returns the total count of keys in the linkset datastore that match the
+      regular expression pattern.
+    name: LinksetDataCountFound
+    deprecated: true
+    must-use: true
+  - return-type: number
+    comment: Returns an integer representing the total number of unique keys stored
+      in the linkset's datastore.
+    name: LinksetDataCountKeys
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the key-value pair to delete.
+    return-type: number
+    comment: Deletes the unprotected key-value pair specified by name from the linkset's
+      datastore, triggering a linkset_data event.
+    name: LinksetDataDelete
+    deprecated: true
+  - parameters:
+    - name: pattern
+      type: string
+      comment: A regular expression (regex) specifying which keys to delete.
+    - name: pass
+      type: string
+      comment: Optional passphrase required to delete matching protected keys.
+    return-type: '{number}'
+    comment: Deletes all keys in the datastore matching the regular expression pattern.
+      Returns a list [num_deleted, num_failed_protected]. Decrypts and deletes protected
+      keys if matching pass is provided.
+    name: LinksetDataDeleteFound
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the protected key-value pair to delete.
+    - name: pass
+      type: string
+      comment: Passphrase required to delete the protected key.
+    return-type: number
+    comment: Deletes the protected key-value pair specified by name from the linkset's
+      datastore using the passphrase pass, triggering a linkset_data event.
+    name: LinksetDataDeleteProtected
+    deprecated: true
+  - parameters:
+    - name: pattern
+      type: string
+      comment: A regular expression (regex) describing which keys to search for.
+    - name: start
+      type: number
+      comment: Zero-based start index of the matching keys to return.
+    - name: count
+      type: number
+      comment: Maximum number of keys to return (or less than 1 to retrieve all matching
+        keys).
+    return-type: '{string}'
+    comment: Returns an alphabetically sorted list of up to count keys from the datastore
+      that match the regular expression pattern, starting at index start (returns
+      all matching keys if count < 1).
+    name: LinksetDataFindKeys
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: start
+      type: number
+      comment: Zero-based start index of the keys to return.
+    - name: count
+      type: number
+      comment: Maximum number of keys to return (or less than 1 to retrieve all keys).
+    return-type: '{string}'
+    comment: Returns an alphabetically sorted list of up to count keys from the datastore,
+      starting at index start (returns all keys if count < 1).
+    name: LinksetDataListKeys
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key of the key-value pair to read.
+    return-type: string
+    comment: Reads and returns the string value corresponding to key name from the
+      linkset's datastore.
+    name: LinksetDataRead
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key of the protected key-value pair to read.
+    - name: pass
+      type: string
+      comment: Passphrase required to read the protected key.
+    return-type: string
+    comment: Reads and returns the string value of the protected key name from the
+      linkset's datastore using the passphrase pass.
+    name: LinksetDataReadProtected
+    deprecated: true
+    must-use: true
+  - comment: Erases all key-value pairs stored in the linkset's datastore, triggering
+      a linkset_data event (with LINKSETDATA_RESET) in all scripts in the linkset.
+    name: LinksetDataReset
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the key-value pair.
+    - name: value
+      type: string
+      comment: String value to write to the datastore.
+    return-type: number
+    comment: Creates or updates an unprotected key-value pair (name and value) in
+      the linkset's datastore. Returns an integer success or failure code.
+    name: LinksetDataWrite
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Key name of the protected key-value pair.
+    - name: value
+      type: string
+      comment: String value to write to the datastore.
+    - name: pass
+      type: string
+      comment: Passphrase used to protect or update the key.
+    return-type: number
+    comment: Creates or updates a protected key-value pair (name and value) in the
+      linkset's datastore using the passphrase pass. Returns an integer success or
+      failure code.
+    name: LinksetDataWriteProtected
+    deprecated: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list to convert.
+    return-type: string
+    comment: Returns a string of comma-separated values taken in order from the list
+      src.
+    name: List2CSV
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: number
+    comment: Returns the float value at index in the list src. Returns 0.0 if the
+      index is out of bounds or if the value cannot be type-cast.
+    name: List2Float
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: number
+    comment: Returns the integer value at index in the list src. Returns 0 if the
+      index is out of bounds or if the value cannot be type-cast.
+    name: List2Integer
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: type
+      type: string
+      comment: JSON target type (JSON_ARRAY or JSON_OBJECT).
+    - name: values
+      type: list
+      comment: List of values to serialize.
+    return-type: string
+    comment: Converts the list values into a JSON string of the specified type (either
+      a JSON_ARRAY or a JSON_OBJECT). Returns JSON_INVALID if an error is encountered.
+    name: List2Json
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: uuid
+    comment: Returns the key (UUID) value at index in the list src. Returns a null
+      string/key if the index is out of bounds or if the value cannot be type-cast.
+    name: List2Key
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source list to slice.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    return-type: '{T}'
+    comment: Returns a new list containing the subset of entries from src within the
+      inclusive range specified by the start and end indices. Negative indices count
+      backward from the end.
+    name: List2List
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source strided list.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    - name: stride
+      type: number
+      comment: Number of entries per stride (defaults to 1 if less than 1).
+    - name: slice_index
+      type: number
+      comment: Zero-based element index within each stride to extract (negatives count
+        backward from the end of the stride).
+    return-type: '{T}'
+    comment: Returns a list containing the slice_index'th element of every stride
+      within the inclusive range from start to end in the strided list src. Stride
+      must be a positive integer.
+    name: List2ListSlice
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source strided list.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive).
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive).
+    - name: stride
+      type: number
+      comment: Number of entries per stride (defaults to 1 if less than 1).
+    return-type: '{T}'
+    comment: Returns a new list containing the first element of every stride in the
+      strided list src within the inclusive range from start to end.
+    name: List2ListStrided
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: quaternion
+    comment: Returns the rotation value at index in the list src. Returns ZERO_ROTATION
+      if the index is out of bounds or if the value cannot be type-cast.
+    name: List2Rot
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: string
+    comment: Returns the string value at index in the list src. Returns an empty string
+      if the index is out of bounds.
+    name: List2String
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: Source list containing the element of interest.
+    - name: index
+      type: number
+      comment: Zero-based index of the entry.
+    return-type: vector
+    comment: Returns the vector value at index in the list src. Returns ZERO_VECTOR
+      if the index is out of bounds or if the value cannot be type-cast.
+    name: List2Vector
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to search within.
+    - name: test
+      type: list
+      comment: List elements to search for.
+    return-type: number
+    comment: (Index semantics) Returns the integer index of the first instance of
+      list test within the list src (returns -1 if not found).
+    name: ListFindList
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to search within.
+    - name: test
+      type: list
+      comment: List elements to search for.
+    - name: instance
+      type: number
+      comment: Zero-based occurrence index of the match to find.
+    return-type: number
+    comment: (Index semantics) Returns the integer index of the specified instance
+      of list test within the list src (returns -1 if not found).
+    name: ListFindListNext
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: list
+      comment: List to search within.
+    - name: test
+      type: list
+      comment: List elements to search for.
+    - name: start
+      type: number
+      comment: Zero-based start index of the range to search.
+    - name: end
+      type: number
+      comment: Zero-based end index of the range to search.
+    - name: stride
+      type: number
+      comment: Number of entries per stride in the list.
+    return-type: number
+    comment: (Index semantics) Returns the integer index of the first instance of
+      list test in the strided list src within the range from start to end (stepping
+      through by stride). Returns -1 if not found.
+    name: ListFindStrided
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: dest
+      type: '{T}'
+      comment: Target destination list.
+    - name: src
+      type: '{T}'
+      comment: Source list to insert.
+    - name: start
+      type: number
+      comment: Zero-based index where insertion begins.
+    return-type: '{T}'
+    comment: Returns a new list containing all elements of dest with the elements
+      of src inserted starting at index start. Does not modify dest itself.
+    name: ListInsertList
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: Source list to randomize.
+    - name: stride
+      type: number
+      comment: Size of each randomized block (defaults to 1 if less than 1).
+    return-type: '{T}'
+    comment: Returns a randomized copy of the list src by blocks of size stride. If
+      the list length is not perfectly divisible by stride, no randomization occurs.
+    name: ListRandomize
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: dest
+      type: '{T}'
+      comment: Target destination list.
+    - name: src
+      type: '{T}'
+      comment: Source list to insert.
+    - name: start
+      type: number
+      comment: Zero-based start index (inclusive) of the replaced range.
+    - name: end
+      type: number
+      comment: Zero-based end index (inclusive) of the replaced range.
+    return-type: '{T}'
+    comment: Returns a copy of the list dest with the inclusive range from start to
+      end removed, and the elements of src inserted in its place at start.
+    name: ListReplaceList
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: List to be sorted.
+    - name: stride
+      type: number
+      comment: Number of entries per block/stride (defaults to 1 if less than 1).
+    - name: ascending
+      type: boolean | number
+      comment: Boolean. If TRUE, sorts in ascending order; if FALSE, sorts in descending
+        order.
+    return-type: '{T}'
+    comment: Returns a copy of the list src, sorted into blocks of stride in ascending
+      order (if ascending is TRUE) or descending order (if FALSE). Only works if the
+      first entry of each block shares the same datatype.
+    name: ListSort
+    deprecated: true
+    must-use: true
+  - type-parameters:
+    - T
+    parameters:
+    - name: src
+      type: '{T}'
+      comment: List to be sorted.
+    - name: stride
+      type: number
+      comment: Number of entries per block/stride (defaults to 1 if less than 1).
+    - name: stride_index
+      type: number
+      comment: Zero-based index of the element within each stride to use as the sort
+        key (negatives count backward from the end of the stride).
+    - name: ascending
+      type: boolean | number
+      comment: Boolean. If TRUE, sorts in ascending order; if FALSE, sorts in descending
+        order.
+    return-type: '{T}'
+    comment: Returns a copy of the list src sorted into blocks of stride by the element
+      at stride_index in each block. Sorted in ascending order (if ascending is TRUE)
+      or descending order (if FALSE).
+    name: ListSortStrided
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: operation
+      type: number
+      comment: LIST_STAT_* constant of the statistical operation to perform.
+    - name: src
+      type: list
+      comment: List of floats and integers to analyze.
+    return-type: number
+    comment: Returns a float representing the result of performing the statistical
+      aggregate function operation (a LIST_STAT_* constant) on the numeric list src.
+    name: ListStatistics
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Input chat channel to listen on (any integer from -2147483648 to 2147483647).
+    - name: name
+      type: string
+      comment: Specific prim name or avatar legacy name to filter by (or empty string
+        for no filter).
+    - name: id
+      type: uuid
+      comment: Specific avatar or prim UUID to filter by (or NULL_KEY for no filter).
+    - name: msg
+      type: string
+      comment: Specific chat message string to filter by (or empty string for no filter).
+    return-type: number
+    comment: Creates a listener on channel from name and id for msg. Returns an integer
+      listener handle used to control or remove the listener. Empty strings or NULL_KEY
+      filters do not filter on those parameters.
+    name: Listen
+    deprecated: true
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer listener handle returned by llListen.
+    - name: active
+      type: boolean | number
+      comment: Boolean. If TRUE, activates the listener; if FALSE, deactivates it.
+    comment: Enables or disables the listener specified by the integer handle. If
+      active is TRUE, the listener is activated; if FALSE, it is deactivated.
+    name: ListenControl
+    deprecated: true
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer listener handle returned by llListen to remove.
+    comment: Completely removes the listener specified by the integer handle.
+    name: ListenRemove
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: message
+      type: string
+      comment: Text message to display in the dialog box.
+    - name: url
+      type: string
+      comment: Web URL to open.
+    comment: Shows a dialog box displaying message to the avatar avatar offering to
+      open the specified url. Clicking yes launches the URL in their default web browser.
+    name: LoadURL
+    deprecated: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to evaluate.
+    return-type: number
+    comment: Returns a float representing the natural (base e) logarithm of the positive
+      value val (returns 0.0 if val <= 0).
+    name: Log
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to evaluate.
+    return-type: number
+    comment: Returns a float representing the base-10 (common) logarithm of the positive
+      value val (returns 0.0 if val <= 0).
+    name: Log10
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: target
+      type: vector
+      comment: Target position vector in region coordinates to look at.
+    - name: strength
+      type: number
+      comment: Force of rotation (0.0 cancels the tracking; values around half the
+        object's mass are typical).
+    - name: damping
+      type: number
+      comment: Timescale in seconds to critically damp the orientation.
+    comment: Causes the object to orient its positive Z-axis (up axis) toward the
+      target vector, keeping its positive X-axis (forward axis) below the horizon.
+      Tracks target until llStopLookAt is called or strength is set to 0.0.
+    name: LookAt
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound looping indefinitely at the specified volume.
+      Only one sound can be attached to a prim at a time; new loops adjust the volume
+      of the currently playing sound without restarting it.
+    name: LoopSound
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound looping indefinitely at the specified volume
+      and declares it a Sync Master, forcing slave sounds to synchronize with it.
+    name: LoopSoundMaster
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound looping indefinitely at the specified volume,
+      synchronized to the most audible active Sync Master in range.
+    name: LoopSoundSlave
+    deprecated: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to hash.
+    - name: nonce
+      type: number
+      comment: Nonce string used as a salt.
+    return-type: string
+    comment: Returns a string of 32 hex characters representing the MD5 checksum of
+      src salted with nonce (formatted as ':' + nonce).
+    name: MD5String
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    comment: Deprecated. Generates a circular explosion of particles. Use llParticleSystem
+      instead.
+    name: MakeExplosion
+    deprecated: true
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    comment: Deprecated. Generates fire-like particles. Use llParticleSystem instead.
+    name: MakeFire
+    deprecated: true
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: bounce
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    - name: bounce_offset
+      type: number
+    comment: Deprecated. Generates a fountain of particles. Use llParticleSystem instead.
+    name: MakeFountain
+    deprecated: true
+  - parameters:
+    - name: particles
+      type: number
+    - name: scale
+      type: number
+    - name: vel
+      type: number
+    - name: lifetime
+      type: number
+    - name: arc
+      type: number
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position (expressed in local coordinates;
+        completely ignored by the system).
+    comment: Deprecated. Generates smoke-like particles. Use llParticleSystem instead.
+    name: MakeSmoke
+    deprecated: true
+  - parameters:
+    - name: action
+      type: number
+      comment: An ESTATE_ACCESS_* action flag specifying the operation to perform.
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar or group to add or remove.
+    return-type: number
+    comment: Adds or removes agents from the estate's access or ban lists, or groups
+      from the estate's group access list, specified by the action. Returns TRUE if
+      successful, or FALSE if throttled, if the action/ID is invalid, or if the script
+      owner lacks estate management rights.
+    name: ManageEstateAccess
+    deprecated: true
+  - parameters:
+    - name: region_name
+      type: string
+      comment: Name of the region where the beacon is displayed.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates to highlight.
+    - name: options
+      type: list
+      comment: A list of options to configure the map beacon.
+    comment: Displays an in-world beacon and optionally opens the world map for the
+      avatar touching or wearing the object, centered on region_name with pos highlighted.
+      Only works for attached scripts or during touch events.
+    name: MapBeacon
+    deprecated: true
+  - parameters:
+    - name: simname
+      type: string
+      comment: Name of the target simulator region.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates to highlight.
+    - name: look_at
+      type: vector
+      comment: Position in local coordinates (currently unused/ignored).
+    comment: 'Opens the world map for the avatar touching or wearing the object, centered
+      on simname with pos highlighted. Only works for attached scripts or during touch
+      events. Note: look_at currently has no effect.'
+    name: MapDestination
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag controlling
+        which prim(s) receive the message.
+    - name: num
+      type: number
+      comment: An integer value passed as the second parameter of the link_message
+        event.
+    - name: str
+      type: string | uuid
+      comment: A string value passed as the third parameter of the link_message event.
+    - name: id
+      type: string | uuid
+      comment: A key value passed as the fourth parameter of the link_message event.
+    comment: Triggers a link_message event, sending num, str, and id to the scripts
+      in the prim(s) specified by link to allow scripts within the same object to
+      communicate.
+    name: MessageLinked
+    deprecated: true
+  - parameters:
+    - name: delay
+      type: number
+      comment: Minimum delay duration in seconds.
+    comment: Sets the minimum delay time between events being handled (minimums and
+      defaults vary by event type).
+    name: MinEventDelay
+    deprecated: true
+  - parameters:
+    - name: a
+      type: number
+      comment: Base integer value.
+    - name: b
+      type: number
+      comment: Power exponent (capped at 0xFFFF / 16 bits).
+    - name: c
+      type: number
+      comment: Modulus integer value.
+    return-type: number
+    comment: Returns an integer representing a raised to the power b, modulo c (i.e.,
+      (a**b)%c). The b value is capped at 0xFFFF (16 bits).
+    name: ModPow
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: action
+      type: number
+      comment: LAND_* action flag to perform (e.g., LAND_LEVEL, LAND_RAISE, LAND_LOWER,
+        LAND_SMOOTH, LAND_NOISE, or LAND_REVERT).
+    - name: brush
+      type: number
+      comment: Brush size (0, 1, or 2, representing 2m x 2m, 4m x 4m, or 8m x 8m).
+    comment: Modifies the terrain using the specified land action and brush size (0,
+      1, or 2, corresponding to 2m x 2m, 4m x 4m, or 8m x 8m).
+    name: ModifyLand
+    deprecated: true
+  - parameters:
+    - name: target
+      type: vector
+      comment: Target position vector in region coordinates.
+    - name: tau
+      type: number
+      comment: Timescale in seconds to critically damp the movement.
+    comment: Critically damps the physical object's motion to position target in tau
+      seconds. Setting tau to 0.0 stops the critical damping; recommended tau values
+      are greater than 0.2.
+    name: MoveToTarget
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the avatar (e.g., 'First Last' or 'first.last').
+    return-type: uuid
+    comment: Requests the key (UUID) of the avatar name in the current region. Returns
+      NULL_KEY if no matching agent is present. Formats are 'First Last' or 'first.last'
+      (assumes 'Resident' if last name is omitted; case-insensitive).
+    name: Name2Key
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Destination position vector in region coordinates.
+    - name: options
+      type: list
+      comment: A list of parameters to configure pathfinding behavior (currently only
+        FORCE_DIRECT_PATH is supported).
+    comment: Directs a pathfinding character to navigate to the position pos (located
+      in the current or adjacent regions) using the parameters specified in options.
+    name: NavigateTo
+    deprecated: true
+  - parameters:
+    - name: u
+      type: number
+      comment: Horizontal (U) offset, typically in the interval [-1.0, 1.0].
+    - name: v
+      type: number
+      comment: Vertical (V) offset, typically in the interval [-1.0, 1.0].
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the texture horizontal (u) and vertical (v) offsets for the chosen
+      face. If face is ALL_SIDES, offsets all faces.
+    name: OffsetTexture
+    deprecated: true
+  - parameters:
+    - name: floater_name
+      type: string
+      comment: Identifier string of the viewer floater to open.
+    - name: url
+      type: string
+      comment: URL to load within the opened floater.
+    - name: params
+      type: list
+      comment: Options or parameters to apply to the opened floater.
+    return-type: number
+    comment: Opens the specified viewer floater_name loaded with url and configured
+      via params. Returns an integer error code, or 0 if successful.
+    name: OpenFloater
+    deprecated: true
+  - comment: Deprecated. Creates a channel to listen for incoming XML-RPC calls, triggering
+      a remote_data event with the channel ID once available.
+    name: OpenRemoteDataChannel
+    deprecated: true
+  - parameters:
+    - name: val
+      type: string
+      comment: Source string containing the character.
+    - name: index
+      type: number
+      comment: Zero-based index of the character to convert.
+    return-type: number
+    comment: Returns the integer Unicode (ordinal) value of the character at index
+      in the string val.
+    name: Ord
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the group, avatar, or object to check.
+    return-type: number
+    comment: Returns TRUE if the avatar or object specified by key id is over land
+      owned by the script owner, or FALSE otherwise.
+    name: OverMyLand
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: msg
+      type: string
+      comment: Text message string to send.
+    comment: Sends the chat message msg privately to the object owner (the owner must
+      be currently in the same region for the message to be received).
+    name: OwnerSay
+    deprecated: true
+  - parameters:
+    - name: commandList
+      type: list
+      comment: A list containing integer PARCEL_MEDIA_COMMAND_* flags and their corresponding
+        parameters.
+    comment: Controls the playback of movies and other multimedia resources on a parcel
+      or for an agent, using the PARCEL_MEDIA_COMMAND_* settings specified in commandList.
+    name: ParcelMediaCommandList
+    deprecated: true
+  - parameters:
+    - name: query
+      type: '{number}'
+      comment: A list of PARCEL_MEDIA_COMMAND_* attributes to query.
+    return-type: '{any}'
+    comment: Queries the media properties of the parcel containing the script, returning
+      a list of values in the order requested by query. Only works if the object is
+      owned by the landowner or deeded to the land's group.
+    name: ParcelMediaQuery
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to parse.
+    - name: separators
+      type: '{string}'
+      comment: A list of up to 8 strings representing separators to be discarded.
+    - name: spacers
+      type: '{string}'
+      comment: A list of up to 8 strings representing spacers to be preserved in the
+        list.
+    return-type: '{string}'
+    comment: Breaks the string src into a list of substrings, discarding any separators,
+      keeping spacers, and omitting any empty null values. separators and spacers
+      accept up to 8 string entries each.
+    name: ParseString2List
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to parse.
+    - name: separators
+      type: '{string}'
+      comment: A list of up to 8 strings representing separators to be discarded.
+    - name: spacers
+      type: '{string}'
+      comment: A list of up to 8 strings representing spacers to be preserved in the
+        list.
+    return-type: '{string}'
+    comment: Breaks the string src into a list, discarding separators and keeping
+      spacers, while preserving empty null values (unlike llParseString2List). separators
+      and spacers accept up to 8 string entries each.
+    name: ParseStringKeepNulls
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: rules
+      type: list
+      comment: A list of particle system rules and data pairs [rule1, data1, ...].
+    comment: Creates or updates a particle system on the prim containing the script
+      based on rules. An empty list removes the particle system.
+    name: ParticleSystem
+    deprecated: true
+  - parameters:
+    - name: pass
+      type: boolean | number
+      comment: A PASS_* flag (e.g., PASS_ALWAYS, PASS_IF_NOT_HANDLED, or PASS_NEVER).
+    comment: Sets the pass-collisions attribute. If pass is TRUE, collision events
+      are passed from child prims to the root; if FALSE (default), they only trigger
+      events in the affected child prim.
+    name: PassCollisions
+    deprecated: true
+  - parameters:
+    - name: pass
+      type: boolean | number
+      comment: A PASS_* flag (e.g., PASS_ALWAYS, PASS_IF_NOT_HANDLED, or PASS_NEVER).
+    comment: Sets the pass-touches attribute. If pass is TRUE, touch events are passed
+      from child prims to the root; if FALSE (default), they only trigger events in
+      the affected child prim.
+    name: PassTouches
+    deprecated: true
+  - parameters:
+    - name: patrolPoints
+      type: '{vector}'
+      comment: A list of at least two position vectors representing the patrol path.
+    - name: options
+      type: list
+      comment: A list of PATROL_* flags and parameters to configure the patrol behavior.
+    comment: Directs a pathfinding character to patrol sequentially through the coordinates
+      specified in patrolPoints, configured by options.
+    name: PatrolPoints
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the specified sound once at volume, attached to the object. Only
+      one sound can be attached to a prim at a time; new sounds or calling llStopSound
+      stops previous playback. A second call with the same sound adjusts the volume
+      without restarting it.
+    name: PlaySound
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays the attached sound once at volume, synchronized to the next loop
+      point of the most audible active Sync Master.
+    name: PlaySoundSlave
+    deprecated: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector to point at.
+    comment: Directs the avatar owning the object to point at the vector pos.
+    name: PointAt
+    deprecated: true
+  - parameters:
+    - name: base
+      type: number
+      comment: Base float value.
+    - name: exponent
+      type: number
+      comment: Exponent float value.
+    return-type: number
+    comment: Returns a float representing base raised to the power exponent. Returns
+      0 and triggers a Math Error for imaginary results.
+    name: Pow
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of the sound in the prim's inventory, or a UUID.
+    comment: Causes nearby viewers in range to preload the specified sound from the
+      object's inventory to prevent playback delays.
+    name: PreloadSound
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the group, avatar, or object to pursue.
+    - name: options
+      type: list
+      comment: A list of options to configure pursuit behavior.
+    comment: Directs a pathfinding character to pursue and chase target, configured
+      by the parameters specified in options.
+    name: Pursue
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target avatar or object in the same region.
+    - name: impulse
+      type: vector
+      comment: Linear impulse vector representing the direction and force of the push.
+    - name: ang_impulse
+      type: vector
+      comment: Angular impulse vector representing the rotational force.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, forces are applied relative to the target's local
+        axes; if FALSE, relative to region axes.
+    comment: Applies physical impulse (force) and ang_impulse (rotational force) to
+      the specified target avatar or object.
+    name: PushObject
+    deprecated: true
+  - parameters:
+    - name: k
+      type: string
+      comment: Key of the key-value pair to read.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to read the value associated with
+      key k in the experience. Returns a key query handle for the dataserver event.
+      Fails with XP_ERROR_KEY_NOT_FOUND if the key does not exist.
+    name: ReadKeyValue
+    deprecated: true
+  - comment: Legacy function intended to reload the web page displayed on the prim's
+      faces (currently non-functional).
+    name: RefreshPrimURL
+    deprecated: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Output chat channel to broadcast on (must be non-zero).
+    - name: msg
+      type: string
+      comment: Text message string to broadcast.
+    comment: Broadcasts the message msg on channel to the entire region (heard by
+      any script listening on that channel; channel 0 is not permitted).
+    name: RegionSay
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the destination avatar or prim in the same region.
+    - name: channel
+      type: number
+      comment: Output chat channel (any integer value).
+    - name: msg
+      type: string
+      comment: Text message string to send.
+    comment: Sends the message msg on channel privately to the targeted avatar or
+      object (if within the region). If target is an avatar and channel is non-zero,
+      the message can also be heard by any attachments worn by the avatar.
+    name: RegionSayTo
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    comment: Deprecated. Intended to return camera control back to the avatar (use
+      llClearCameraParams instead).
+    name: ReleaseCamera
+    deprecated: true
+  - comment: Stops taking inputs (previously acquired via llTakeControls) from the
+      avatar, dequeuing any remaining control events and revoking the PERMISSION_TAKE_CONTROLS
+      permission.
+    name: ReleaseControls
+    deprecated: true
+  - parameters:
+    - name: url
+      type: string
+      comment: URL string to release.
+    comment: Releases the specified url (previously obtained via llRequestURL), rendering
+      it no longer usable.
+    name: ReleaseURL
+    deprecated: true
+  - parameters:
+    - name: channel
+      type: uuid
+      comment: XML-RPC channel ID.
+    - name: message_id
+      type: uuid
+      comment: XML-RPC message ID.
+    - name: sdata
+      type: string
+      comment: String payload data to reply with.
+    - name: idata
+      type: number
+      comment: Integer payload data to reply with.
+    comment: Deprecated. Sends an XML-RPC reply on channel to message_id with payload
+      string sdata and integer idata.
+    name: RemoteDataReply
+    deprecated: true
+  - comment: Deprecated. Used with XML-RPC to reregister remote data channels if the
+      object moves to another region.
+    name: RemoteDataSetRegion
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target prim.
+    - name: name
+      type: string
+      comment: Name of the script in the prim's inventory.
+    - name: running
+      type: number
+      comment: Whether the script should start running.
+    - name: start_param
+      type: number
+      comment: Start parameter passed to the script.
+    comment: Deprecated.
+    name: RemoteLoadScript
+    deprecated: true
+  - parameters:
+    - name: target
+      type: uuid
+      comment: UUID of the target prim in the same region.
+    - name: name
+      type: string
+      comment: Name of the script in the prim's inventory.
+    - name: pin
+      type: number
+      comment: Integer PIN code (must match the PIN set on the target via llSetRemoteScriptAccessPin).
+    - name: running
+      type: boolean | number
+      comment: Boolean. If TRUE, sets the copied script to run immediately; if FALSE,
+        leaves it stopped.
+    - name: start_param
+      type: number
+      comment: Integer start parameter passed to the copied script (readable via llGetStartParameter).
+    comment: Copies the script name into target, setting it running (if running is
+      TRUE) with the start_param, provided the script owner has modify permissions
+      on target and target's PIN matches pin (set via llSetRemoteScriptAccessPin).
+    name: RemoteLoadScriptPin
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to remove.
+    comment: Removes the specified avatar from the land parcel's ban list.
+    name: RemoveFromLandBanList
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to remove.
+    comment: Removes the specified avatar from the land parcel's pass/access list.
+    name: RemoveFromLandPassList
+    deprecated: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory to remove.
+    comment: Permanently deletes the named inventory item from the prim's inventory.
+    name: RemoveInventory
+    deprecated: true
+  - parameters:
+    - name: flags
+      type: number
+      comment: A bitwise mask of VEHICLE_FLAG_* constants to disable.
+    comment: Disables the specified vehicle flags (sets them to FALSE) using the bitwise
+      mask flags.
+    name: RemoveVehicleFlags
+    deprecated: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of an agent in the region participating in the experience.
+    - name: transition
+      type: number
+      comment: Duration in seconds over which to transition to the new environment.
+    - name: environment
+      type: string | uuid
+      comment: Name of an environmental setting in inventory, or its asset UUID (or
+        empty string/NULL_KEY to clear).
+    return-type: number
+    comment: Replaces the region and parcel environment seen by the specified agent_id
+      as part of an experience, transitioning the settings over transition seconds.
+      Passing NULL_KEY or an empty string for environment restores defaults.
+    name: ReplaceAgentEnvironment
+    deprecated: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Position vector of the target parcel (the Z component is ignored; use
+        <-1.0, -1.0, -1.0> for the entire region).
+    - name: environment
+      type: string | uuid
+      comment: Name of an environmental setting in inventory, or its asset UUID (or
+        empty string/NULL_KEY to clear).
+    - name: track_no
+      type: number
+      comment: 'The elevation track to change (0: water, 1: ground, 2: 1000m, 3: 2000m,
+        4: 3000m, -1: all tracks).'
+    - name: day_length
+      type: number
+      comment: Day cycle length in seconds (-1 to leave unchanged).
+    - name: day_offset
+      type: number
+      comment: Day cycle offset in seconds from UTC (-1 to leave unchanged).
+    return-type: number
+    comment: Replaces the environment on the parcel containing position (or the entire
+      region if position is <-1.0, -1.0, -1.0>) for the specified track_no. Modifies
+      day_length and day_offset if specified. Requires edit permissions on the parcel
+      or estate management rights.
+    name: ReplaceEnvironment
+    deprecated: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Original source string to search.
+    - name: pattern
+      type: string
+      comment: Substring pattern to find and replace.
+    - name: replacement_pattern
+      type: string
+      comment: New substring used to replace the pattern.
+    - name: count
+      type: number
+      comment: Maximum number of replacements to make (0 for all, positive for left-to-right,
+        negative for right-to-left).
+    return-type: string
+    comment: Returns a new string representing src with count occurrences of pattern
+      replaced by replacement_pattern. Setting count to 0 replaces all occurrences;
+      positive counts process left-to-right, while negative counts process right-to-left.
+    name: ReplaceSubString
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the agent.
+    - name: data
+      type: number
+      comment: DATA_* category flag of the requested information.
+    return-type: uuid
+    comment: Asynchronously requests the specified data category (DATA_*) about the
+      agent id. Triggers a dataserver event with the results and returns a key query
+      handle.
+    name: RequestAgentData
+    deprecated: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar to query.
+    return-type: uuid
+    comment: Asynchronously requests the display name of the agent specified by id,
+      triggering a dataserver event with the results. The agent does not need to be
+      online or in the region. Returns a key query handle.
+    name: RequestDisplayName
+    deprecated: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the agent to request permissions from.
+    - name: name
+      type: string
+      comment: Deprecated parameter (no longer used).
+    comment: Requests permission from the specified agent to participate in the experience.
+      These permissions are persistent and apply grid-wide across all scripts in the
+      experience, automatically triggering experience_permissions or experience_permissions_denied.
+    name: RequestExperiencePermissions
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the item in the prim's inventory.
+    return-type: uuid
+    comment: Asynchronously requests data for the inventory item specified by name,
+      triggering a dataserver event. Currently, only landmark items are supported
+      (which return local region coordinates). Returns a key query handle.
+    name: RequestInventoryData
+    deprecated: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the agent in the same region.
+    - name: permissions
+      type: number
+      comment: Bitfield containing the PERMISSION_* constants to request.
+    comment: Requests permissions (a bitfield specified by permissions) from the agent
+      in the same region, calling run_time_permissions if granted. This call does
+      not pause script execution.
+    name: RequestPermissions
+    deprecated: true
+  - return-type: uuid
+    comment: Asynchronously requests one secure HTTPS (SSL, port 12043) URL for use
+      by this object, triggering an http_request event. Returns a key query handle.
+    name: RequestSecureURL
+    deprecated: true
+  - parameters:
+    - name: region
+      type: string
+      comment: Case-sensitive region name.
+    - name: data
+      type: number
+      comment: DATA_SIM_* flag of the requested simulator data.
+    return-type: uuid
+    comment: Asynchronously requests data (using a DATA_SIM_* constant) about the
+      region. Triggers a dataserver event and returns a key query handle.
+    name: RequestSimulatorData
+    deprecated: true
+  - return-type: uuid
+    comment: Asynchronously requests one HTTP URL for use by this script, triggering
+      an http_request event. Returns a key query handle.
+    name: RequestURL
+    deprecated: true
+  - parameters:
+    - name: username
+      type: string
+      comment: Current or historical username of the avatar to resolve.
+    return-type: uuid
+    comment: Asynchronously requests the Agent ID key (UUID) for the agent specified
+      by their current or historical username, returning NULL_KEY if not found. Returns
+      a key query handle for the dataserver event.
+    name: RequestUserKey
+    deprecated: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar to query.
+    return-type: uuid
+    comment: Asynchronously requests the unique single-word username of the agent
+      identified by id, triggering a dataserver event. The agent does not need to
+      be online or in the region. Returns a key query handle.
+    name: RequestUsername
+    deprecated: true
+  - parameters:
+    - name: anim_state
+      type: string
+      comment: Animation state string (or 'ALL') to reset.
+    comment: Resets the animation override for anim_state to its default value (use
+      'ALL' to reset all states). Requires the PERMISSION_OVERRIDE_ANIMATIONS permission.
+    name: ResetAnimationOverride
+    deprecated: true
+  - comment: Removes all blocked residents from the land parcel's ban list.
+    name: ResetLandBanList
+    deprecated: true
+  - comment: Removes all residents from the land parcel's access/pass list.
+    name: ResetLandPassList
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the target script in the prim's inventory.
+    comment: Resets the script name located in the prim's inventory.
+    name: ResetOtherScript
+    deprecated: true
+  - comment: Resets the current script.
+    name: ResetScript
+    deprecated: true
+  - comment: Resets the script's elapsed time timer back to zero.
+    name: ResetTime
+    deprecated: true
+  - parameters:
+    - name: objects
+      type: '{uuid}'
+      comment: A list of object UUID keys to return.
+    return-type: number
+    comment: Returns objects specified by the list of UUIDs objects to their owners.
+      Requires the PERMISSION_RETURN_OBJECTS permission, and the script owner must
+      own the parcel or be an estate manager/region owner.
+    name: ReturnObjectsByID
+    deprecated: true
+  - parameters:
+    - name: owner
+      type: uuid
+      comment: UUID of the avatar or group whose objects will be returned.
+    - name: scope
+      type: number
+      comment: OBJECT_RETURN_* scope flag (such as OBJECT_RETURN_PARCEL, OBJECT_RETURN_PARCEL_OWNER,
+        or OBJECT_RETURN_REGION).
+    return-type: number
+    comment: Returns objects owned by owner within the specified scope (parcel, parcel
+      owner, or region). Requires the PERMISSION_RETURN_OBJECTS permission, and the
+      script owner must own the parcel or be an estate manager/region owner.
+    name: ReturnObjectsByOwner
+    deprecated: true
+  - parameters:
+    - name: inventory
+      type: string
+      comment: Name of the object in the prim's inventory.
+    - name: position
+      type: vector
+      comment: Position vector in region coordinates where the root of the object
+        will be placed.
+    - name: velocity
+      type: vector
+      comment: Initial velocity vector for the rezzed object.
+    - name: rot
+      type: quaternion
+      comment: Initial rotation of the rezzed object.
+    - name: param
+      type: number
+      comment: Start parameter passed to the rezzed object's on_rez event (accessible
+        via llGetStartParameter).
+    comment: Instantiates the inventory object at position moving at velocity, rotated
+      to rot with its root prim centered exactly on position, passing param as the
+      on_rez start parameter.
+    name: RezAtRoot
+    deprecated: true
+  - parameters:
+    - name: inventory
+      type: string
+      comment: Name of the object in the prim's inventory.
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates where the center of the object
+        will be placed.
+    - name: vel
+      type: vector
+      comment: Initial velocity vector (maximum magnitude ~200m/s).
+    - name: rot
+      type: quaternion
+      comment: Initial rotation of the rezzed object.
+    - name: param
+      type: number
+      comment: Start parameter passed to the rezzed object's on_rez event (accessible
+        via llGetStartParameter).
+    comment: Instantiates the inventory object at pos with velocity vel and rotation
+      rot, passing param as the on_rez start parameter. The vel parameter is ignored
+      if the rezzed object is non-physical.
+    name: RezObject
+    deprecated: true
+  - parameters:
+    - name: inventory
+      type: string
+      comment: Name of the object in the prim's inventory.
+    - name: params
+      type: list
+      comment: A list of REZ_* parameters to configure the rezzed object's attributes.
+    return-type: uuid
+    comment: Instantiates the inventory object (defaulting to the rezzing prim's position
+      unless REZ_POS is specified) using the initial set of parameters specified in
+      params. Returns the key of the rezzed object, or a blank key on failure.
+    name: RezObjectWithParams
+    deprecated: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Rotation value.
+    return-type: number
+    comment: Returns a float representing the rotation angle of rot.
+    name: Rot2Angle
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a vector representing the rotation axis of rot.
+    name: Rot2Axis
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: quat
+      type: quaternion
+      comment: Rotation value to convert.
+    return-type: vector
+    comment: Returns a vector representing the Euler rotation (roll, pitch, yaw) of
+      quat, with each component expressed in radians.
+    name: Rot2Euler
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a unit vector pointing in the local positive X direction (forward)
+      relative to the parent (root prim or region) defined by rotation q.
+    name: Rot2Fwd
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a unit vector pointing in the local positive Y direction (left)
+      relative to the parent (root prim or region) defined by rotation q.
+    name: Rot2Left
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Rotation value.
+    return-type: vector
+    comment: Returns a unit vector pointing in the local positive Z direction (up)
+      relative to the parent (root prim or region) defined by rotation q.
+    name: Rot2Up
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: start
+      type: vector
+      comment: Starting vector.
+    - name: end
+      type: vector
+      comment: Target ending vector.
+    return-type: quaternion
+    comment: Returns a rotation representing the shortest path rotation from vector
+      start to vector end.
+    name: RotBetween
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: target_direction
+      type: quaternion
+      comment: Target rotation to align the object with.
+    - name: strength
+      type: number
+      comment: Force of rotation (0.0 cancels the tracking; values around half the
+        object's mass are typical).
+    - name: damping
+      type: number
+      comment: Timescale in seconds to critically damp the rotation.
+    comment: Causes the object to smoothly rotate to target_direction with a force
+      defined by strength and damping. A strength of 0.0 cancels the rotation target.
+      Rotation is maintained until stopped with llStopLookAt.
+    name: RotLookAt
+    deprecated: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Target rotation to track.
+    - name: error
+      type: number
+      comment: Tolerance angle in radians defining when the target rotation is considered
+        reached.
+    return-type: number
+    comment: Registers the rotation rot with a leeway tolerance error (in radians)
+      as a target, triggering at_rot_target and not_at_rot_target events. Returns
+      an integer handle to unregister the target via llRotTargetRemove.
+    name: RotTarget
+    deprecated: true
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer target handle returned by llRotTarget to remove.
+    comment: Removes the rotational target specified by the integer handle registered
+      with llRotTarget.
+    name: RotTargetRemove
+    deprecated: true
+  - parameters:
+    - name: angle
+      type: number
+      comment: Rotation angle expressed in radians.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the texture rotation of face to the specified angle (in radians).
+      If face is ALL_SIDES, rotates the texture on all faces.
+    name: RotateTexture
+    deprecated: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Float value to round.
+    return-type: number
+    comment: Returns the integer that float val is closest to.
+    name: Round
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to hash.
+    return-type: string
+    comment: Returns a string of 40 hex characters representing the SHA-1 security
+      hash of src.
+    name: SHA1String
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to hash.
+    return-type: string
+    comment: Returns a string of 64 hex characters representing the SHA-256 security
+      hash of src.
+    name: SHA256String
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: uuid
+      type: uuid
+      comment: UUID of the group, avatar, or prim to check.
+    return-type: number
+    comment: Returns TRUE if the agent or object specified by uuid is in the same
+      region (simulator) and shares the same active group as the prim containing the
+      script; returns FALSE otherwise.
+    name: SameGroup
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Integer chat channel to transmit the message on.
+    - name: msg
+      type: string
+      comment: Text message string to transmit.
+    comment: Says the text message msg on the specified channel. The message can be
+      heard up to a 20m radius. Channels other than PUBLIC_CHANNEL (0) and DEBUG_CHANNEL
+      (2147483647) are not visible to avatars and can be used for script-to-script
+      communication.
+    name: Say
+    deprecated: true
+  - parameters:
+    - name: scaling_factor
+      type: number
+      comment: Multiplier scale factor to apply to the prim sizes and their local
+        positions.
+    return-type: number
+    comment: Attempts to uniformly resize the entire object by scaling_factor, maintaining
+      size-position ratios of the prims. Fails if the linkset is physical, a pathfinding
+      character, in keyframed motion, would exceed prim scale/linkability limits,
+      or would overflow parcel capacity.
+    name: ScaleByFactor
+    deprecated: true
+  - parameters:
+    - name: u
+      type: number
+      comment: Horizontal (U) texture repeats scale value, in the interval [-100.0,
+        100.0].
+    - name: v
+      type: number
+      comment: Vertical (V) texture repeats scale value, in the interval [-100.0,
+        100.0].
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the diffuse texture horizontal u and vertical v scales (repeats)
+      on the specified face of the prim. Setting face to ALL_SIDES updates all sides.
+      Negative scale values flip the texture.
+    name: ScaleTexture
+    deprecated: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector in region coordinates to check.
+    return-type: number
+    comment: Returns TRUE if the vector position pos is over public land, sandbox
+      land, land restricting edit/build permissions, or land that disables outside
+      scripts.
+    name: ScriptDanger
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: flags
+      type: number
+      comment: PROFILE_* flag (such as PROFILE_NONE or PROFILE_SCRIPT_MEMORY) to set
+        the profiling state.
+    comment: Enables or disables the script's profiling state using flags (supports
+      PROFILE_SCRIPT_MEMORY on Mono, or PROFILE_NONE). Active profiling can significantly
+      reduce script performance.
+    name: ScriptProfiler
+    deprecated: true
+  - parameters:
+    - name: channel
+      type: uuid
+      comment: XML-RPC channel ID.
+    - name: dest
+      type: string
+      comment: Destination XML-RPC URL or server.
+    - name: idata
+      type: number
+      comment: Integer payload data.
+    - name: sdata
+      type: string
+      comment: String payload data.
+    return-type: uuid
+    comment: Deprecated. Sends an XML-RPC request to dest on channel, containing the
+      channel ID as a string, integer idata, and string sdata. Returns a key representing
+      the message_id.
+    name: SendRemoteData
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Specific object or avatar name to filter for (or empty string for no
+        filter).
+    - name: id
+      type: uuid
+      comment: UUID of the group, avatar, or object to filter by (or NULL_KEY for
+        no filter).
+    - name: type
+      type: number
+      comment: Integer bitfield type mask containing AGENT, AGENT_BY_LEGACY_NAME,
+        AGENT_BY_USERNAME, ACTIVE, PASSIVE, or SCRIPTED (0 for no filter).
+    - name: radius
+      type: number
+      comment: Maximum distance in meters to scan (range [0.0, 96.0]).
+    - name: arc
+      type: number
+      comment: Maximum angle in radians relative to the local X-axis to scan (range
+        [0.0, PI]).
+    comment: Performs a single scan from the prim's forward vector for name and id
+      of type within radius meters and arc radians. Results trigger a sensor or no_sensor
+      event. Passing empty filters (blank name, 0 type, or NULL_KEY id) disables that
+      filter.
+    name: Sensor
+    deprecated: true
+  - comment: Removes the periodic sensor previously configured by llSensorRepeat.
+    name: SensorRemove
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Specific object or avatar name to filter for (or empty string for no
+        filter).
+    - name: id
+      type: uuid
+      comment: UUID of the group, avatar, or object to filter by (or NULL_KEY for
+        no filter).
+    - name: type
+      type: number
+      comment: Integer bitfield type mask containing AGENT, AGENT_BY_LEGACY_NAME,
+        AGENT_BY_USERNAME, ACTIVE, PASSIVE, or SCRIPTED (0 for no filter).
+    - name: radius
+      type: number
+      comment: Maximum distance in meters to scan (range [0.0, 96.0]).
+    - name: arc
+      type: number
+      comment: Maximum angle in radians relative to the local X-axis to scan (range
+        [0.0, PI]).
+    - name: rate
+      type: number
+      comment: Interval in seconds between repeated scans.
+    comment: Sets up a repeating periodic scan every rate seconds for name and id
+      of type within radius meters and arc radians of the forward vector. Results
+      trigger sensor or no_sensor events.
+    name: SensorRepeat
+    deprecated: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the agent participating in the experience.
+    - name: transition
+      type: number
+      comment: Transition duration in seconds.
+    - name: params
+      type: list
+      comment: A list of environmental parameters to apply.
+    return-type: number
+    comment: Sets an individual agent's environmental settings using the attributes
+      in params over a duration of transition seconds. Must be used as part of an
+      experience; passing an empty list removes overrides.
+    name: SetAgentEnvironment
+    deprecated: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Target rotation to turn the avatar to face.
+    - name: flags
+      type: number
+      comment: Flags to configure the rotation behavior.
+    comment: Sets the rotation of the avatar to rot, controlled by flags.
+    name: SetAgentRot
+    deprecated: true
+  - parameters:
+    - name: alpha
+      type: number
+      comment: Transparency value to set, from 0.0 (clear) to 1.0 (solid; clamped
+        to a minimum of 0.1).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the diffuse texture alpha (opacity) of face. If face is ALL_SIDES,
+      applies to all faces. Values are clamped between 0.1 and 1.0 (where 1.0 is fully
+      opaque).
+    name: SetAlpha
+    deprecated: true
+  - parameters:
+    - name: initial_omega
+      type: vector
+      comment: Angular velocity vector to apply (in radians per second).
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, initial_omega is treated as a local vector; if FALSE,
+        as a global region vector.
+    comment: Sets the angular velocity of a physical object to initial_omega (mass-independent).
+      If local is TRUE, applied in local coordinates; if FALSE, applied in global
+      coordinates. Has no effect on non-physical objects.
+    name: SetAngularVelocity
+    deprecated: true
+  - parameters:
+    - name: anim_state
+      type: string
+      comment: Animation state to override.
+    - name: anim
+      type: string
+      comment: Name of an animation in the prim's inventory, or a built-in animation
+        name.
+    comment: Overrides the default animation for anim_state with anim (which must
+      be in the object's inventory or a built-in animation). Requires the PERMISSION_OVERRIDE_ANIMATIONS
+      permission.
+    name: SetAnimationOverride
+    deprecated: true
+  - parameters:
+    - name: buoyancy
+      type: number
+      comment: Float buoyancy value to set.
+    comment: Sets the buoyancy of a physical object (requires physics to be enabled).
+      A value of 0.0 offers no buoyancy, < 1.0 sinks, 1.0 counteracts gravity, and
+      > 1.0 rises.
+    name: SetBuoyancy
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset position vector in local coordinates relative to the prim.
+    comment: Sets the target offset vector (in local coordinates) that a seated avatar's
+      camera will look at.
+    name: SetCameraAtOffset
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset position vector in local coordinates relative to the prim.
+    comment: Sets the eye offset vector (in local coordinates) where a seated avatar's
+      camera is positioned.
+    name: SetCameraEyeOffset
+    deprecated: true
+  - parameters:
+    - name: rules
+      type: list
+      comment: A strided list of rules and data pairs configuring the camera.
+    comment: Sets multiple camera parameters simultaneously using the list of rules.
+      Requires the PERMISSION_CONTROL_CAMERA runtime permission.
+    name: SetCameraParams
+    deprecated: true
+  - parameters:
+    - name: action
+      type: number
+      comment: CLICK_ACTION_* flag representing the action to apply.
+    comment: Sets the action (a CLICK_ACTION_* flag) performed when an avatar left-clicks
+      the prim.
+    name: SetClickAction
+    deprecated: true
+  - parameters:
+    - name: color
+      type: vector
+      comment: Color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the Blinn-Phong diffuse RGB color of face. If face is ALL_SIDES,
+      applies the color to all faces.
+    name: SetColor
+    deprecated: true
+  - parameters:
+    - name: request_id
+      type: uuid
+      comment: Unique key identifying the incoming HTTP request.
+    - name: content_type
+      type: number
+      comment: CONTENT_TYPE_* constant representing the Internet media type to use.
+    comment: Sets the 'Content-Type' header of subsequent HTTP server responses (via
+      llHTTPResponse) for request_id using the specified content_type (a CONTENT_TYPE_*
+      constant).
+    name: SetContentType
+    deprecated: true
+  - parameters:
+    - name: damage
+      type: number
+      comment: Float damage value to set (range -100.0 for full heal to 100.0 for
+        instant kill).
+    comment: Sets the amount of damage delivered when this object hits an avatar.
+      The object is immediately destroyed upon inflicting damage, and no collision
+      event is triggered.
+    name: SetDamage
+    deprecated: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Position vector in region coordinates to specify the target parcel,
+        or <-1.0, -1.0, z> for the entire region (where z specifies the sky track,
+        or -1 for all tracks).
+    - name: params
+      type: list
+      comment: A list of environmental attributes and values to apply (or empty to
+        clear).
+    return-type: number
+    comment: Overrides the environmental settings at position for a parcel (or region
+      if position is <-1.0, -1.0, z>) using the parameters in params. Passing an empty
+      params list removes previous overrides.
+    name: SetEnvironment
+    deprecated: true
+  - parameters:
+    - name: experienceid
+      type: uuid
+    return-type: number
+    name: SetExperienceKey
+    deprecated: true
+  - parameters:
+    - name: force
+      type: vector
+      comment: Directional force vector to apply.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, force is treated as a local vector; if FALSE, as
+        a global region vector.
+    comment: Applies a constant linear force to a physical object. If local is TRUE,
+      force is applied relative to local coordinates; if FALSE, applied relative to
+      region coordinates.
+    name: SetForce
+    deprecated: true
+  - parameters:
+    - name: force
+      type: vector
+      comment: Directional linear force vector.
+    - name: torque
+      type: vector
+      comment: Torque rotational force vector.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, force and torque are treated as local vectors; if
+        FALSE, as global region vectors.
+    comment: Sets both the constant linear force and constant torque acting on a physical
+      object. If local is TRUE, forces are applied in local coordinates; if FALSE,
+      in global coordinates.
+    name: SetForceAndTorque
+    deprecated: true
+  - parameters:
+    - name: changes
+      type: list
+      comment: A list of terrain detail properties and values to change.
+    return-type: number
+    comment: Changes the painted terrain textures on the region based on changes.
+      The script owner must have estate management rights. Returns an integer status.
+    name: SetGroundTexture
+    deprecated: true
+  - parameters:
+    - name: height
+      type: number
+      comment: Distance to hover above the ground or water.
+    - name: water
+      type: boolean | number
+      comment: Boolean. If TRUE, hovers above water too; if FALSE, water is ignored.
+    - name: tau
+      type: number
+      comment: Timescale in seconds to critically damp the movement.
+    comment: Critically damps the physical object's vertical movement to hover at
+      height (above ground, or above water if water is TRUE) in tau seconds. Do not
+      use with vehicles; call llStopHover to cancel.
+    name: SetHoverHeight
+    deprecated: true
+  - parameters:
+    - name: item
+      type: string
+      comment: Name of the item in the prim's inventory.
+    - name: category
+      type: number
+      comment: MASK_* category flag (such as MASK_NEXT, MASK_OWNER, etc.).
+    - name: value
+      type: number
+      comment: Bitfield of permissions (PERM_* flags) to set.
+    comment: Sets the specified permission category of the inventory item to the value
+      permissions mask.
+    name: SetInventoryPermMask
+    deprecated: true
+  - parameters:
+    - name: keyframes
+      type: list
+      comment: A strided list of the form [vector position, rotation orientation,
+        float time] representing sequential relative keyframes (minimum time is 1/9s).
+    - name: options
+      type: list
+      comment: A list of options (KFM_* constants) to modify playback behavior.
+    comment: Smoothly moves a non-physical object between the positions, orientations,
+      and times specified in the keyframes list, configured via options. Collisions
+      with keyframed objects are ignored. An empty keyframes list terminates the motion.
+    name: SetKeyframedMotion
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: alpha
+      type: number
+      comment: Transparency value to set, from 0.0 (clear) to 1.0 (solid).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the Blinn-Phong alpha (transparency) of face on the linked prim
+      link.
+    name: SetLinkAlpha
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: eye
+      type: vector
+      comment: Eye offset position vector in local coordinates relative to the prim.
+    - name: at
+      type: vector
+      comment: Look-at offset position vector in local coordinates relative to the
+        prim.
+    comment: Sets the camera eye position offset eye and looking-at position offset
+      at for avatars who sit on the linked prim link.
+    name: SetLinkCamera
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: color
+      type: vector
+      comment: Color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Sets the Blinn-Phong diffuse RGB color of face on the linked prim link.
+    name: SetLinkColor
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    - name: params
+      type: list
+      comment: A list of overrides and their corresponding values to set.
+    comment: Sets or removes individual GLTF override parameters specified by params
+      on face of the linked prim link.
+    name: SetLinkGLTFOverrides
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: list
+      comment: A set of property-value pairs (in no particular order) specifying media
+        parameters.
+    return-type: number
+    comment: Sets the media parameters specified by params on face of the linked prim
+      link without a script delay. Returns an integer STATUS_* flag detailing success
+      or failure.
+    name: SetLinkMedia
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: rules
+      type: list
+      comment: A list of PRIM_* rules and data to apply.
+    comment: Deprecated (use llSetLinkPrimitiveParamsFast instead). Sets primitive
+      parameters for the linked prim link according to rules.
+    name: SetLinkPrimitiveParams
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: rules
+      type: list
+      comment: A list of PRIM_* rules and data to apply.
+    comment: Sets primitive parameters for the linked prim link according to rules
+      with no built-in script sleep delay.
+    name: SetLinkPrimitiveParamsFast
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: material
+      type: string | uuid
+      comment: Name of a material in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: 'Applies material (UUID or inventory name) to face of the linked prim
+      link. Note: This clears most PRIM_GLTF_* properties on the face except for repeats,
+      offsets, and rotation.'
+    name: SetLinkRenderMaterial
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: flags
+      type: number
+      comment: A bitfield of sit flags (SIT_FLAG_*) to apply.
+    comment: Sets the sit target flags for the linked prim link inside the linkset.
+    name: SetLinkSitFlags
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag.
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Applies texture (UUID or inventory name) to face of the linked prim link.
+    name: SetLinkTexture
+    deprecated: true
+  - parameters:
+    - name: link
+      type: number
+      comment: Link number (1 for root, >1 for children) or a LINK_* flag to animate.
+    - name: mode
+      type: number
+      comment: Bitfield of texture animation mode flags (ANIM_ON, LOOP, etc.).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    - name: sizex
+      type: number
+      comment: Number of horizontal frames (ignored for ROTATE and SCALE).
+    - name: sizey
+      type: number
+      comment: Number of vertical frames (ignored for ROTATE and SCALE).
+    - name: start
+      type: number
+      comment: Start frame number (or radians for ROTATE).
+    - name: length
+      type: number
+      comment: Number of frames to display (or radians for ROTATE).
+    - name: rate
+      type: number
+      comment: Playback rate in frames per second (or radians/sec for ROTATE, UV coords/sec
+        for SMOOTH). Must not be zero.
+    comment: Animates the texture on face of the linked prim link by setting the scale
+      and offset according to mode. Parameters sizex/sizey define frames, start defines
+      the start frame/angle, length defines duration, and rate defines playback speed.
+    name: SetLinkTextureAnim
+    deprecated: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Local rotation to set.
+    comment: Sets the rotation of a child prim relative to its root prim using rot.
+    name: SetLocalRot
+    deprecated: true
+  - parameters:
+    - name: limit
+      type: number
+      comment: Integer memory limit in bytes to reserve (must be less than the 64KB
+        maximum).
+    return-type: number
+    comment: Requests that limit bytes are reserved for the script. Returns TRUE on
+      success or FALSE on failure (has no effect in LSO).
+    name: SetMemoryLimit
+    deprecated: true
+  - parameters:
+    - name: description
+      type: string
+      comment: New description string (up to 127 characters).
+    comment: Sets the description of the prim containing the script to description
+      (limited to 127 characters).
+    name: SetObjectDesc
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: New name string.
+    comment: Sets the name of the prim containing the script to name.
+    name: SetObjectName
+    deprecated: true
+  - parameters:
+    - name: mask
+      type: number
+      comment: MASK_* category flag (e.g., MASK_BASE, MASK_OWNER, etc.).
+    - name: value
+      type: number
+      comment: Bitfield of permissions (PERM_* flags) to set.
+    comment: Sets the specified permission mask category to value on the root object
+      containing the script.
+    name: SetObjectPermMask
+    deprecated: true
+  - parameters:
+    - name: ForSale
+      type: boolean | number
+      comment: Boolean. If TRUE, puts the parcel up for sale; if FALSE, removes it
+        from sale.
+    - name: Options
+      type: list
+      comment: A list of options to configure the sale (e.g., price, authorized buyer,
+        and object inclusion).
+    return-type: number
+    comment: Sets the parcel the object is on for sale. If ForSale is TRUE, puts the
+      land up for sale using Options (price, buyer, objects included). Setting ForSale
+      to FALSE removes the parcel from sale. Requires parcel ownership and the PERMISSION_PRIVILEGED_LAND_ACCESS
+      permission. Returns an error code or 0 if successful.
+    name: SetParcelForSale
+    deprecated: true
+  - parameters:
+    - name: url
+      type: string
+      comment: Streaming audio URL string.
+    comment: Sets the streaming audio (music) URL for the parcel containing the object.
+      The object owner must match the landowner or land group.
+    name: SetParcelMusicURL
+    deprecated: true
+  - parameters:
+    - name: price
+      type: number
+      comment: Default price integer shown in the text field (can accept PAY_* constants
+        or positive values).
+    - name: quick_pay_buttons
+      type: '{number}'
+      comment: A list of four integer values or PAY_* constants specifying the button
+        payment choices.
+    comment: Suggests default amounts for the pay text input field price and the four
+      payment dialog quick_pay_buttons when an avatar pays this object.
+    name: SetPayPrice
+    deprecated: true
+  - parameters:
+    - name: mask
+      type: number
+      comment: Bitwise mask combination specifying which of the floats (DENSITY, FRICTION,
+        RESTITUTION, or GRAVITY_MULTIPLIER) to apply.
+    - name: gravity_multiplier
+      type: number
+      comment: Gravity multiplier float value (range [-1.0, +28.0], default is 1.0).
+    - name: restitution
+      type: number
+      comment: Elasticity restitution float value (range [0.0, 1.0]).
+    - name: friction
+      type: number
+      comment: Friction coefficient float value (range [0.0, 255.0]).
+    - name: density
+      type: number
+      comment: "Density float value in kg/m\xB3 (range [1.0, 22587.0])."
+    comment: Configures the physical characteristics of an object. The mask bitfield
+      specifies which of the other parameters (gravity_multiplier, restitution, friction,
+      or density) should be applied to the object.
+    name: SetPhysicsMaterial
+    deprecated: true
+  - parameters:
+    - name: pos
+      type: vector
+      comment: Position vector to move to (in region coordinates, or local coordinates
+        if in a child prim).
+    comment: Moves the non-physical object or prim toward the vector pos (up to 10m).
+      If called in a child prim, pos is treated as root-relative; if called from the
+      root prim, the entire object is moved.
+    name: SetPos
+    deprecated: true
+  - parameters:
+    - name: face
+      type: number
+      comment: Face number (side) of the prim.
+    - name: params
+      type: list
+      comment: A set of property-value pairs (in no particular order) specifying media
+        parameters.
+    return-type: number
+    comment: Sets the media parameters specified by params on the designated face
+      of the prim. Returns an integer STATUS_* flag detailing success or failure.
+    name: SetPrimMediaParams
+    deprecated: true
+  - parameters:
+    - name: url
+      type: string
+      comment: Web URL to display.
+    comment: Deprecated (use llSetPrimMediaParams instead). Updates the URL displayed
+      on the prim's faces.
+    name: SetPrimURL
+    deprecated: true
+  - parameters:
+    - name: rules
+      type: list
+      comment: A list of PRIM_* rules and data to apply.
+    comment: Deprecated (use llSetLinkPrimitiveParamsFast instead). Sets the prim's
+      attributes according to rules.
+    name: SetPrimitiveParams
+    deprecated: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Target position vector in region coordinates (can cross up to 10m over
+        a region border).
+    return-type: number
+    comment: Tries to move the entire object so that its root prim is within 0.1m
+      of the vector position (underground positions are set to ground level). Returns
+      TRUE on success or FALSE on failure.
+    name: SetRegionPos
+    deprecated: true
+  - parameters:
+    - name: pin
+      type: number
+      comment: Integer PIN code (non-zero enables, zero disables).
+    comment: Sets the prim's remote script access PIN to pin (a non-zero value enables
+      loading via llRemoteLoadScriptPin, while zero disables it).
+    name: SetRemoteScriptAccessPin
+    deprecated: true
+  - parameters:
+    - name: material
+      type: string | uuid
+      comment: Name of a material in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: 'Applies material (UUID or inventory name) to face of the prim. Note:
+      This clears most PRIM_GLTF_* properties on the face except for repeats, offsets,
+      and rotation.'
+    name: SetRenderMaterial
+    deprecated: true
+  - parameters:
+    - name: rot
+      type: quaternion
+      comment: Target rotation.
+    comment: Sets the rotation of the prim to rot. If in a child prim, rot is treated
+      as root-relative; if in the root prim of a non-physical object, rotates the
+      entire object.
+    name: SetRot
+    deprecated: true
+  - parameters:
+    - name: size
+      type: vector
+      comment: Target size vector.
+    comment: Sets the physical scale (dimensions) of the prim containing the script
+      to size.
+    name: SetScale
+    deprecated: true
+  - parameters:
+    - name: name
+      type: string
+      comment: Name of the script in the prim's inventory.
+    - name: running
+      type: boolean | number
+      comment: Boolean. If TRUE, enables the script; if FALSE, disables it.
+    comment: Sets the running state of the script name in the prim's inventory. If
+      running is TRUE, the script is enabled; if FALSE, it is disabled.
+    name: SetScriptState
+    deprecated: true
+  - parameters:
+    - name: text
+      type: string
+      comment: Context menu text to display.
+    comment: Displays the string text instead of 'Sit' (or 'Sit Here') in the viewer's
+      right-click context menu.
+    name: SetSitText
+    deprecated: true
+  - parameters:
+    - name: queue
+      type: boolean | number
+      comment: Boolean. If TRUE, sound queuing is enabled; if FALSE, it is disabled.
+    comment: Sets whether attached sounds wait for the current sound to end before
+      playing (enables queuing if queue is TRUE, disables if FALSE). The queue is
+      one level deep.
+    name: SetSoundQueueing
+    deprecated: true
+  - parameters:
+    - name: radius
+      type: number
+      comment: Maximum distance in meters at which the sounds can be heard.
+    comment: Limits the audibility radius of attached and triggered scripted sounds
+      to distance radius.
+    name: SetSoundRadius
+    deprecated: true
+  - parameters:
+    - name: status
+      type: number
+      comment: Bitmask representing the STATUS_* flag(s) to change.
+    - name: value
+      type: boolean | number
+      comment: Boolean. If TRUE, enables the status; if FALSE, disables it.
+    comment: Sets the object status attributes specified by status to value.
+    name: SetStatus
+    deprecated: true
+  - parameters:
+    - name: text
+      type: string
+      comment: Floating text string to display.
+    - name: color
+      type: vector
+      comment: Color vector in RGB <R, G, B> (values from 0.0 to 1.0).
+    - name: alpha
+      type: number
+      comment: Transparency value to set, from 0.0 (clear) to 1.0 (solid).
+    comment: Displays floating text above the prim with the specified color vector
+      and transparency alpha.
+    name: SetText
+    deprecated: true
+  - parameters:
+    - name: texture
+      type: string | uuid
+      comment: Name of a texture in the prim's inventory, or a UUID.
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    comment: Applies the Blinn-Phong diffuse texture to face of the prim.
+    name: SetTexture
+    deprecated: true
+  - parameters:
+    - name: mode
+      type: number
+      comment: Bitfield of texture animation mode flags (ANIM_ON, LOOP, etc.).
+    - name: face
+      type: number
+      comment: Face number or ALL_SIDES.
+    - name: sizex
+      type: number
+      comment: Number of horizontal frames (ignored for ROTATE and SCALE).
+    - name: sizey
+      type: number
+      comment: Number of vertical frames (ignored for ROTATE and SCALE).
+    - name: start
+      type: number
+      comment: Start frame number (or radians for ROTATE).
+    - name: length
+      type: number
+      comment: Number of frames to display (or radians for ROTATE).
+    - name: rate
+      type: number
+      comment: Playback rate in frames per second (or radians/sec for ROTATE, UV coords/sec
+        for SMOOTH). Must not be zero.
+    comment: Animates the texture on face of the prim by setting its scale and offset.
+      mode defines options, sizex/sizey define frames, start defines the start frame/angle,
+      length defines duration, and rate defines playback speed.
+    name: SetTextureAnim
+    deprecated: true
+  - parameters:
+    - name: sec
+      type: number
+      comment: Interval in seconds between timer events (0.0 to disable).
+    comment: Sets a timer to trigger a timer event periodically every sec seconds.
+      Passing 0.0 stops further timer events.
+    name: SetTimerEvent
+    deprecated: true
+  - parameters:
+    - name: torque
+      type: vector
+      comment: Torque rotational force vector.
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, torque is treated as a local vector; if FALSE, as
+        a global region vector.
+    comment: Applies a constant torque rotational force to a physical object. If local
+      is TRUE, torque is applied in local coordinates; if FALSE, applied in global
+      coordinates.
+    name: SetTorque
+    deprecated: true
+  - parameters:
+    - name: text
+      type: string
+      comment: Context menu text to display.
+    comment: Displays the string text instead of 'Touch' in the right-click context
+      menu.
+    name: SetTouchText
+    deprecated: true
+  - parameters:
+    - name: flags
+      type: number
+      comment: A bitwise mask of VEHICLE_FLAG_* constants to enable.
+    comment: Enables the vehicle flags specified in the Flags bitmask.
+    name: SetVehicleFlags
+    deprecated: true
+  - parameters:
+    - name: param
+      type: number
+      comment: VEHICLE_* float parameter constant to set.
+    - name: value
+      type: number
+      comment: Float value to set.
+    comment: Sets the specified vehicle float parameter param to value.
+    name: SetVehicleFloatParam
+    deprecated: true
+  - parameters:
+    - name: param
+      type: number
+      comment: VEHICLE_* rotation parameter constant to set.
+    - name: rot
+      type: quaternion
+      comment: Rotation value to set.
+    comment: Sets the specified vehicle rotation parameter param to rot.
+    name: SetVehicleRotationParam
+    deprecated: true
+  - parameters:
+    - name: type
+      type: number
+      comment: VEHICLE_TYPE_* constant to set.
+    comment: Sets the vehicle physics preset type to one of the default vehicle types.
+    name: SetVehicleType
+    deprecated: true
+  - parameters:
+    - name: param
+      type: number
+      comment: VEHICLE_* vector parameter constant to set.
+    - name: vec
+      type: vector
+      comment: Vector value to set.
+    comment: Sets the specified vehicle vector parameter param to vec.
+    name: SetVehicleVectorParam
+    deprecated: true
+  - parameters:
+    - name: velocity
+      type: vector
+      comment: Linear velocity vector to apply (in meters per second).
+    - name: local
+      type: boolean | number
+      comment: Boolean. If TRUE, velocity is treated as a local directional vector;
+        if FALSE, as a global region vector.
+    comment: Sets the linear velocity of a physical object to velocity. If local is
+      TRUE, velocity is treated as a local directional vector; if FALSE, as a global
+      region directional vector. Has no effect on non-physical objects.
+    name: SetVelocity
+    deprecated: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Integer chat channel to shout the message on.
+    - name: msg
+      type: string
+      comment: Text message string to transmit.
+    comment: Shouts the text message msg on the specified channel. The message can
+      be heard up to a 100m radius. All channels other than PUBLIC_CHANNEL (0) and
+      DEBUG_CHANNEL (2147483647) are not sent to avatars and are used to communicate
+      with scripts.
+    name: Shout
+    deprecated: true
+  - parameters:
+    - name: private_key
+      type: string
+      comment: PEM-formatted private key.
+    - name: msg
+      type: string
+      comment: Message contents to sign.
+    - name: algorithm
+      type: string
+      comment: Digest algorithm to use (sha1, sha224, sha256, sha384, or sha512).
+    return-type: string
+    comment: Returns the Base64-encoded RSA signature of msg using the PEM-formatted
+      private_key and the specified digest algorithm (sha1, sha224, sha256, sha384,
+      or sha512). Can be paired with llVerifyRSA to pass verifiable messages.
+    name: SignRSA
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: theta
+      type: number
+      comment: Angle expressed in radians.
+    return-type: number
+    comment: Returns a float representing the sine of theta.
+    name: Sin
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the avatar being forced to sit.
+    - name: link
+      type: number
+      comment: Link number for the prim containing the desired sit target.
+    return-type: number
+    comment: Forces the avatar specified by agent_id (who must be participating in
+      the experience) to sit on the sit target of the prim indicated by link. If occupied,
+      searches down the linkset for an available sit target. Returns an integer.
+    name: SitOnLink
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Target position vector in local prim coordinates.
+    - name: rot
+      type: quaternion
+      comment: Target rotation relative to the prim's rotation.
+    comment: Sets the sit target position (offset) and rotation (rot) relative to
+      the prim's position and orientation. Clears the sit target if offset is ZERO_VECTOR.
+    name: SitTarget
+    deprecated: true
+  - parameters:
+    - name: sec
+      type: number
+      comment: Duration in seconds to put the script to sleep.
+    comment: Puts the script to sleep for sec seconds (at least until the next server-frame,
+      ~0.02222 seconds). The script is inactive during this time. If sec is 0.0 or
+      less, the script does not sleep.
+    name: Sleep
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    - name: queue
+      type: boolean | number
+      comment: Boolean. If TRUE, queues the sound; if FALSE, interrupts the currently
+        playing sound.
+    - name: loop
+      type: boolean | number
+      comment: Boolean. If TRUE, loops the sound.
+    comment: Deprecated (use llPlaySound instead). Plays the specified sound at volume,
+      with options to loop or queue the sound.
+    name: Sound
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    comment: Deprecated (use llPreloadSound instead). Preloads the specified sound
+      on viewers within range.
+    name: SoundPreload
+    deprecated: true
+  - parameters:
+    - name: val
+      type: number
+      comment: Positive float value (must be >= 0.0).
+    return-type: number
+    comment: Returns a float representing the square root of the positive value val.
+      Triggers a math runtime error if val is less than 0.0 (imaginary results).
+    name: Sqrt
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: anim
+      type: string
+      comment: Name of an animation in the prim's inventory, or a built-in animation.
+    comment: Starts the animation anim (inventory or built-in) on the avatar who granted
+      the script the PERMISSION_TRIGGER_ANIMATION permission (automatically granted
+      for attached or sat-on objects).
+    name: StartAnimation
+    deprecated: true
+  - parameters:
+    - name: anim
+      type: string
+      comment: Name of an animation in the current object's inventory.
+    comment: Starts the specified animation anim (inventory or built-in) on the rigged
+      mesh object associated with the current script.
+    name: StartObjectAnimation
+    deprecated: true
+  - parameters:
+    - name: anim
+      type: string | uuid
+      comment: Name of an animation in the prim's inventory, a UUID of an animation,
+        or a built-in animation name.
+    comment: Stops the specified animation anim (inventory, built-in, or UUID) on
+      the avatar who granted the script the PERMISSION_TRIGGER_ANIMATION permission
+      (automatically granted for attached or sat-on objects).
+    name: StopAnimation
+    deprecated: true
+  - comment: Stops the hover behavior (such as that initiated by llSetHoverHeight).
+    name: StopHover
+    deprecated: true
+  - comment: Stops causing the object to look at or point toward a target (canceling
+      llLookAt or llRotLookAt).
+    name: StopLookAt
+    deprecated: true
+  - comment: Stops the critically damped movement of the object toward a target (canceling
+      llMoveToTarget). Use llStopLookAt to stop rotational tracking.
+    name: StopMoveToTarget
+    deprecated: true
+  - parameters:
+    - name: anim
+      type: string | uuid
+      comment: Name of an animation in the current object's inventory, or an animation
+        UUID.
+    comment: Stops the specified animation anim (inventory, built-in, or UUID) on
+      the rigged mesh object associated with the current script.
+    name: StopObjectAnimation
+    deprecated: true
+  - comment: Stops the avatar who owns the object from pointing.
+    name: StopPointAt
+    deprecated: true
+  - comment: Stops playback of the currently playing attached sound.
+    name: StopSound
+    deprecated: true
+  - parameters:
+    - name: str
+      type: string
+      comment: String to measure.
+    return-type: number
+    comment: Returns an integer representing the number of characters in the string
+      str (excluding the null terminator).
+    name: StringLength
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: str
+      type: string
+      comment: Source string to encode.
+    return-type: string
+    comment: Returns the Base64 representation string of str, interpreting it as a
+      UTF-8 byte sequence.
+    name: StringToBase64
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: String to trim.
+    - name: type
+      type: number
+      comment: Trim type flag (STRING_TRIM_HEAD, STRING_TRIM_TAIL, or STRING_TRIM).
+    return-type: string
+    comment: Returns a copy of the string src with leading, trailing, or both types
+      of whitespace (including spaces, tabs, and line feeds) eliminated, according
+      to the specified trim type.
+    name: StringTrim
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: source
+      type: string
+      comment: Source string to search within.
+    - name: pattern
+      type: string
+      comment: Substring pattern to search for.
+    return-type: number
+    comment: (Index semantics) Returns the zero-based index of the first instance
+      of the pattern substring inside the string source. Returns -1 if not found.
+    name: SubStringIndex
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    comment: Deprecated (use llSetCameraParams instead). Formerly used to take control
+      of the agent's camera.
+    name: TakeCamera
+    deprecated: true
+  - parameters:
+    - name: controls
+      type: number
+      comment: Bitfield of CONTROL_* flags to intercept.
+    - name: accept
+      type: boolean | number
+      comment: Boolean. Determines whether control events are generated to trigger
+        script handlers.
+    - name: pass_on
+      type: boolean | number
+      comment: Boolean. If TRUE, the keys also perform their default functions; if
+        FALSE, default actions are suppressed.
+    comment: Intercepts inputs (keyboard/mouse clicks) from the agent, specifically
+      those specified by controls. The boolean accept determines if events are generated,
+      and pass_on determines if inputs also perform their default functions. Requires
+      the PERMISSION_TAKE_CONTROLS runtime permission.
+    name: TakeControls
+    deprecated: true
+  - parameters:
+    - name: theta
+      type: number
+      comment: Angle expressed in radians.
+    return-type: number
+    comment: Returns a float representing the tangent of theta.
+    name: Tan
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: position
+      type: vector
+      comment: Target position vector in region coordinates.
+    - name: range
+      type: number
+      comment: Radius tolerance in meters surrounding the target position.
+    return-type: number
+    comment: Registers a positional target at position with a leeway radius range.
+      This triggers at_target and not_at_target events. Returns an integer handle
+      to unregister the target via llTargetRemove.
+    name: Target
+    deprecated: true
+  - parameters:
+    - name: axis
+      type: vector
+      comment: Local axis vector around which the object rotates.
+    - name: spinrate
+      type: number
+      comment: Rotation rate multiplier in radians per second.
+    - name: gain
+      type: number
+      comment: A float modulating the rotational strength (disables the rotation if
+        set to 0.0).
+    comment: Applies a smooth client-side rotation around the local axis at a rate
+      equal to spinrate multiplied by the magnitude of axis (in radians per second)
+      with a force defined by gain. Set spinrate to 0.0 to cancel.
+    name: TargetOmega
+    deprecated: true
+  - parameters:
+    - name: handle
+      type: number
+      comment: Integer target handle returned by llTarget to remove.
+    comment: Removes the positional target specified by the integer handle registered
+      with llTarget.
+    name: TargetRemove
+    deprecated: true
+  - parameters:
+    - name: target
+      type: number
+      comment: Target constant (e.g., TARGETED_EMAIL_OBJECT_OWNER or TARGETED_EMAIL_ROOT_CREATOR).
+    - name: subject
+      type: string
+      comment: Subject of the email.
+    - name: message
+      type: string
+      comment: Email message body.
+    comment: Sends an email containing subject and message to the target (which can
+      designate the owner or creator of the object).
+    name: TargetedEmail
+    deprecated: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the owning avatar to teleport.
+    - name: landmark
+      type: string
+      comment: Name of the landmark in the prim's inventory, or an empty string to
+        teleport locally.
+    - name: position
+      type: vector
+      comment: Position vector in local region coordinates to teleport to if landmark
+        is empty.
+    - name: look_at
+      type: vector
+      comment: Position vector (or direction unit vector if teleporting out of region)
+        the agent faces upon landing.
+    comment: Teleports the owning agent (who must grant PERMISSION_TELEPORT) to a
+      landmark in the object's inventory. If landmark is empty, teleports them to
+      position within the current region. Upon arrival, the agent is turned to face
+      look_at. Can only teleport the owner.
+    name: TeleportAgent
+    deprecated: true
+  - parameters:
+    - name: agent
+      type: uuid
+      comment: UUID of the owning avatar to teleport.
+    - name: global_coordinates
+      type: vector
+      comment: Global coordinates vector of the target region (obtained via llRequestSimulatorData).
+    - name: region_coordinates
+      type: vector
+      comment: Target coordinates vector within the destination region.
+    - name: look_at
+      type: vector
+      comment: Position vector within the region (or unit direction vector if out
+        of region) that the agent faces upon landing.
+    comment: Teleports the owning agent (who must grant PERMISSION_TELEPORT) to region_coordinates
+      within a target region specified by global_coordinates. Upon landing, the agent
+      faces the direction look_at. Can only teleport the owner.
+    name: TeleportAgentGlobalCoords
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar to teleport.
+    comment: Teleports the avatar (who must be standing on land owned by the script
+      owner) directly to their designated home location without warning (similar to
+      a God Summons).
+    name: TeleportAgentHome
+    deprecated: true
+  - parameters:
+    - name: avatar
+      type: uuid
+      comment: UUID of the avatar in the same region.
+    - name: message
+      type: string
+      comment: Text message to display in the text box.
+    - name: channel
+      type: number
+      comment: Output chat channel (any integer value) where the input text is chatted.
+    comment: Opens an input text box dialog displaying message to the avatar. Submitting
+      text chats the input string on channel as if said by the avatar.
+    name: TextBox
+    deprecated: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to convert.
+    return-type: string
+    comment: Returns a copy of the string src converted entirely to lowercase.
+    name: ToLower
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: src
+      type: string
+      comment: Source string to convert.
+    return-type: string
+    comment: Returns a copy of the string src converted entirely to uppercase.
+    name: ToUpper
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: destination
+      type: uuid
+      comment: UUID of the destination avatar.
+    - name: amount
+      type: number
+      comment: Quantity of L$ to transfer (must be greater than 0).
+    return-type: uuid
+    comment: Transfers amount of L$ from the script owner to the destination avatar,
+      requiring the PERMISSION_DEBIT permission. Returns a key query handle matching
+      the resulting transaction_result event.
+    name: TransferLindenDollars
+    deprecated: true
+  - parameters:
+    - name: agent_id
+      type: uuid
+      comment: UUID of the avatar to receive ownership of the object.
+    - name: flags
+      type: number
+      comment: Flags controlling the transfer type (such as TRANSFER_FLAG_COPY or
+        TRANSFER_FLAG_TAKE).
+    - name: options
+      type: list
+      comment: Extra options applied to the transfer (currently unused).
+    return-type: number
+    comment: Transfers ownership of the object (or a copy of it, depending on flags)
+      to the avatar agent_id. Returns an integer indicating the success or failure
+      of the transfer.
+    name: TransferOwnership
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    comment: Plays specified sound once at volume, centered at the object's current
+      position but not attached (does not move with the object and cannot be stopped
+      or adjusted). Does not affect attached sounds.
+    name: TriggerSound
+    deprecated: true
+  - parameters:
+    - name: sound
+      type: string | uuid
+      comment: Name of a sound in the prim's inventory, or a UUID.
+    - name: volume
+      type: number
+      comment: Volume level to set, between 0.0 (silent) and 1.0 (loud).
+    - name: top_north_east
+      type: vector
+      comment: Top-north-east boundary position vector in region coordinates.
+    - name: bottom_south_west
+      type: vector
+      comment: Bottom-south-west boundary position vector in region coordinates.
+    comment: Plays the specified sound once at volume, centered at the object but
+      not attached, restricted to the axis-aligned bounding box defined by the coordinates
+      top_north_east and bottom_south_west.
+    name: TriggerSoundLimited
+    deprecated: true
+  - parameters:
+    - name: id
+      type: uuid
+      comment: UUID of the avatar to unsit.
+    comment: Forces the agent specified by id to stand up if they are sitting on the
+      object containing the script, or are currently over land owned by the object's
+      owner.
+    name: UnSit
+    deprecated: true
+  - parameters:
+    - name: url
+      type: string
+      comment: Escaped URL string to decode.
+    return-type: string
+    comment: Returns a string representing the unescaped/decoded version of url, replacing
+      '%20' with spaces and decoding raw UTF-8 characters.
+    name: UnescapeURL
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: options
+      type: list
+      comment: A list of key-value pairs specifying the character's new configuration
+        options (takes same constants as llCreateCharacter).
+    comment: Updates settings for a pathfinding character using the parameters specified
+      in options.
+    name: UpdateCharacter
+    deprecated: true
+  - parameters:
+    - name: k
+      type: string
+      comment: Key of the key-value pair to update.
+    - name: v
+      type: string
+      comment: New value for the key-value pair.
+    - name: checked
+      type: boolean | number
+      comment: Boolean. If TRUE, requires the existing value to match original_value
+        to complete the update; if FALSE, creates the key if needed.
+    - name: original_value
+      type: string
+      comment: String value to compare against the existing value in the datastore.
+    return-type: uuid
+    comment: Starts an asynchronous transaction to update the key k to value v inside
+      the experience datastore. If checked is TRUE, the update fails with XP_ERROR_RETRY_UPDATE
+      unless the existing value matches original_value.
+    name: UpdateKeyValue
+    deprecated: true
+  - parameters:
+    - name: vec_a
+      type: vector
+      comment: First vector.
+    - name: vec_b
+      type: vector
+      comment: Second vector.
+    return-type: number
+    comment: Returns a float representing the undirected, non-negative distance between
+      vectors vec_a and vec_b.
+    name: VecDist
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: vec
+      type: vector
+      comment: Vector to evaluate.
+    return-type: number
+    comment: Returns a float representing the magnitude (geometric length) of the
+      vector vec.
+    name: VecMag
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: vec
+      type: vector
+      comment: Vector to normalize.
+    return-type: vector
+    comment: Returns a normalized unit vector sharing the same direction as vec.
+    name: VecNorm
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: public_key
+      type: string
+      comment: PEM-formatted public key to use for signature verification.
+    - name: msg
+      type: string
+      comment: Message string that was signed.
+    - name: signature
+      type: string
+      comment: Base64-encoded signature to verify.
+    - name: algorithm
+      type: string
+      comment: Cryptographic digest algorithm to use.
+    return-type: number
+    comment: Returns TRUE if the Base64-formatted signature is verified as valid for
+      the message msg when using the digest algorithm and public_key. Returns FALSE
+      otherwise.
+    name: VerifyRSA
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: detect
+      type: boolean | number
+      comment: Boolean. If TRUE, enables VolumeDetect; if FALSE (default), disables
+        it.
+    comment: If detect is TRUE, enables VolumeDetect (object becomes phantom and physical
+      objects/avatars can pass through it). Triggers collision_start on initial intersection
+      and collision_end when intersection stops (standard collision events are suppressed
+      while intersecting).
+    name: VolumeDetect
+    deprecated: true
+  - parameters:
+    - name: origin
+      type: vector
+      comment: Center coordinate position vector to wander about.
+    - name: dist
+      type: vector
+      comment: A vector specifying the maximum distance limits (half-extents) along
+        each world-aligned axis from the origin.
+    - name: options
+      type: list
+      comment: A list of WANDER_* flags and parameters to configure the wander behavior.
+    comment: Directs a pathfinding character to wander around a central coordinate
+      origin, restricted within the bounding distance limits of dist and configured
+      by options.
+    name: WanderWithin
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: number
+    comment: Returns a float representing the water height directly below the prim's
+      position offset by the vector offset.
+    name: Water
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: channel
+      type: number
+      comment: Integer chat channel to whisper the message on.
+    - name: msg
+      type: string
+      comment: Text message string to transmit.
+    comment: Whispers the text message msg on the specified channel. The message can
+      be heard up to a 10m radius. All channels other than PUBLIC_CHANNEL (0) and
+      DEBUG_CHANNEL (2147483647) are not sent to avatars and are used to communicate
+      with scripts.
+    name: Whisper
+    deprecated: true
+  - parameters:
+    - name: offset
+      type: vector
+      comment: Offset relative to the prim's position, expressed in local coordinates.
+    return-type: vector
+    comment: Returns a vector representing the wind velocity at the prim's position
+      offset by the vector offset.
+    name: Wind
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: world_pos
+      type: vector
+      comment: World-frame position vector to project into HUD space.
+    return-type: vector
+    comment: Returns the local position vector that places the center of the HUD object
+      directly over the world coordinate world_pos as viewed by the current camera.
+      Requires the PERMISSION_TRACK_CAMERA runtime permission.
+    name: WorldPosToHUD
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: str1
+      type: string
+      comment: First Base64 string.
+    - name: str2
+      type: string
+      comment: Second Base64 string (will repeat if shorter than str1).
+    return-type: string
+    comment: Correctly performs a bitwise exclusive OR (XOR) on Base64 strings str1
+      and str2, returning the result as a Base64 string. The string str2 repeats if
+      it is shorter than str1.
+    name: XorBase64
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: str1
+      type: string
+      comment: First Base64 string.
+    - name: str2
+      type: string
+      comment: Second Base64 string (will repeat if shorter than str1).
+    return-type: string
+    comment: Deprecated (use llXorBase64 instead). Retained for backwards compatibility.
+      Incorrectly performs a bitwise exclusive OR (XOR) on Base64 strings str1 and
+      str2.
+    name: XorBase64Strings
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: str1
+      type: string
+      comment: First Base64 string.
+    - name: str2
+      type: string
+      comment: Second Base64 string (will repeat if shorter than str1).
+    return-type: string
+    comment: Deprecated (use llXorBase64 instead). Correctly performs (unless nulls
+      are present) a bitwise exclusive OR (XOR) on Base64 strings str1 and str2.
+    name: XorBase64StringsCorrect
+    deprecated: true
+    must-use: true
+  - parameters:
+    - name: srgb
+      type: vector
+      comment: Color vector in the sRGB colorspace to convert.
+    return-type: vector
+    comment: Returns a vector representing the conversion of the color srgb from the
+      sRGB colorspace into the linear RGB colorspace.
+    name: sRGB2Linear
+    deprecated: true
+    must-use: true
+- name: rotation
+  comment: Quaternion manipulation library.
+  callable:
+    parameters:
+    - name: x
+      type: number
+      comment: X component of the quaternion.
+    - name: y
+      type: number
+      comment: Y component of the quaternion.
+    - name: z
+      type: number
+      comment: Z component of the quaternion.
+    - name: s
+      type: number
+      comment: S component of the quaternion.
+    return-type: quaternion
+    comment: Creates a new quaternion with the given component values. Alias of quaternion.create.
+    name: quaternion
+    must-use: true
+  constants:
+  - name: identity
+    type: quaternion
+    value: quaternion(0, 0, 0, 1)
+    comment: Identity quaternion constant.
+  functions:
+  - parameters:
+    - name: x
+      type: number
+      comment: X component of the quaternion.
+    - name: y
+      type: number
+      comment: Y component of the quaternion.
+    - name: z
+      type: number
+      comment: Z component of the quaternion.
+    - name: s
+      type: number
+      comment: S component of the quaternion.
+    return-type: quaternion
+    comment: Creates a new quaternion with the given component values.
+    name: create
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: quaternion
+    comment: Computes the normalized version (unit quaternion) of the quaternion.
+    name: normalize
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: number
+    comment: Computes the magnitude of the quaternion.
+    name: magnitude
+    must-use: true
+  - parameters:
+    - name: a
+      type: quaternion
+      comment: Left input quaternion.
+    - name: b
+      type: quaternion
+      comment: Right input quaternion.
+    return-type: number
+    comment: Computes the dot product of two quaternions.
+    name: dot
+    must-use: true
+  - parameters:
+    - name: a
+      type: quaternion
+      comment: Start quaternion.
+    - name: b
+      type: quaternion
+      comment: End quaternion.
+    - name: t
+      type: number
+      comment: Interpolation factor.
+    return-type: quaternion
+    comment: Spherical linear interpolation from a to b using factor t.
+    name: slerp
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: quaternion
+    comment: Computes the conjugate of the quaternion.
+    name: conjugate
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: vector
+    comment: Computes the forward vector from the quaternion.
+    name: tofwd
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: vector
+    comment: Computes the left vector from the quaternion.
+    name: toleft
+    must-use: true
+  - parameters:
+    - name: q
+      type: quaternion
+      comment: Input quaternion.
+    return-type: vector
+    comment: Computes the up vector from the quaternion.
+    name: toup
+    must-use: true
+constants:
+- name: _G
+  type: any
+  value: '{}'
+  comment: Table of Lua builtin globals.
+- name: _VERSION
+  type: string
+  value: '"Luau"'
+- name: ACTIVE
+  type: number
+  value: '0x2'
+  comment: Objects running a script or physically moving (using server resources).
+    In llDetectedType(), it identifies physical objects and agents. In llSensor()
+    or llSensorRepeat(), it searches for moving physical objects or scripted objects.
+- name: AGENT
+  type: number
+  value: '0x1'
+  comment: Agents (avatars). In llDetectedType, it indicates an avatar. In llSensor
+    or llSensorRepeat, it searches for avatars by legacy name (functionally identical
+    to AGENT_BY_LEGACY_NAME, though using AGENT_BY_LEGACY_NAME is recommended instead).
+- name: AGENT_ALWAYS_RUN
+  type: number
+  value: '0x1000'
+  comment: Used with llGetAgentInfo to determine if the queried avatar has 'Always
+    Run' enabled or is using tap-tap-hold.
+- name: AGENT_ATTACHMENTS
+  type: number
+  value: '0x2'
+  comment: Used with llGetAgentInfo to determine if the queried avatar has attachments.
+- name: AGENT_AUTOMATED
+  type: number
+  value: '0x4000'
+  comment: Used with llGetAgentInfo to identify if the avatar is registered with Linden
+    Lab as an automated/scripted agent (bot).
+- name: AGENT_AUTOPILOT
+  type: number
+  value: '0x2000'
+  comment: Used with llGetAgentInfo to determine if the avatar is in autopilot mode,
+    which is enabled when the user selects 'Go Here' on the ground or uses double-click
+    autopilot.
+- name: AGENT_AWAY
+  type: number
+  value: '0x40'
+  comment: Used with llGetAgentInfo to determine if the avatar is in 'away' mode,
+    which indicates they toggled away or have been inactive for too long.
+- name: AGENT_BUSY
+  type: number
+  value: '0x800'
+  comment: Used with llGetAgentInfo to determine if the avatar is in 'busy' mode.
+- name: AGENT_BY_LEGACY_NAME
+  type: number
+  value: '0x1'
+  comment: Used to find agents by legacy name. In llDetectedType, it indicates an
+    avatar. In llSensor or llSensorRepeat, it searches for avatars by legacy name.
+- name: AGENT_BY_USERNAME
+  type: number
+  value: '0x10'
+  comment: Used to find agents by username (see Avatar Names).
+- name: AGENT_CROUCHING
+  type: number
+  value: '0x400'
+  comment: Used with llGetAgentInfo to determine if the avatar is crouching.
+- name: AGENT_FLOATING_VIA_SCRIPTED_ATTACHMENT
+  type: number
+  value: '0x8000'
+  comment: Used with llGetAgentInfo to determine if the avatar is floating or hovering
+    because of a scripted attachment using either llSetHoverHeight or llGroundRepel.
+- name: AGENT_FLYING
+  type: number
+  value: '0x1'
+  comment: Used with llGetAgentInfo to determine if the queried avatar is flying or
+    hovering.
+- name: AGENT_IN_AIR
+  type: number
+  value: '0x100'
+  comment: Used with llGetAgentInfo to determine if the avatar is in the air (jumping,
+    flying, or falling).
+- name: AGENT_LIST_PARCEL
+  type: number
+  value: '1'
+  comment: Agents on the same parcel where the script is running.
+- name: AGENT_LIST_PARCEL_OWNER
+  type: number
+  value: '2'
+  comment: Agents on any parcel in the region where the parcel owner is the same as
+    the owner of the parcel under the scripted object.
+- name: AGENT_LIST_REGION
+  type: number
+  value: '4'
+  comment: Returns any or all agents in the region.
+- name: AGENT_MOUSELOOK
+  type: number
+  value: '0x8'
+  comment: Used with llGetAgentInfo to determine if the avatar is in mouselook.
+- name: AGENT_ON_OBJECT
+  type: number
+  value: '0x20'
+  comment: Used with llGetAgentInfo to determine if the avatar is sitting on an object
+    and linked to it.
+- name: AGENT_SCRIPTED
+  type: number
+  value: '0x4'
+  comment: Used with llGetAgentInfo to determine if the avatar is carrying scripted
+    objects or has scripted attachments.
+- name: AGENT_SITTING
+  type: number
+  value: '0x10'
+  comment: Used with llGetAgentInfo to determine if the avatar is sitting.
+- name: AGENT_TYPING
+  type: number
+  value: '0x200'
+  comment: Used with llGetAgentInfo to determine if the avatar is typing.
+- name: AGENT_WALKING
+  type: number
+  value: '0x80'
+  comment: Used with llGetAgentInfo to determine if the queried avatar is walking,
+    running, or crouch walking.
+- name: ALL_SIDES
+  type: number
+  value: '-1'
+  comment: Selects all sides of an object in an applicable function.
+- name: ANIM_ON
+  type: number
+  value: '0x1'
+  comment: Enables texture animation. This must be set to start the animation and
+    cleared to stop it.
+- name: ATTACH_ANY_HUD
+  type: number
+  value: '-1'
+  comment: A special constant representing all HUD attachment points when filtering
+    for any HUD attachment.
+- name: ATTACH_AVATAR_CENTER
+  type: number
+  value: '40'
+  comment: Attachment point for the avatar's geometric center or root.
+- name: ATTACH_BACK
+  type: number
+  value: '9'
+  comment: Attachment point for the avatar's back.
+- name: ATTACH_BELLY
+  type: number
+  value: '28'
+  comment: Attachment point for the avatar's belly, stomach, or tummy.
+- name: ATTACH_CHEST
+  type: number
+  value: '1'
+  comment: Attachment point for the avatar's chest or sternum.
+- name: ATTACH_CHIN
+  type: number
+  value: '12'
+  comment: Attachment point for the avatar's chin.
+- name: ATTACH_FACE_JAW
+  type: number
+  value: '47'
+  comment: Attachment point for the avatar's jaw.
+- name: ATTACH_FACE_LEAR
+  type: number
+  value: '48'
+  comment: Attachment point for the avatar's left ear (extended).
+- name: ATTACH_FACE_LEYE
+  type: number
+  value: '50'
+  comment: Attachment point for the avatar's left eye (extended).
+- name: ATTACH_FACE_REAR
+  type: number
+  value: '49'
+  comment: Attachment point for the avatar's right ear (extended).
+- name: ATTACH_FACE_REYE
+  type: number
+  value: '51'
+  comment: Attachment point for the avatar's right eye (extended).
+- name: ATTACH_FACE_TONGUE
+  type: number
+  value: '52'
+  comment: Attachment point for the avatar's tongue.
+- name: ATTACH_GROIN
+  type: number
+  value: '53'
+  comment: Attachment point for the avatar's groin.
+- name: ATTACH_HEAD
+  type: number
+  value: '2'
+  comment: Attachment point for the avatar's head.
+- name: ATTACH_HIND_LFOOT
+  type: number
+  value: '54'
+  comment: Attachment point for the avatar's left hind foot.
+- name: ATTACH_HIND_RFOOT
+  type: number
+  value: '55'
+  comment: Attachment point for the avatar's right hind foot.
+- name: ATTACH_HUD_BOTTOM
+  type: number
+  value: '37'
+  comment: Attachment point for HUD Bottom.
+- name: ATTACH_HUD_BOTTOM_LEFT
+  type: number
+  value: '36'
+  comment: Attachment point for HUD Bottom Left.
+- name: ATTACH_HUD_BOTTOM_RIGHT
+  type: number
+  value: '38'
+  comment: Attachment point for HUD Bottom Right.
+- name: ATTACH_HUD_CENTER_1
+  type: number
+  value: '35'
+  comment: Attachment point for HUD Center.
+- name: ATTACH_HUD_CENTER_2
+  type: number
+  value: '31'
+  comment: Attachment point for HUD Center 2.
+- name: ATTACH_HUD_TOP_CENTER
+  type: number
+  value: '33'
+  comment: Attachment point for HUD Top Center.
+- name: ATTACH_HUD_TOP_LEFT
+  type: number
+  value: '34'
+  comment: Attachment point for HUD Top Left.
+- name: ATTACH_HUD_TOP_RIGHT
+  type: number
+  value: '32'
+  comment: Attachment point for HUD Top Right.
+- name: ATTACH_LEAR
+  type: number
+  value: '13'
+  comment: Attachment point for the avatar's left ear.
+- name: ATTACH_LEFT_PEC
+  type: number
+  value: '29'
+  comment: Attachment point for the avatar's left pectoral.
+- name: ATTACH_LEYE
+  type: number
+  value: '15'
+  comment: Attachment point for the avatar's left eye.
+- name: ATTACH_LFOOT
+  type: number
+  value: '7'
+  comment: Attachment point for the avatar's left foot.
+- name: ATTACH_LHAND
+  type: number
+  value: '5'
+  comment: Attachment point for the avatar's left hand.
+- name: ATTACH_LHAND_RING1
+  type: number
+  value: '41'
+  comment: Attachment point for the avatar's left ring finger.
+- name: ATTACH_LHIP
+  type: number
+  value: '25'
+  comment: Attachment point for the avatar's left hip.
+- name: ATTACH_LLARM
+  type: number
+  value: '21'
+  comment: Attachment point for the avatar's left lower arm.
+- name: ATTACH_LLLEG
+  type: number
+  value: '27'
+  comment: Attachment point for the avatar's left lower leg.
+- name: ATTACH_LPEC
+  type: number
+  value: '30'
+  comment: Attachment point for the avatar's right pectoral (deprecated, use ATTACH_RIGHT_PEC).
+- name: ATTACH_LSHOULDER
+  type: number
+  value: '3'
+  comment: Attachment point for the avatar's left shoulder.
+- name: ATTACH_LUARM
+  type: number
+  value: '20'
+  comment: Attachment point for the avatar's left upper arm.
+- name: ATTACH_LULEG
+  type: number
+  value: '26'
+  comment: Attachment point for the avatar's left upper leg.
+- name: ATTACH_LWING
+  type: number
+  value: '45'
+  comment: Attachment point for the avatar's left wing.
+- name: ATTACH_MOUTH
+  type: number
+  value: '11'
+  comment: Attachment point for the avatar's mouth.
+- name: ATTACH_NECK
+  type: number
+  value: '39'
+  comment: Attachment point for the avatar's neck.
+- name: ATTACH_NOSE
+  type: number
+  value: '17'
+  comment: Attachment point for the avatar's nose.
+- name: ATTACH_PELVIS
+  type: number
+  value: '10'
+  comment: Attachment point for the avatar's pelvis.
+- name: ATTACH_REAR
+  type: number
+  value: '14'
+  comment: Attachment point for the avatar's right ear.
+- name: ATTACH_REYE
+  type: number
+  value: '16'
+  comment: Attachment point for the avatar's right eye.
+- name: ATTACH_RFOOT
+  type: number
+  value: '8'
+  comment: Attachment point for the avatar's right foot.
+- name: ATTACH_RHAND
+  type: number
+  value: '6'
+  comment: Attachment point for the avatar's right hand (the default attachment point).
+- name: ATTACH_RHAND_RING1
+  type: number
+  value: '42'
+  comment: Attachment point for the avatar's right ring finger.
+- name: ATTACH_RHIP
+  type: number
+  value: '22'
+  comment: Attachment point for the avatar's right hip.
+- name: ATTACH_RIGHT_PEC
+  type: number
+  value: '30'
+  comment: Attachment point for the avatar's right pectoral.
+- name: ATTACH_RLARM
+  type: number
+  value: '19'
+  comment: Attachment point for the avatar's right lower arm.
+- name: ATTACH_RLLEG
+  type: number
+  value: '24'
+  comment: Attachment point for the avatar's right lower leg.
+- name: ATTACH_RPEC
+  type: number
+  value: '29'
+  comment: Attachment point for the avatar's left pectoral (deprecated, use ATTACH_LEFT_PEC).
+- name: ATTACH_RSHOULDER
+  type: number
+  value: '4'
+  comment: Attachment point for the avatar's right shoulder.
+- name: ATTACH_RUARM
+  type: number
+  value: '18'
+  comment: Attachment point for the avatar's right upper arm.
+- name: ATTACH_RULEG
+  type: number
+  value: '23'
+  comment: Attachment point for the avatar's right upper leg.
+- name: ATTACH_RWING
+  type: number
+  value: '46'
+  comment: Attachment point for the avatar's right wing.
+- name: ATTACH_TAIL_BASE
+  type: number
+  value: '43'
+  comment: Attachment point for the avatar's tail base.
+- name: ATTACH_TAIL_TIP
+  type: number
+  value: '44'
+  comment: Attachment point for the avatar's tail tip.
+- name: AVOID_CHARACTERS
+  type: number
+  value: '1'
+- name: AVOID_DYNAMIC_OBSTACLES
+  type: number
+  value: '2'
+- name: AVOID_NONE
+  type: number
+  value: '0'
+- name: BEACON_MAP
+  type: number
+  value: '1'
+  comment: Causes llMapBeacon to optionally display and focus the world map on the
+    avatar's viewer.
+- name: CAMERA_ACTIVE
+  type: number
+  value: '12'
+  comment: Option flag used with llSetCameraParams to turn scripted control of the
+    camera on or off.
+- name: CAMERA_BEHINDNESS_ANGLE
+  type: number
+  value: '8'
+  comment: Sets the angle in degrees within which the camera is not constrained by
+    changes in target rotation.
+- name: CAMERA_BEHINDNESS_LAG
+  type: number
+  value: '9'
+  comment: Sets how strongly the camera is forced to stay behind the target if outside
+    of the behindness angle.
+- name: CAMERA_DISTANCE
+  type: number
+  value: '7'
+  comment: Sets how far away the camera wants to be from its target.
+- name: CAMERA_FOCUS
+  type: number
+  value: '17'
+  comment: Sets camera focus (target position) in region coordinates.
+- name: CAMERA_FOCUS_LAG
+  type: number
+  value: '6'
+  comment: Sets how much the camera lags as it aims toward the target.
+- name: CAMERA_FOCUS_LOCKED
+  type: number
+  value: '22'
+  comment: Option flag used with llSetCameraParams to lock the camera focus so it
+    does not move.
+- name: CAMERA_FOCUS_OFFSET
+  type: number
+  value: '1'
+  comment: Adjusts the camera focus position relative to the target.
+- name: CAMERA_FOCUS_THRESHOLD
+  type: number
+  value: '11'
+  comment: Sets the radius of a sphere around the camera's target position within
+    which its focus is not affected by target motion.
+- name: CAMERA_PITCH
+  type: number
+  value: '0'
+  comment: Adjusts the angular amount that the camera aims straight ahead versus straight
+    down, maintaining the same distance (analogous to 'incidence').
+- name: CAMERA_POSITION
+  type: number
+  value: '13'
+  comment: Sets camera position in region coordinates.
+- name: CAMERA_POSITION_LAG
+  type: number
+  value: '5'
+  comment: Sets how much the camera lags as it moves toward its ideal position.
+- name: CAMERA_POSITION_LOCKED
+  type: number
+  value: '21'
+  comment: Option flag used with llSetCameraParams to lock the camera position so
+    it does not move.
+- name: CAMERA_POSITION_THRESHOLD
+  type: number
+  value: '10'
+  comment: Sets the radius of a sphere around the camera's ideal position within which
+    it is not affected by target motion.
+- name: CHANGED_ALLOWED_DROP
+  type: number
+  value: '0x40'
+  comment: Object inventory changed because a user other than the owner (or the owner
+    if the object is no-mod) added an item. This is only possible if enabled via llAllowInventoryDrop.
+- name: CHANGED_COLOR
+  type: number
+  value: '0x2'
+  comment: Object's Blinn-Phong color or alpha parameters have changed.
+- name: CHANGED_INVENTORY
+  type: number
+  value: '0x1'
+  comment: Prim inventory has changed by someone who has modification rights to it.
+- name: CHANGED_LINK
+  type: number
+  value: '0x20'
+  comment: Number of prims making up the object or avatars seated on it has changed.
+    Also occurs when duplicating a linked object or when a prim changes type or shape.
+    Does not trigger on attach/detach, sit/unsit in attachments, or single prim duplication.
+- name: CHANGED_MEDIA
+  type: number
+  value: '0x800'
+  comment: Prim Media on the prim has changed.
+- name: CHANGED_OWNER
+  type: number
+  value: '0x80'
+  comment: Object has changed owners. Triggers in the original object when a user
+    takes it, copies it, or deeds it to a group, and in the new object when it is
+    first rezzed.
+- name: CHANGED_REGION
+  type: number
+  value: '0x100'
+  comment: Object has changed regions by crossing a boundary or teleporting (if attached).
+    Triggers only in the root prim of a linkset.
+- name: CHANGED_REGION_START
+  type: number
+  value: '0x400'
+  comment: Region containing this object has just come online.
+- name: CHANGED_RENDER_MATERIAL
+  type: number
+  value: '0x1000'
+  comment: Render material (prim material ID or material overrides) has changed on
+    one or more faces.
+- name: CHANGED_SCALE
+  type: number
+  value: '0x8'
+  comment: Prim scale of at least one prim in the linked object has changed. Only
+    the root prim receives this event.
+- name: CHANGED_SHAPE
+  type: number
+  value: '0x4'
+  comment: Prim base shape (PRIM_TYPE, such as box, prism, torus, taper, twist, or
+    cut) has changed.
+- name: CHANGED_TELEPORT
+  type: number
+  value: '0x200'
+  comment: Avatar this object is attached to has teleported. Triggers only in the
+    root prim of an attachment. Does not occur for child prims or 'sit teleports'.
+    If scripts are disabled at the destination, the event queues and triggers after
+    moving to a script-enabled parcel.
+- name: CHANGED_TEXTURE
+  type: number
+  value: '0x10'
+  comment: Prim texture parameters (shine/bump settings, repeats, flip, rotation,
+    offset, or texture) have changed.
+- name: CHARACTER_ACCOUNT_FOR_SKIPPED_FRAMES
+  type: number
+  value: '14'
+  comment: If set to FALSE, the pathfinding character will not attempt to catch up
+    on lost time when performance is low, potentially providing more reliable (though
+    potentially more stuttery) movement. Default is TRUE.
+- name: CHARACTER_AVOIDANCE_MODE
+  type: number
+  value: '5'
+  comment: Specifies which objects a pathfinding character avoids (other characters,
+    dynamic obstacles like fast-moving objects and avatars, or both). Combined using
+    bit flags; setting to AVOID_NONE disables avoidance for both categories.
+- name: CHARACTER_CMD_JUMP
+  type: number
+  value: '0x01'
+  comment: Makes the character jump. Requires a height parameter between 0.1m and
+    2.0m as the first element of the llExecCharacterCmd option list.
+- name: CHARACTER_CMD_SMOOTH_STOP
+  type: number
+  value: '2'
+  comment: Stops any current pathfinding operation in a smooth fashion.
+- name: CHARACTER_CMD_STOP
+  type: number
+  value: '0x00'
+  comment: Stops any current pathfinding operation.
+- name: CHARACTER_DESIRED_SPEED
+  type: number
+  value: '1'
+  comment: Constant used to indicate that the following argument is the desired speed
+    (or speed of pursuit in meters per second) for a pathfinding character.
+- name: CHARACTER_DESIRED_TURN_SPEED
+  type: number
+  value: '12'
+  comment: Specifies the character's maximum speed while turning about the Z-axis
+    (default is 6 meters/second). Note that this is only loosely enforced, and a character
+    may turn at higher speeds under certain conditions.
+- name: CHARACTER_LENGTH
+  type: number
+  value: '3'
+  comment: Sets the collision capsule length for a pathfinding character. If the value
+    is less than twice the radius plus 0.1m, it automatically adjusts to twice the
+    radius plus 0.1m.
+- name: CHARACTER_MAX_ACCEL
+  type: number
+  value: '8'
+  comment: "Specifies the character's maximum acceleration rate (default is 20 m/s\xB2\
+    )."
+- name: CHARACTER_MAX_DECEL
+  type: number
+  value: '9'
+  comment: "Specifies the character's maximum deceleration rate (default is 30 m/s\xB2\
+    )."
+- name: CHARACTER_MAX_SPEED
+  type: number
+  value: '13'
+  comment: Specifies the character's maximum speed (must be between 0.2 and 50 meters/second;
+    default is 20 m/s). Affects speed when avoiding dynamic obstacles and when traversing
+    low-walkability objects in TRAVERSAL_TYPE_FAST mode.
+- name: CHARACTER_MAX_TURN_RADIUS
+  type: number
+  value: '10'
+  comment: Specifies the character's turn radius when traveling at CHARACTER_DESIRED_TURN_SPEED
+    (default is 1.25 meters).
+- name: CHARACTER_ORIENTATION
+  type: number
+  value: '4'
+  comment: Specifies the orientation of the collision capsule for a pathfinding character
+    to denote how to interpret its size. Valid options are VERTICAL and HORIZONTAL.
+- name: CHARACTER_RADIUS
+  type: number
+  value: '2'
+  comment: Sets the collision capsule radius used to define the size of a pathfinding
+    character.
+- name: CHARACTER_STAY_WITHIN_PARCEL
+  type: number
+  value: '15'
+  comment: Determines whether a character is restricted to its starting parcel (default
+    is FALSE). If TRUE, parcel boundaries act as one-way obstacles; the character
+    cannot voluntarily leave and pathfinding behaviors (wander, flee, evade, pursue)
+    will only choose goal points within the parcel. If pushed out, it can re-enter
+    but cannot voluntarily leave again.
+- name: CHARACTER_TYPE
+  type: number
+  value: '6'
+  comment: Specifies the preferred surface and terrain terrain-type for the character
+    (default is CHARACTER_TYPE_NONE). Used to describe preferred surfaces rather than
+    behavior (e.g., cows prefer type B, sheep herded along a road prefer type C).
+- name: CHARACTER_TYPE_A
+  type: number
+  value: '0'
+  comment: Used for pathfinding character types that prefer movement consistent with
+    humanoids.
+- name: CHARACTER_TYPE_B
+  type: number
+  value: '1'
+  comment: Used for pathfinding character types that prefer movement consistent with
+    wild animals or off-road vehicles.
+- name: CHARACTER_TYPE_C
+  type: number
+  value: '2'
+  comment: Used for mechanical pathfinding character types or road-going vehicles.
+- name: CHARACTER_TYPE_D
+  type: number
+  value: '3'
+  comment: Used for pathfinding character types that are inconsistent with types A,
+    B, or C.
+- name: CHARACTER_TYPE_NONE
+  type: number
+  value: '4'
+  comment: Used to set no specific pathfinding character type.
+- name: CLICK_ACTION_BUY
+  type: number
+  value: '2'
+  comment: Opens the buy dialog when the prim is clicked or touched.
+- name: CLICK_ACTION_DISABLED
+  type: number
+  value: '8'
+  comment: Disables click actions. No touches are detected or passed.
+- name: CLICK_ACTION_IGNORE
+  type: number
+  value: '9'
+  comment: Disables click actions. Clicks pass through the object to whatever is behind
+    it, and no touches are detected.
+- name: CLICK_ACTION_NONE
+  type: number
+  value: '0'
+  comment: 'Performs the default action: triggers touch events when the prim is clicked
+    or touched.'
+- name: CLICK_ACTION_OPEN
+  type: number
+  value: '4'
+  comment: Opens the object inventory dialog when the prim is clicked or touched.
+- name: CLICK_ACTION_OPEN_MEDIA
+  type: number
+  value: '6'
+  comment: Opens the web media dialog or plays parcel media (without pausing) when
+    the prim is touched.
+- name: CLICK_ACTION_PAY
+  type: number
+  value: '3'
+  comment: Opens the pay dialog when the prim is clicked or touched.
+- name: CLICK_ACTION_PLAY
+  type: number
+  value: '5'
+  comment: Enables HTML-on-a-prim or plays/pauses parcel media when the prim is clicked
+    or touched.
+- name: CLICK_ACTION_SIT
+  type: number
+  value: '1'
+  comment: Causes the avatar to sit on the prim when it is clicked or touched.
+- name: CLICK_ACTION_TOUCH
+  type: number
+  value: '0'
+  comment: Triggers touch events when the prim is clicked or touched.
+- name: CLICK_ACTION_ZOOM
+  type: number
+  value: '7'
+  comment: Zooms the avatar camera in on the object (Viewer 2) when clicked or touched.
+- name: COMBAT_CHANNEL
+  type: number
+  value: '2147483646'
+  comment: A region-wide channel reserved for combat-related log events. Passing this
+    to llRegionSay adds the message to the combat log, and scripts listening on this
+    channel can monitor the combat log.
+- name: COMBAT_LOG_ID
+  type: uuid
+  value: uuid("45e0fcfa-2268-4490-a51c-3e51bdfe80d1")
+  comment: ID used by all combat log messages sent from the region to the COMBAT_CHANNEL.
+    Scripts can filter llListen calls with this ID to receive only system-generated
+    combat log messages.
+- name: CONTENT_TYPE_ATOM
+  type: number
+  value: '4'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/atom+xml'.
+- name: CONTENT_TYPE_FORM
+  type: number
+  value: '7'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/x-www-form-urlencoded'.
+- name: CONTENT_TYPE_HTML
+  type: number
+  value: '1'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'text/html'. Only valid for embedded browsers on content
+    owned by the viewer; falls back to 'text/plain' otherwise.
+- name: CONTENT_TYPE_JSON
+  type: number
+  value: '5'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/json'.
+- name: CONTENT_TYPE_LLSD
+  type: number
+  value: '6'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/llsd+xml' (Linden Lab Structured Data).
+- name: CONTENT_TYPE_RSS
+  type: number
+  value: '8'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/rss+xml'.
+- name: CONTENT_TYPE_TEXT
+  type: number
+  value: '0'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'text/plain'.
+- name: CONTENT_TYPE_XHTML
+  type: number
+  value: '3'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/xhtml+xml'.
+- name: CONTENT_TYPE_XML
+  type: number
+  value: '2'
+  comment: Sets the 'Content-Type' header of subsequent LSL HTTP server responses
+    via llHTTPResponse to 'application/xml'.
+- name: CONTROL_BACK
+  type: number
+  value: '0x2'
+  comment: "Tests for the avatar move back control (\u2193 or S)."
+- name: CONTROL_DOWN
+  type: number
+  value: '0x20'
+  comment: Tests for the avatar move down control (PgDn or C).
+- name: CONTROL_FWD
+  type: number
+  value: '0x1'
+  comment: "Tests for the avatar move forward control (\u2191 or W)."
+- name: CONTROL_LBUTTON
+  type: number
+  value: '0x10000000'
+  comment: Tests for the avatar left mouse button control.
+- name: CONTROL_LEFT
+  type: number
+  value: '0x4'
+  comment: "Tests for the avatar move left control (Shift + \u2190 or Shift + A)."
+- name: CONTROL_ML_LBUTTON
+  type: number
+  value: '0x40000000'
+  comment: Tests for the avatar left mouse button control while in mouselook.
+- name: CONTROL_RIGHT
+  type: number
+  value: '0x8'
+  comment: "Tests for the avatar move right control (Shift + \u2192 or Shift + D)."
+- name: CONTROL_ROT_LEFT
+  type: number
+  value: '0x100'
+  comment: "Tests for the avatar rotate left control (\u2190 or A)."
+- name: CONTROL_ROT_RIGHT
+  type: number
+  value: '0x200'
+  comment: "Tests for the avatar rotate right control (\u2192 or D)."
+- name: CONTROL_UP
+  type: number
+  value: '0x10'
+  comment: Tests for the avatar move up control (PgUp or E).
+- name: DAMAGEABLE
+  type: number
+  value: '0x20'
+  comment: Identifies objects in the world that can process damage. In llDetectedType,
+    it indicates a damageable agent, or an object containing a script with on_damage
+    or final_damage events. Can also filter llSensor/llSensorRepeat calls.
+- name: DAMAGE_TYPE_ACID
+  type: number
+  value: '1'
+  comment: Damage caused by a caustic substance, such as acid.
+- name: DAMAGE_TYPE_BLUDGEONING
+  type: number
+  value: '2'
+  comment: Damage caused by a blunt object, such as a club.
+- name: DAMAGE_TYPE_COLD
+  type: number
+  value: '3'
+  comment: Damage inflicted by exposure to extreme cold.
+- name: DAMAGE_TYPE_ELECTRIC
+  type: number
+  value: '4'
+  comment: Damage caused by electricity.
+- name: DAMAGE_TYPE_EMOTIONAL
+  type: number
+  value: '14'
+- name: DAMAGE_TYPE_FIRE
+  type: number
+  value: '5'
+  comment: Damage inflicted by exposure to heat or flames.
+- name: DAMAGE_TYPE_FORCE
+  type: number
+  value: '6'
+  comment: Damage inflicted by a great force or impact (Vertical Sim / SLMC).
+- name: DAMAGE_TYPE_GENERIC
+  type: number
+  value: '0'
+  comment: Generic or legacy damage.
+- name: DAMAGE_TYPE_IMPACT
+  type: number
+  value: '-1'
+  comment: System damage generated by impact with land, terrain, or a prim.
+- name: DAMAGE_TYPE_NECROTIC
+  type: number
+  value: '7'
+  comment: Damage caused by a direct assault on the life-force.
+- name: DAMAGE_TYPE_PIERCING
+  type: number
+  value: '8'
+  comment: Damage caused by a piercing object such as a bullet, spear, or arrow (Vertical
+    Sim / SLMC).
+- name: DAMAGE_TYPE_POISON
+  type: number
+  value: '9'
+  comment: Damage caused by poison.
+- name: DAMAGE_TYPE_PSYCHIC
+  type: number
+  value: '10'
+  comment: Damage caused by a direct assault on the mind.
+- name: DAMAGE_TYPE_RADIANT
+  type: number
+  value: '11'
+  comment: Damage caused by radiation or extreme light.
+- name: DAMAGE_TYPE_SLASHING
+  type: number
+  value: '12'
+  comment: Damage caused by a slashing object such as a sword or axe.
+- name: DAMAGE_TYPE_SONIC
+  type: number
+  value: '13'
+  comment: Damage caused by loud noises, like a Crash Worship concert.
+- name: DATA_BORN
+  type: number
+  value: '3'
+  comment: Used with llRequestAgentData to return the agent's account creation ('born
+    on') date as a string in ISO 8601 format (YYYY-MM-DD), based on Pacific Time (not
+    UTC).
+- name: DATA_NAME
+  type: number
+  value: '2'
+  comment: Used with llRequestAgentData to return the requested agent's legacy name.
+- name: DATA_ONLINE
+  type: number
+  value: '1'
+  comment: 'Used with llRequestAgentData to return whether the requested agent is
+    online (returns an integer boolean string: TRUE if online, FALSE if offline).'
+- name: DATA_PAYINFO
+  type: number
+  value: '8'
+  comment: Used with llRequestAgentData to return a string containing the integer
+    mask flag for payment status (contains PAYMENT_INFO_ON_FILE, PAYMENT_INFO_USED,
+    or both).
+- name: DATA_RATING
+  type: number
+  value: '4'
+  comment: Deprecated. Used with llRequestAgentData to return the string '0, 0, 0,
+    0, 0, 0'. It formerly returned a comma-separated list of positive and negative
+    ratings (behavior, appearance, and building) before ratings were removed from
+    SL.
+- name: DATA_RESERVED_0
+  type: number
+  value: '9'
+  comment: Reserved for Linden use.
+- name: DATA_SIM_POS
+  type: number
+  value: '5'
+  comment: Used with llRequestSimulatorData to return the region's global position
+    as a vector.
+- name: DATA_SIM_RATING
+  type: number
+  value: '7'
+  comment: Used with llRequestSimulatorData to return the simulator rating string
+    ('PG', 'MATURE', 'ADULT', or 'UNKNOWN').
+- name: DATA_SIM_STATUS
+  type: number
+  value: '6'
+  comment: Used with llRequestSimulatorData to return the simulator status as a string.
+- name: DEBUG_CHANNEL
+  type: number
+  value: '2147483647'
+  comment: A chat channel reserved for script debugging and error messages. Passing
+    this to llSay, llWhisper, or llShout prints text to the Script Warning/Error Window
+    and broadcasts it to nearby avatars' script consoles.
+- name: DEG_TO_RAD
+  type: number
+  value: '0.017453293'
+  comment: Constant 0.017453293 (precise value is PI/180). Multiply a value in degrees
+    by this number to convert it to radians.
+- name: DENSITY
+  type: number
+  value: '1'
+  comment: "Used with llSetPhysicsMaterial to indicate that the density parameter\
+    \ is enabled (which overrides the previous value). Must be between 1.0 and 22587.0\
+    \ kg/m\xB3."
+- name: DEREZ_DIE
+  type: number
+  value: '0'
+  comment: Used with llDerezObject to immediately delete (kill) the object.
+- name: DEREZ_MAKE_TEMP
+  type: number
+  value: '1'
+  comment: Used with llDerezObject to mark the object as temporary, allowing the simulator
+    to clean it up at a later time.
+- name: DEREZ_TO_INVENTORY
+  type: number
+  value: '2'
+  comment: Used with llDerezObject to return the targeted object to the rezzer's (derezzer's)
+    inventory, saving its current state.
+- name: ENVIRONMENT_DAYINFO
+  type: number
+  value: '200'
+  comment: 'Day cycle and time information: day_length (seconds in the environment''s
+    day cycle), day_offset (seconds offset from GMT), and secs_since_midnight (seconds
+    elapsed since the last day cycle midnight).'
+- name: ENV_INVALID_AGENT
+  type: number
+  value: '-4'
+  comment: Unable to find the specified agent, or could not find an agent with the
+    specified ID.
+- name: ENV_INVALID_RULE
+  type: number
+  value: '-5'
+  comment: There was an issue with one of the rules, or an attempt was made to change
+    an unknown property.
+- name: ENV_NOT_EXPERIENCE
+  type: number
+  value: '-1'
+  comment: Attempted to change environments outside an experience, or the script is
+    not running as part of an experience with a valid experience key.
+- name: ENV_NO_ENVIRONMENT
+  type: number
+  value: '-3'
+  comment: Environmental settings inventory object could not be found, or there is
+    no environment on this parcel to modify.
+- name: ENV_NO_EXPERIENCE_LAND
+  type: number
+  value: '-7'
+  comment: Experience has not been enabled or cannot run on the land.
+- name: ENV_NO_EXPERIENCE_PERMISSION
+  type: number
+  value: '-2'
+  comment: Agent has not granted permission to change environments.
+- name: ENV_NO_PERMISSIONS
+  type: number
+  value: '-9'
+  comment: Script lacks permissions to modify the environment at this location, or
+    an attempt was made to remove altitude track 0 or 1.
+- name: ENV_OK
+  type: number
+  value: '1'
+  comment: Agent, parcel, or region will attempt to change the applied environment.
+- name: ENV_THROTTLE
+  type: number
+  value: '-8'
+  comment: Scripts have exceeded the throttle limit. Wait and retry the request.
+- name: ENV_VALIDATION_FAIL
+  type: number
+  value: '-6'
+  comment: Could not validate the environmental settings or values passed.
+- name: EOF
+  type: string
+  value: '"\n\n\n"'
+  comment: A value equal to three newline characters ("\n\n\n") returned by the dataserver
+    event, indicating that the requested line is past the end of the notecard.
+- name: ERR_GENERIC
+  type: number
+  value: '-1'
+  comment: An inexplicable and generic error where nothing is known about the cause.
+- name: ERR_MALFORMED_PARAMS
+  type: number
+  value: '-3'
+  comment: Return value for llReturnObject* functions indicating that the parameters
+    passed are malformed.
+- name: ERR_PARCEL_PERMISSIONS
+  type: number
+  value: '-2'
+  comment: Return value for llReturnObject* functions indicating a lack of permissions
+    to perform the task on the specified parcel.
+- name: ERR_RUNTIME_PERMISSIONS
+  type: number
+  value: '-4'
+  comment: Return value for llReturnObject* functions indicating the script lacks
+    the runtime permissions required to perform the requested task.
+- name: ERR_THROTTLED
+  type: number
+  value: '-5'
+  comment: Return value for llReturnObject* functions indicating that the task has
+    been throttled and should be retried later.
+- name: ESTATE_ACCESS_ALLOWED_AGENT_ADD
+  type: number
+  value: '4'
+  comment: Used as an input parameter for llManageEstateAccess to add an agent to
+    the estate's Allowed Residents list.
+- name: ESTATE_ACCESS_ALLOWED_AGENT_REMOVE
+  type: number
+  value: '8'
+  comment: Used as an input parameter for llManageEstateAccess to remove an agent
+    from the estate's Allowed Residents list.
+- name: ESTATE_ACCESS_ALLOWED_GROUP_ADD
+  type: number
+  value: '16'
+  comment: Used as an input parameter for llManageEstateAccess to add a group to the
+    estate's Allowed Groups list.
+- name: ESTATE_ACCESS_ALLOWED_GROUP_REMOVE
+  type: number
+  value: '32'
+  comment: Used as an input parameter for llManageEstateAccess to remove a group from
+    the estate's Allowed Groups list.
+- name: ESTATE_ACCESS_BANNED_AGENT_ADD
+  type: number
+  value: '64'
+  comment: Used as an input parameter for llManageEstateAccess to add an agent to
+    the estate's Banned Residents list.
+- name: ESTATE_ACCESS_BANNED_AGENT_REMOVE
+  type: number
+  value: '128'
+  comment: Used as an input parameter for llManageEstateAccess to remove an agent
+    from the estate's Banned Residents list.
+- name: FILTER_FLAGS
+  type: number
+  value: '2'
+  comment: Flags used to control which attachments are returned.
+- name: FILTER_FLAG_HUDS
+  type: number
+  value: '0x0001'
+  comment: Filter flag used with llGetAttachedListFiltered to include HUDs with matching
+    experiences in the returned result.
+- name: FILTER_INCLUDE
+  type: number
+  value: '1'
+  comment: Filter parameter used to include a specific attachment point.
+- name: FORCE_DIRECT_PATH
+  type: number
+  value: '1'
+  comment: Forces the pathfinding character to navigate in a straight line toward
+    the specified position (can be set to TRUE or FALSE).
+- name: FRICTION
+  type: number
+  value: '2'
+  comment: Used with llSetPhysicsMaterial to enable the friction override. The value
+    must be between 0.0 and 255.0.
+- name: GAME_CONTROL_AXIS_LEFTX
+  type: number
+  value: '0'
+- name: GAME_CONTROL_AXIS_LEFTY
+  type: number
+  value: '1'
+- name: GAME_CONTROL_AXIS_RIGHTX
+  type: number
+  value: '2'
+- name: GAME_CONTROL_AXIS_RIGHTY
+  type: number
+  value: '3'
+- name: GAME_CONTROL_AXIS_TRIGGERLEFT
+  type: number
+  value: '4'
+- name: GAME_CONTROL_AXIS_TRIGGERRIGHT
+  type: number
+  value: '5'
+- name: GAME_CONTROL_BUTTON_A
+  type: number
+  value: '0x1'
+- name: GAME_CONTROL_BUTTON_B
+  type: number
+  value: '0x2'
+- name: GAME_CONTROL_BUTTON_BACK
+  type: number
+  value: '0x10'
+- name: GAME_CONTROL_BUTTON_DPAD_DOWN
+  type: number
+  value: '0x1000'
+- name: GAME_CONTROL_BUTTON_DPAD_LEFT
+  type: number
+  value: '0x2000'
+- name: GAME_CONTROL_BUTTON_DPAD_RIGHT
+  type: number
+  value: '0x4000'
+- name: GAME_CONTROL_BUTTON_DPAD_UP
+  type: number
+  value: '0x800'
+- name: GAME_CONTROL_BUTTON_GUIDE
+  type: number
+  value: '0x20'
+- name: GAME_CONTROL_BUTTON_LEFTSHOULDER
+  type: number
+  value: '0x200'
+- name: GAME_CONTROL_BUTTON_LEFTSTICK
+  type: number
+  value: '0x80'
+- name: GAME_CONTROL_BUTTON_MISC1
+  type: number
+  value: '0x8000'
+- name: GAME_CONTROL_BUTTON_PADDLE1
+  type: number
+  value: '0x10000'
+- name: GAME_CONTROL_BUTTON_PADDLE2
+  type: number
+  value: '0x20000'
+- name: GAME_CONTROL_BUTTON_PADDLE3
+  type: number
+  value: '0x40000'
+- name: GAME_CONTROL_BUTTON_PADDLE4
+  type: number
+  value: '0x80000'
+- name: GAME_CONTROL_BUTTON_RIGHTSHOULDER
+  type: number
+  value: '0x400'
+- name: GAME_CONTROL_BUTTON_RIGHTSTICK
+  type: number
+  value: '0x100'
+- name: GAME_CONTROL_BUTTON_START
+  type: number
+  value: '0x40'
+- name: GAME_CONTROL_BUTTON_TOUCHPAD
+  type: number
+  value: '0x100000'
+- name: GAME_CONTROL_BUTTON_X
+  type: number
+  value: '0x4'
+- name: GAME_CONTROL_BUTTON_Y
+  type: number
+  value: '0x8'
+- name: GCNP_GET_WALKABILITY
+  type: number
+  value: '2'
+- name: GCNP_RADIUS
+  type: number
+  value: '0'
+  comment: Used with llGetClosestNavPoint to limit how far out to search for a navigation
+    point.
+- name: GCNP_STATIC
+  type: number
+  value: '1'
+  comment: Used with llGetClosestNavPoint to specify that the test should use the
+    static navmesh, ignoring all dynamic obstacles.
+- name: GRAVITY_MULTIPLIER
+  type: number
+  value: '8'
+  comment: Used with llSetPhysicsMaterial to enable the gravity multiplier override.
+    The value must be between -1.0 and +28.0.
+- name: HORIZONTAL
+  type: number
+  value: '1'
+  comment: Constant indicating that the collision capsule orientation for a pathfinding
+    character is horizontal.
+- name: HTTP_ACCEPT
+  type: number
+  value: '8'
+  comment: Used with llHTTPRequest to override the default Accept header with custom
+    MIME types (such as application/json, text/html, etc.). Responses with unlisted
+    content types will return status 415.
+- name: HTTP_BODY_MAXLENGTH
+  type: number
+  value: '2'
+  comment: 'Sets the maximum (UTF-8 encoded) byte length of the HTTP response body.
+    The maximum limit depends on the VM being used (Mono Max: 16384 bytes, LSO Max:
+    4096 bytes).'
+- name: HTTP_BODY_TRUNCATED
+  type: number
+  value: '0'
+  comment: Indicates the response body truncation point in bytes.
+- name: HTTP_CUSTOM_HEADER
+  type: number
+  value: '5'
+  comment: Adds a custom HTTP header (name and value pair) to the request. Up to 8
+    custom headers can be configured per request. Some default or sensitive headers
+    are blocked for security reasons.
+- name: HTTP_EXTENDED_ERROR
+  type: number
+  value: '9'
+  comment: If set to TRUE, llHTTPRequest always returns a key. If an error occurs
+    during the request, detailed error information (delivered in an RFC 7807 JSON
+    block) is reported through the http_response event using that key.
+- name: HTTP_METHOD
+  type: number
+  value: '0'
+  comment: Specifies the HTTP method ('GET', 'POST', 'PUT', or 'DELETE') for the request.
+- name: HTTP_MIMETYPE
+  type: number
+  value: '1'
+  comment: Specifies the request Content-Type MIME type. Text types should define
+    a charset (e.g., 'text/plain;charset=utf-8'). Use 'application/x-www-form-urlencoded'
+    to emulate HTML forms.
+- name: HTTP_PRAGMA_NO_CACHE
+  type: number
+  value: '6'
+  comment: 'Controls whether the ''Pragma: no-cache'' header is sent with the HTTP
+    request. When SendHeader is TRUE (default), the header is sent; when FALSE, it
+    is omitted.'
+- name: HTTP_USER_AGENT
+  type: number
+  value: '7'
+  comment: Appends a custom string to the default LSL User-Agent header value. Must
+    follow HTTP standard syntax (e.g., 'My-Script-Name/1.0'). Spaces are not allowed
+    and will cause a script error; use hyphens instead.
+- name: HTTP_VERBOSE_THROTTLE
+  type: number
+  value: '4'
+  comment: If set to TRUE, shouts error messages to DEBUG_CHANNEL if the outgoing
+    request rate exceeds the server limit. If FALSE, these error messages are suppressed.
+- name: HTTP_VERIFY_CERT
+  type: number
+  value: '3'
+  comment: If set to TRUE, the server's SSL certificate must be verifiable using a
+    standard certificate authority when making HTTPS requests. If FALSE, any SSL certificate
+    is accepted.
+- name: IMG_USE_BAKED_AUX1
+  type: uuid
+  value: uuid("9742065b-19b5-297c-858a-29711d539043")
+- name: IMG_USE_BAKED_AUX2
+  type: uuid
+  value: uuid("03642e83-2bd1-4eb9-34b4-4c47ed586d2d")
+- name: IMG_USE_BAKED_AUX3
+  type: uuid
+  value: uuid("edd51b77-fc10-ce7a-4b3d-011dfc349e4f")
+- name: IMG_USE_BAKED_EYES
+  type: uuid
+  value: uuid("52cc6bb6-2ee5-e632-d3ad-50197b1dcb8a")
+- name: IMG_USE_BAKED_HAIR
+  type: uuid
+  value: uuid("09aac1fb-6bce-0bee-7d44-caac6dbb6c63")
+- name: IMG_USE_BAKED_HEAD
+  type: uuid
+  value: uuid("5a9f4a74-30f2-821c-b88d-70499d3e7183")
+- name: IMG_USE_BAKED_LEFTARM
+  type: uuid
+  value: uuid("ff62763f-d60a-9855-890b-0c96f8f8cd98")
+- name: IMG_USE_BAKED_LEFTLEG
+  type: uuid
+  value: uuid("8e915e25-31d1-cc95-ae08-d58a47488251")
+- name: IMG_USE_BAKED_LOWER
+  type: uuid
+  value: uuid("24daea5f-0539-cfcf-047f-fbc40b2786ba")
+- name: IMG_USE_BAKED_SKIRT
+  type: uuid
+  value: uuid("43529ce8-7faa-ad92-165a-bc4078371687")
+- name: IMG_USE_BAKED_UPPER
+  type: uuid
+  value: uuid("ae2de45c-d252-50b8-5c6e-19f39ce79317")
+- name: INVENTORY_ALL
+  type: number
+  value: '-1'
+  comment: Used with inventory functions to specify that all types of inventory items
+    should be retrieved.
+- name: INVENTORY_ANIMATION
+  type: number
+  value: '20'
+  comment: Used with inventory functions to filter or retrieve items of the ANIMATION
+    type.
+- name: INVENTORY_BODYPART
+  type: number
+  value: '13'
+  comment: Used with inventory functions to filter or retrieve items of the BODYPART
+    type.
+- name: INVENTORY_CLOTHING
+  type: number
+  value: '5'
+  comment: Used with inventory functions to filter or retrieve items of the CLOTHING
+    type.
+- name: INVENTORY_GESTURE
+  type: number
+  value: '21'
+  comment: Used with inventory functions to filter or retrieve items of the GESTURE
+    type.
+- name: INVENTORY_LANDMARK
+  type: number
+  value: '3'
+  comment: Used with inventory functions to filter or retrieve items of the LANDMARK
+    type.
+- name: INVENTORY_MATERIAL
+  type: number
+  value: '57'
+  comment: Used with inventory functions to filter or retrieve items of the MATERIAL
+    type.
+- name: INVENTORY_NONE
+  type: number
+  value: '-1'
+  comment: Value returned by inventory functions indicating that the specified inventory
+    item does not exist.
+- name: INVENTORY_NOTECARD
+  type: number
+  value: '7'
+  comment: Used with inventory functions to filter or retrieve items of the NOTECARD
+    type.
+- name: INVENTORY_OBJECT
+  type: number
+  value: '6'
+  comment: Used with inventory functions to filter or retrieve items of the OBJECT
+    type.
+- name: INVENTORY_SCRIPT
+  type: number
+  value: '10'
+  comment: Used with inventory functions to filter or retrieve items of the SCRIPT
+    type.
+- name: INVENTORY_SETTING
+  type: number
+  value: '56'
+  comment: Used with inventory functions to filter or retrieve items of the SETTING
+    type.
+- name: INVENTORY_SOUND
+  type: number
+  value: '1'
+  comment: Used with inventory functions to filter or retrieve items of the SOUND
+    type.
+- name: INVENTORY_TEXTURE
+  type: number
+  value: '0'
+  comment: Used with inventory functions to filter or retrieve items of the TEXTURE
+    type.
+- name: JSON_APPEND
+  type: number
+  value: '-1'
+  comment: A specifier for llJsonSetValue indicating the given value should be appended
+    to the array at the specified level. If the target value is not an array, the
+    existing data will be overwritten and replaced by the new array.
+- name: JSON_ARRAY
+  type: string
+  value: '"\u{FDD2}"'
+  comment: Used with llList2Json to indicate that the provided list should be encoded
+    and returned as a string-serialized JSON array.
+- name: JSON_DELETE
+  type: string
+  value: '"\u{FDD8}"'
+  comment: A constant used to delete a value within a JSON text string.
+- name: JSON_FALSE
+  type: string
+  value: '"\u{FDD7}"'
+  comment: Return value for llJsonValueType indicating that the value at the specified
+    address in a JSON string is a boolean FALSE.
+- name: JSON_INVALID
+  type: string
+  value: '"\u{FDD0}"'
+  comment: Indicates an invalid state or parameter. Returned by llList2Json when inputs
+    are not well-formed, by llJsonValueType for an invalid JSON type, or by llJsonGetValue
+    when attempting to access a nonexistent location.
+- name: JSON_NULL
+  type: string
+  value: '"\u{FDD5}"'
+  comment: Return value for llJsonValueType indicating that the value at the specified
+    address in a JSON string is a JSON null.
+- name: JSON_NUMBER
+  type: string
+  value: '"\u{FDD3}"'
+  comment: Return value for llJsonValueType indicating that the value at the specified
+    address in a JSON string is a number.
+- name: JSON_OBJECT
+  type: string
+  value: '"\u{FDD1}"'
+  comment: Used with llList2Json to indicate that the provided list is a strided list
+    of key-value pairs to be encoded and returned as a JSON object.
+- name: JSON_STRING
+  type: string
+  value: '"\u{FDD4}"'
+  comment: Return value for llJsonValueType indicating that the value at the specified
+    address in a JSON string is a string.
+- name: JSON_TRUE
+  type: string
+  value: '"\u{FDD6}"'
+  comment: Return value for llJsonValueType indicating that the value at the specified
+    address in a JSON string is a boolean TRUE.
+- name: KFM_CMD_PAUSE
+  type: number
+  value: '2'
+  comment: Command used with KFM_COMMAND in llSetKeyframedMotion to pause the keyframed
+    motion without resetting it to the start.
+- name: KFM_CMD_PLAY
+  type: number
+  value: '0'
+  comment: Command used with KFM_COMMAND in llSetKeyframedMotion to resume a motion
+    previously stopped by KFM_CMD_STOP or paused by KFM_CMD_PAUSE.
+- name: KFM_CMD_STOP
+  type: number
+  value: '1'
+  comment: Command used with KFM_COMMAND in llSetKeyframedMotion to stop the keyframed
+    motion and reset it to the start.
+- name: KFM_COMMAND
+  type: number
+  value: '0'
+  comment: Option flag in llSetKeyframedMotion followed by KFM_CMD_STOP, KFM_CMD_PLAY,
+    or KFM_CMD_PAUSE to play, stop, or pause the motion.
+- name: KFM_DATA
+  type: number
+  value: '2'
+  comment: Option flag in llSetKeyframedMotion followed by a bitwise combination of
+    KFM_TRANSLATION and KFM_ROTATION to specify keyframe data. If absent, both rotation
+    and translation data must be provided.
+- name: KFM_FORWARD
+  type: number
+  value: '0'
+  comment: Playback mode used with KFM_MODE in llSetKeyframedMotion (default). It
+    plays the frames sequentially from 1 to N and then stops.
+- name: KFM_LOOP
+  type: number
+  value: '1'
+  comment: Playback mode used with KFM_MODE in llSetKeyframedMotion. It plays the
+    frames sequentially from 1 to N, returns to the initial position, and repeats
+    indefinitely.
+- name: KFM_MODE
+  type: number
+  value: '1'
+  comment: Option flag in llSetKeyframedMotion followed by KFM_LOOP, KFM_REVERSE,
+    KFM_FORWARD, or KFM_PING_PONG to set the playback mode (defaults to KFM_FORWARD).
+    Must be specified when the keyframe list is provided.
+- name: KFM_PING_PONG
+  type: number
+  value: '2'
+  comment: Playback mode used with KFM_MODE in llSetKeyframedMotion.
+- name: KFM_REVERSE
+  type: number
+  value: '3'
+  comment: Playback mode used with KFM_MODE in llSetKeyframedMotion. It plays the
+    frames in reverse order (from N down to 1) and then stops.
+- name: KFM_ROTATION
+  type: number
+  value: '1'
+  comment: Specifies that rotation data is included in the moves list for llSetKeyframedMotion.
+- name: KFM_TRANSLATION
+  type: number
+  value: '2'
+  comment: Specifies that translation data is included in the moves list for llSetKeyframedMotion.
+- name: LAND_BRUSH_LARGE
+  type: number
+  value: '2'
+  comment: Use a large brush size (8m x 8m).
+- name: LAND_BRUSH_MEDIUM
+  type: number
+  value: '1'
+  comment: Use a medium brush size (4m x 4m)..
+- name: LAND_BRUSH_SMALL
+  type: number
+  value: '0'
+  comment: Use a small brush size (2m x 2m).
+- name: LAND_LARGE_BRUSH
+  type: number
+  value: '3'
+  comment: 'Legacy large brush size (8m x 8m). Note: This constant value is incorrect;
+    use LAND_BRUSH_LARGE instead.'
+- name: LAND_LEVEL
+  type: number
+  value: '0'
+  comment: Action used with llModifyLand to level the land at the prim's center.
+- name: LAND_LOWER
+  type: number
+  value: '2'
+  comment: Action used with llModifyLand to lower the land.
+- name: LAND_MEDIUM_BRUSH
+  type: number
+  value: '2'
+  comment: 'Legacy medium brush size (4m x 4m). Note: This constant value is incorrect;
+    use LAND_BRUSH_MEDIUM instead.'
+- name: LAND_NOISE
+  type: number
+  value: '4'
+  comment: Action used with llModifyLand to randomize the terrain and make it rough.
+- name: LAND_RAISE
+  type: number
+  value: '1'
+  comment: Action used with llModifyLand to raise the land.
+- name: LAND_REVERT
+  type: number
+  value: '5'
+  comment: Action used with llModifyLand to restore the land to its baked value.
+- name: LAND_SMALL_BRUSH
+  type: number
+  value: '1'
+  comment: 'Legacy small brush size (2m x 2m). Note: This constant value is incorrect;
+    use LAND_BRUSH_SMALL instead.'
+- name: LAND_SMOOTH
+  type: number
+  value: '3'
+  comment: Action used with llModifyLand to smooth the land.
+- name: LEGACY_MASS_FACTOR
+  type: number
+  value: '0.01'
+- name: LINKSETDATA_DELETE
+  type: number
+  value: '2'
+  comment: Event or flag indicating a key-value pair has been removed from the linkset
+    datastore, either via llLinksetDataDelete or by writing an empty value.
+- name: LINKSETDATA_EMEMORY
+  type: number
+  value: '1'
+  comment: Error code indicating a key-value pair was too large to write to the linkset
+    datastore.
+- name: LINKSETDATA_ENOKEY
+  type: number
+  value: '2'
+  comment: Error code indicating the key name supplied to a linkset datastore operation
+    was empty.
+- name: LINKSETDATA_EPROTECTED
+  type: number
+  value: '3'
+  comment: Error code indicating the key-value pair is protected from being deleted
+    or overwritten in the linkset datastore.
+- name: LINKSETDATA_MULTIDELETE
+  type: number
+  value: '3'
+  comment: Flag or value indicating a comma-separated list of keys has been deleted
+    from the linkset datastore via llLinksetDataDeleteFound.
+- name: LINKSETDATA_NOTFOUND
+  type: number
+  value: '4'
+  comment: Error code indicating the specified key could not be found in the linkset
+    datastore.
+- name: LINKSETDATA_NOUPDATE
+  type: number
+  value: '5'
+  comment: Status code indicating that the linkset datastore was not updated because
+    the written value matched the existing stored value.
+- name: LINKSETDATA_OK
+  type: number
+  value: '0'
+  comment: Status code indicating the linkset datastore operation completed successfully.
+- name: LINKSETDATA_RESET
+  type: number
+  value: '0'
+  comment: Event or flag indicating the linkset datastore has been cleared/reset via
+    llLinksetDataReset.
+- name: LINKSETDATA_UPDATE
+  type: number
+  value: '1'
+  comment: Event or flag indicating a key in the linkset datastore has been created
+    or updated with a new value via llLinksetDataWrite.
+- name: LINK_ALL_CHILDREN
+  type: number
+  value: '-3'
+  comment: Refers to all child prims in the linkset (every prim except the root).
+- name: LINK_ALL_OTHERS
+  type: number
+  value: '-2'
+  comment: Refers to every other prim in the linkset, excluding the prim containing
+    the script.
+- name: LINK_ROOT
+  type: number
+  value: '1'
+  comment: Refers to the root prim of the linkset.
+- name: LINK_SET
+  type: number
+  value: '-1'
+  comment: Refers to every prim in the linkset.
+- name: LINK_THIS
+  type: number
+  value: '-4'
+  comment: Refers specifically to the single prim containing the running script.
+- name: LIST_STAT_GEOMETRIC_MEAN
+  type: number
+  value: '9'
+  comment: Option used with llListStatistics to calculate the geometric mean of a
+    list of numbers.
+- name: LIST_STAT_MAX
+  type: number
+  value: '2'
+  comment: Option used with llListStatistics to find the largest number in the list.
+- name: LIST_STAT_MEAN
+  type: number
+  value: '3'
+  comment: Option used with llListStatistics to calculate the mean (average) of the
+    numbers in the list.
+- name: LIST_STAT_MEDIAN
+  type: number
+  value: '4'
+  comment: Option used with llListStatistics to calculate the median of the numbers
+    in the list.
+- name: LIST_STAT_MIN
+  type: number
+  value: '1'
+  comment: Option used with llListStatistics to find the smallest number in the list.
+- name: LIST_STAT_NUM_COUNT
+  type: number
+  value: '8'
+  comment: Option used with llListStatistics to determine the count of float and integer
+    elements in the list.
+- name: LIST_STAT_RANGE
+  type: number
+  value: '0'
+  comment: Option used with llListStatistics to calculate the range (maximum value
+    minus minimum value) of the list.
+- name: LIST_STAT_STD_DEV
+  type: number
+  value: '5'
+  comment: Option used with llListStatistics to calculate the sample standard deviation
+    of a list of numbers.
+- name: LIST_STAT_SUM
+  type: number
+  value: '6'
+  comment: Option used with llListStatistics to calculate the sum of the numbers in
+    the list.
+- name: LIST_STAT_SUM_SQUARES
+  type: number
+  value: '7'
+  comment: Option used with llListStatistics to calculate the sum of the squares of
+    the numbers in the list.
+- name: LOOP
+  type: number
+  value: '0x2'
+  comment: Used with texture animation functions to cause the animation to loop continuously.
+- name: MASK_BASE
+  type: number
+  value: '0'
+  comment: Permissions mask option representing base permissions.
+- name: MASK_COMBINED
+  type: number
+  value: '0x10'
+  comment: Permissions mask option to include the object's inventory contents when
+    calculating permissions. Can be combined with other mask flags (e.g., MASK_OWNER
+    | MASK_COMBINED).
+- name: MASK_EVERYONE
+  type: number
+  value: '3'
+  comment: Permissions mask option representing permissions held by everyone.
+- name: MASK_GROUP
+  type: number
+  value: '2'
+  comment: Permissions mask option representing active group permissions.
+- name: MASK_NEXT
+  type: number
+  value: '4'
+  comment: Permissions mask option representing permissions the next owner will inherit.
+- name: MASK_OWNER
+  type: number
+  value: '1'
+  comment: Permissions mask option representing current owner permissions.
+- name: NAK
+  type: string
+  value: '"\n\x15\n"'
+  comment: Value returned by llGetNotecardLineSync (ASCII NAK surrounded by newlines,
+    i.e., codes 10, 21, 10) when requested notecard data is not in the region's cache.
+- name: NAVIGATE_TO_GOAL_REACHED_DIST
+  type: number
+  value: '2'
+- name: NULL_KEY
+  type: uuid
+  value: uuid("00000000-0000-0000-0000-000000000000")
+  comment: A special string constant used as a null or empty key value.
+- name: OBJECT_ACCOUNT_LEVEL
+  type: number
+  value: '41'
+  comment: Flag used with llGetObjectDetails to retrieve an avatar's account level.
+    Returns 0 for Basic, 1 for Premium, 5 for Plus, 10 for Premium Plus, or -1 if
+    the target is not an avatar.
+- name: OBJECT_ANIMATED_COUNT
+  type: number
+  value: '39'
+  comment: Flag used with llGetObjectDetails. For an object, returns a boolean indicating
+    if the root is set as 'Animated Mesh'. For an agent, returns the total number
+    of 'Animated Mesh' attachments worn.
+- name: OBJECT_ANIMATED_SLOTS_AVAILABLE
+  type: number
+  value: '40'
+  comment: Flag used with llGetObjectDetails to get the avatar's available 'Animated
+    Mesh' attachment slot count (returns 0 if the ID is not an avatar).
+- name: OBJECT_ATTACHED_POINT
+  type: number
+  value: '19'
+  comment: Flag used with llGetObjectDetails. Returns the integer attachment point
+    matching an ATTACH_* constant, or 0 if the target is not an attachment (e.g.,
+    an avatar or unattached object).
+- name: OBJECT_ATTACHED_SLOTS_AVAILABLE
+  type: number
+  value: '35'
+  comment: Flag used with llGetObjectDetails to get an avatar's available attachment
+    slot count. Returns 0 if the ID is not an avatar or if no slots are available.
+- name: OBJECT_BODY_SHAPE_TYPE
+  type: number
+  value: '26'
+  comment: Flag used with llGetObjectDetails to retrieve a float representing the
+    gender/sex setting of an avatar's shape (0.0 is standard female, 1.0 is standard
+    male, and values greater than or equal to 0.5 are considered male). Returns -1.0
+    if not an avatar or if no data is available.
+- name: OBJECT_CHARACTER_TIME
+  type: number
+  value: '17'
+  comment: Flag used with llGetObjectDetails to get the average CPU time (in seconds)
+    spent on navigation if the target is a pathfinding character. Returns 0 for non-characters.
+- name: OBJECT_CLICK_ACTION
+  type: number
+  value: '28'
+  comment: Flag used with llGetObjectDetails to get the click action of a prim. Returns
+    an integer corresponding to a CLICK_ACTION_* constant (default is 0).
+- name: OBJECT_CREATION_TIME
+  type: number
+  value: '36'
+  comment: Flag used with llGetObjectDetails to get the object's creation time (established
+    via build-menu rezzing or mesh uploads, not via inventory/script rezzes, copying,
+    or modifying). Returns an empty string for avatars.
+- name: OBJECT_CREATOR
+  type: number
+  value: '8'
+  comment: Flag used with llGetObjectDetails to get the key of the prim's creator.
+    Returns NULL_KEY if the ID is an avatar.
+- name: OBJECT_DAMAGE
+  type: number
+  value: '51'
+  comment: Flag used with llGetObjectDetails to retrieve the amount of damage a prim
+    inflicts upon collision.
+- name: OBJECT_DAMAGE_TYPE
+  type: number
+  value: '52'
+  comment: Flag used with llGetObjectDetails to retrieve the type of damage a prim
+    inflicts on collision. Returns an integer matching a DAMAGE_TYPE_* constant, a
+    custom type, or a value repurposed by a combat system.
+- name: OBJECT_DESC
+  type: number
+  value: '2'
+  comment: Flag used with llGetObjectDetails to retrieve the prim's description. Returns
+    an empty string if the ID is an avatar.
+- name: OBJECT_GROUP
+  type: number
+  value: '7'
+  comment: Flag used with llGetObjectDetails to get the prim's group key. Returns
+    NULL_KEY if the target is an avatar (which means a workaround is required to get
+    an avatar's active group).
+- name: OBJECT_GROUP_TAG
+  type: number
+  value: '33'
+  comment: Flag used with llGetObjectDetails to get an avatar's active group tag/title.
+    Returns an empty string if the target is not an avatar.
+- name: OBJECT_HEALTH
+  type: number
+  value: '50'
+  comment: Flag used with llGetObjectDetails to retrieve the current health value
+    of an avatar or prim.
+- name: OBJECT_HOVER_HEIGHT
+  type: number
+  value: '25'
+  comment: Flag used with llGetObjectDetails to get the dynamic hover height of an
+    avatar (default is 0.0). Returns 0.0 if not an avatar or if no data is available;
+    does not reflect the shape's 'Hover' slider.
+- name: OBJECT_LAST_OWNER_ID
+  type: number
+  value: '27'
+  comment: Flag used with llGetObjectDetails to get the key of the previous owner.
+    For group-owned objects, returns the avatar who deeded it. Returns NULL_KEY for
+    avatars, untransferred objects, or objects taken to inventory and re-rezzed.
+- name: OBJECT_LINK_NUMBER
+  type: number
+  value: '46'
+  comment: Flag used with llGetObjectDetails to get the index of the prim within its
+    linkset, or 0 if unlinked.
+- name: OBJECT_LOCKED
+  type: number
+  value: '55'
+  comment: Flag used with llGetObjectDetails to get a boolean, indicating if the object
+    is locked.
+- name: OBJECT_MASS
+  type: number
+  value: '43'
+  comment: Flag used with llGetObjectDetails to retrieve the total mass (in kilograms)
+    of the object's linkset.
+- name: OBJECT_MATERIAL
+  type: number
+  value: '42'
+  comment: Flag used with llGetObjectDetails to retrieve the physics material of the
+    object, returning an integer matching a PRIM_MATERIAL_* constant.
+- name: OBJECT_NAME
+  type: number
+  value: '1'
+  comment: Flag used with llGetObjectDetails to get the prim's name, or the legacy
+    name if the target is an avatar.
+- name: OBJECT_OMEGA
+  type: number
+  value: '29'
+  comment: Flag used with llGetObjectDetails to get the rotational (angular) velocity
+    of an object in radians per second.
+- name: OBJECT_OWNER
+  type: number
+  value: '6'
+  comment: Flag used with llGetObjectDetails to get the owner's key. If the target
+    is an avatar, their own key is returned. If group-owned, it returns NULL_KEY.
+- name: OBJECT_PATHFINDING_TYPE
+  type: number
+  value: '20'
+  comment: Flag used with llGetObjectDetails to get the pathfinding setting of an
+    object in the region, returning an integer matching an OPT_* constant.
+- name: OBJECT_PERMS
+  type: number
+  value: '53'
+  comment: Flag used with llGetObjectDetails to retrieve the permissions of the object
+    as five integers.
+- name: OBJECT_PERMS_COMBINED
+  type: number
+  value: '54'
+  comment: Flag used with llGetObjectDetails to retrieve the permissions of the object
+    combined with all of its inventory items as five integers.
+- name: OBJECT_PHANTOM
+  type: number
+  value: '22'
+  comment: Flag used with llGetObjectDetails to get a boolean indicating if phantom
+    is enabled on the object. Returns 0 if the target is an avatar or attachment.
+- name: OBJECT_PHYSICS
+  type: number
+  value: '21'
+  comment: Flag used with llGetObjectDetails to get a boolean indicating if physics
+    is enabled on the object. Returns 0 if the target is an avatar or attachment.
+- name: OBJECT_PHYSICS_COST
+  type: number
+  value: '16'
+  comment: Flag used with llGetObjectDetails to get the physics cost of the object.
+- name: OBJECT_POS
+  type: number
+  value: '3'
+  comment: Flag used with llGetObjectDetails to get the prim's position in region
+    coordinates. For an avatar outside the region, the returned position is relative
+    to the script's region.
+- name: OBJECT_PRIM_COUNT
+  type: number
+  value: '30'
+  comment: Flag used with llGetObjectDetails to get the prim count of the object.
+    Note that the script and target object must be owned by the same owner.
+- name: OBJECT_PRIM_EQUIVALENCE
+  type: number
+  value: '13'
+  comment: Flag used with llGetObjectDetails to get the prim equivalence of the object.
+- name: OBJECT_RENDER_WEIGHT
+  type: number
+  value: '24'
+  comment: Flag used with llGetObjectDetails to get the render weight (Avatar Rendering
+    Cost) of an avatar based on viewer reports. Returns 0 for objects, -1 if unknown,
+    and is capped at 500,000.
+- name: OBJECT_RETURN_PARCEL
+  type: number
+  value: '1'
+  comment: Scope flag used with llReturnObjectsByOwner to return all objects on the
+    same parcel as the script owned by the specified owner. Requires the script owner
+    to be an estate manager or the parcel owner.
+- name: OBJECT_RETURN_PARCEL_OWNER
+  type: number
+  value: '2'
+  comment: Scope flag used with llReturnObjectsByOwner to return all objects owned
+    by the specified owner that are located on parcels owned by the script's owner.
+- name: OBJECT_RETURN_REGION
+  type: number
+  value: '4'
+  comment: Scope flag used with llReturnObjectsByOwner to return all objects in the
+    region owned by the specified owner. Only works if the script is owned by the
+    estate owner or an estate manager.
+- name: OBJECT_REZZER_KEY
+  type: number
+  value: '32'
+  comment: Flag used with llGetObjectDetails to retrieve the key of the object or
+    avatar that rezzed the target object.
+- name: OBJECT_REZ_TIME
+  type: number
+  value: '45'
+  comment: Flag used with llGetObjectDetails to retrieve the timestamp of when the
+    object was rezzed.
+- name: OBJECT_ROOT
+  type: number
+  value: '18'
+  comment: Flag used with llGetObjectDetails to get the ID of the root prim. For an
+    avatar, returns the root prim of the linkset they are sitting on (or the avatar's
+    own ID if not sitting).
+- name: OBJECT_ROT
+  type: number
+  value: '4'
+  comment: Flag used with llGetObjectDetails to get the prim's rotation.
+- name: OBJECT_RUNNING_SCRIPT_COUNT
+  type: number
+  value: '9'
+  comment: Flag used with llGetObjectDetails to get the total number of running scripts
+    attached to the target object or agent.
+- name: OBJECT_SCALE
+  type: number
+  value: '47'
+  comment: Flag used with llGetObjectDetails to get the size (scale) of the object.
+- name: OBJECT_SCRIPT_MEMORY
+  type: number
+  value: '11'
+  comment: Flag used with llGetObjectDetails to get the allocated script memory (or
+    its upper limit) in bytes for the object or agent. This value is recomputed every
+    10-20 seconds.
+- name: OBJECT_SCRIPT_TIME
+  type: number
+  value: '12'
+  comment: Flag used with llGetObjectDetails to get the average script CPU time (in
+    seconds) used per frame. Reports a 30-minute average, or the average since entering
+    the region if present for less than 30 minutes.
+- name: OBJECT_SELECT_COUNT
+  type: number
+  value: '37'
+  comment: Flag used with llGetObjectDetails to get the total number of agents/avatars
+    actively selecting any link in the object. Returns 0 if the target is an avatar.
+- name: OBJECT_SERVER_COST
+  type: number
+  value: '14'
+  comment: Flag used with llGetObjectDetails to get the server cost of the object.
+- name: OBJECT_SIT_COUNT
+  type: number
+  value: '38'
+  comment: Flag used with llGetObjectDetails to get the total number of agents sitting
+    on any links in the object. Returns 0 if the target is an avatar.
+- name: OBJECT_STREAMING_COST
+  type: number
+  value: '15'
+  comment: Flag used with llGetObjectDetails to get the streaming (download) cost
+    of the object.
+- name: OBJECT_TEMP_ATTACHED
+  type: number
+  value: '34'
+  comment: Flag used with llGetObjectDetails to get a boolean indicating whether the
+    object is temporarily attached.
+- name: OBJECT_TEMP_ON_REZ
+  type: number
+  value: '23'
+  comment: Flag used with llGetObjectDetails to get a boolean indicating if temporary-on-rez
+    is enabled for the object.
+- name: OBJECT_TEXT
+  type: number
+  value: '44'
+  comment: Flag used with llGetObjectDetails to get the floating (hover) text displayed
+    above the object.
+- name: OBJECT_TEXT_ALPHA
+  type: number
+  value: '49'
+  comment: Flag used with llGetObjectDetails to get the alpha value of the floating
+    (hover) text displayed above the object.
+- name: OBJECT_TEXT_COLOR
+  type: number
+  value: '48'
+  comment: Flag used with llGetObjectDetails to get the color vector of the floating
+    (hover) text displayed above the object.
+- name: OBJECT_TOTAL_INVENTORY_COUNT
+  type: number
+  value: '31'
+  comment: Flag used with llGetObjectDetails to get the total number of inventory
+    items inside the object. Requires the script and target object to share the same
+    owner.
+- name: OBJECT_TOTAL_SCRIPT_COUNT
+  type: number
+  value: '10'
+  comment: Flag used with llGetObjectDetails to get the total number of scripts (both
+    running and stopped) attached to the target object or agent.
+- name: OBJECT_UNKNOWN_DETAIL
+  type: number
+  value: '-1'
+  comment: Flag returned by llGetObjectDetails when an invalid flag is requested.
+- name: OBJECT_VELOCITY
+  type: number
+  value: '5'
+  comment: Flag used with llGetObjectDetails to get the velocity vector of the target
+    object.
+- name: OBJECT_VOLUME_DETECT
+  type: number
+  value: '56'
+  comment: Flag used with llGetObjectDetails to get a boolean, indicating if the object
+    is VolumeDetect.
+- name: OPT_AVATAR
+  type: number
+  value: '1'
+  comment: Returned for avatars.
+- name: OPT_CHARACTER
+  type: number
+  value: '2'
+  comment: Returned for pathfinding characters.
+- name: OPT_EXCLUSION_VOLUME
+  type: number
+  value: '6'
+  comment: Returned for exclusion volumes.
+- name: OPT_LEGACY_LINKSET
+  type: number
+  value: '0'
+  comment: Returned for movable obstacles, movable phantoms, physical, and volumedetect
+    objects.
+- name: OPT_MATERIAL_VOLUME
+  type: number
+  value: '5'
+  comment: Returned for material volumes.
+- name: OPT_OTHER
+  type: number
+  value: '-1'
+  comment: Returned for attachments, Linden trees, and grass.
+- name: OPT_STATIC_OBSTACLE
+  type: number
+  value: '4'
+  comment: Returned for static obstacles.
+- name: OPT_WALKABLE
+  type: number
+  value: '3'
+  comment: Returned for walkable objects.
+- name: OVERRIDE_GLTF_BASE_ALPHA
+  type: number
+  value: '2'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
+    for the face(s). Only impacts rendering when the alpha mode is set to PRIM_GLTF_ALPHA_MODE_BLEND.
+- name: OVERRIDE_GLTF_BASE_ALPHA_MASK
+  type: number
+  value: '4'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
+    cutoff level on the face(s) when the alpha mode is set to mask.
+- name: OVERRIDE_GLTF_BASE_ALPHA_MODE
+  type: number
+  value: '3'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
+    mode on the face(s) to one of the valid blend modes.
+- name: OVERRIDE_GLTF_BASE_COLOR_FACTOR
+  type: number
+  value: '1'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to set the tinting
+    color (specified in linear RGB) used for the base color. Use llsRGB2Linear to
+    convert colors from Blinn-Phong to PBR.
+- name: OVERRIDE_GLTF_BASE_DOUBLE_SIDED
+  type: number
+  value: '5'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides. If set to TRUE,
+    the texture on the face(s) will be rendered as double-sided.
+- name: OVERRIDE_GLTF_EMISSIVE_FACTOR
+  type: number
+  value: '8'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to set the tint
+    (specified in linear RGB) used for the emissive texture on the face(s).
+- name: OVERRIDE_GLTF_METALLIC_FACTOR
+  type: number
+  value: '6'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to adjust the metallic
+    factor on the specified face(s) to a value between 0 and 1.
+- name: OVERRIDE_GLTF_ROUGHNESS_FACTOR
+  type: number
+  value: '7'
+  comment: GLTF override setting used with llSetLinkGLTFOverrides to adjust the roughness
+    factor on the specified face(s) to a value between 0 and 1.
+- name: PARCEL_COUNT_GROUP
+  type: number
+  value: '2'
+  comment: Used with llGetParcelPrimCount to get the total land impact of objects
+    not owned by the parcel owner but set to or owned by the parcel's group.
+- name: PARCEL_COUNT_OTHER
+  type: number
+  value: '3'
+  comment: Used with llGetParcelPrimCount to get the land impact of all objects that
+    are neither owned by the parcel owner nor set to or owned by the parcel's group.
+- name: PARCEL_COUNT_OWNER
+  type: number
+  value: '1'
+  comment: Used with llGetParcelPrimCount to get the total land impact of objects
+    owned by the parcel owner.
+- name: PARCEL_COUNT_SELECTED
+  type: number
+  value: '4'
+  comment: Used with llGetParcelPrimCount to get the total land impact of all objects
+    currently selected or sat on.
+- name: PARCEL_COUNT_TEMP
+  type: number
+  value: '5'
+  comment: Used with llGetParcelPrimCount to get the total land impact of temporary
+    (temp-on-rez) objects.
+- name: PARCEL_COUNT_TOTAL
+  type: number
+  value: '0'
+  comment: Used with llGetParcelPrimCount to get the total land impact of all objects
+    on the parcel(s), excluding temporary (temp-on-rez) objects.
+- name: PARCEL_DETAILS_AREA
+  type: number
+  value: '4'
+  comment: Flag used with llGetParcelDetails to retrieve the parcel's area in square
+    meters (sqm).
+- name: PARCEL_DETAILS_DESC
+  type: number
+  value: '1'
+  comment: Flag used with llGetParcelDetails to retrieve the description of the parcel
+    (up to 127 characters).
+- name: PARCEL_DETAILS_FLAGS
+  type: number
+  value: '12'
+  comment: Flag used with llGetParcelDetails to retrieve the parcel flags set on this
+    parcel (see llGetParcelFlags for listings and meanings).
+- name: PARCEL_DETAILS_GROUP
+  type: number
+  value: '3'
+  comment: Flag used with llGetParcelDetails to retrieve the parcel group's 36-character
+    key.
+- name: PARCEL_DETAILS_ID
+  type: number
+  value: '5'
+  comment: Flag used with llGetParcelDetails to retrieve the parcel's 36-character
+    UUID/key.
+- name: PARCEL_DETAILS_LANDING_LOOKAT
+  type: number
+  value: '10'
+  comment: Flag used with llGetParcelDetails to retrieve the lookat vector set for
+    the landing point (teleport routing) on this parcel, if any.
+- name: PARCEL_DETAILS_LANDING_POINT
+  type: number
+  value: '9'
+  comment: Flag used with llGetParcelDetails to retrieve the landing point vector
+    set for this parcel, if any.
+- name: PARCEL_DETAILS_NAME
+  type: number
+  value: '0'
+  comment: Flag used with llGetParcelDetails to retrieve the name of the parcel (up
+    to 63 characters).
+- name: PARCEL_DETAILS_OWNER
+  type: number
+  value: '2'
+  comment: Flag used with llGetParcelDetails to retrieve the parcel owner's 36-character
+    key.
+- name: PARCEL_DETAILS_PRIM_CAPACITY
+  type: number
+  value: '7'
+  comment: Flag used with llGetParcelDetails to retrieve the total prim capacity on
+    this and all same-owner parcels, sim-wide (see llGetParcelMaxPrims for same-parcel-only
+    and/or sim-wide reporting).
+- name: PARCEL_DETAILS_PRIM_USED
+  type: number
+  value: '8'
+  comment: Flag used with llGetParcelDetails to retrieve the total prim usage on this
+    and all same-owner parcels, sim-wide (see llGetParcelPrimCount to get prim counts
+    by owner, group, or temporary status).
+- name: PARCEL_DETAILS_SCRIPT_DANGER
+  type: number
+  value: '13'
+  comment: Flag used with llGetParcelDetails to check if the script is in danger (due
+    to restrictions that impact script execution) on the indicated parcel; see llScriptDanger.
+- name: PARCEL_DETAILS_SEE_AVATARS
+  type: number
+  value: '6'
+  comment: Flag used with llGetParcelDetails to retrieve the 'See and chat with residents
+    on this parcel' avatar visibility setting.
+- name: PARCEL_DETAILS_TP_ROUTING
+  type: number
+  value: '11'
+  comment: Flag used with llGetParcelDetails to retrieve the teleport routing setting
+    for this parcel (0 = TP_ROUTING_BLOCKED, 1 = TP_ROUTING_LANDINGP, 2 = TP_ROUTING_FREE;
+    rules are only enforced if a landing point is set).
+- name: PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY
+  type: number
+  value: '0x08000000'
+  comment: Flag used with llGetParcelFlags to check if the parcel allows all objects
+    to enter.
+- name: PARCEL_FLAG_ALLOW_CREATE_GROUP_OBJECTS
+  type: number
+  value: '0x4000000'
+  comment: Flag used with llGetParcelFlags to check if group members or scripts in
+    group-deeded objects are allowed to create/rez objects on the parcel.
+- name: PARCEL_FLAG_ALLOW_CREATE_OBJECTS
+  type: number
+  value: '0x40'
+  comment: Flag used with llGetParcelFlags to check if the parcel allows anyone to
+    create objects.
+- name: PARCEL_FLAG_ALLOW_DAMAGE
+  type: number
+  value: '0x20'
+  comment: Flag used with llGetParcelFlags to check if damage is enabled on the parcel.
+- name: PARCEL_FLAG_ALLOW_FLY
+  type: number
+  value: '0x1'
+  comment: Flag used with llGetParcelFlags to check if flying is allowed on the parcel.
+- name: PARCEL_FLAG_ALLOW_GROUP_OBJECT_ENTRY
+  type: number
+  value: '0x10000000'
+  comment: Flag used with llGetParcelFlags to check if the parcel restricts object
+    entry to only group-owned and owner-owned objects.
+- name: PARCEL_FLAG_ALLOW_GROUP_SCRIPTS
+  type: number
+  value: '0x2000000'
+  comment: Flag used with llGetParcelFlags to check if the parcel allows scripts owned
+    by the parcel's group to run.
+- name: PARCEL_FLAG_ALLOW_LANDMARK
+  type: number
+  value: '0x8'
+  comment: Flag used with llGetParcelFlags to check if the parcel allows landmarks
+    to be created.
+- name: PARCEL_FLAG_ALLOW_SCRIPTS
+  type: number
+  value: '0x2'
+  comment: Flag used with llGetParcelFlags to check if scripts (including outside
+    scripts) are allowed to run on the parcel.
+- name: PARCEL_FLAG_ALLOW_TERRAFORM
+  type: number
+  value: '0x10'
+  comment: Flag used with llGetParcelFlags to check if the parcel allows anyone to
+    terraform the land.
+- name: PARCEL_FLAG_LINDEN_HOMES
+  type: number
+  value: '0x800000'
+- name: PARCEL_FLAG_LOCAL_SOUND_ONLY
+  type: number
+  value: '0x8000'
+  comment: Flag used with llGetParcelFlags to check if the parcel restricts spatialized
+    sounds to the parcel (preventing outside sound from being heard inside).
+- name: PARCEL_FLAG_RESTRICT_PUSHOBJECT
+  type: number
+  value: '0x200000'
+  comment: Flag used with llGetParcelFlags to check if the parcel restricts the use
+    of llPushObject by non-owners (or non-group officers if group-owned).
+- name: PARCEL_FLAG_USE_ACCESS_GROUP
+  type: number
+  value: '0x100'
+  comment: Flag used with llGetParcelFlags to check if the parcel limits access to
+    group members.
+- name: PARCEL_FLAG_USE_ACCESS_LIST
+  type: number
+  value: '0x200'
+  comment: Flag used with llGetParcelFlags to check if the parcel limits access to
+    a specific list of residents (avatars).
+- name: PARCEL_FLAG_USE_BAN_LIST
+  type: number
+  value: '0x400'
+  comment: Flag used with llGetParcelFlags to check if the parcel uses a ban list
+    (including restricting access based on payment information).
+- name: PARCEL_FLAG_USE_LAND_PASS_LIST
+  type: number
+  value: '0x800'
+  comment: Flag used with llGetParcelFlags to check if the parcel restricts access
+    via purchasable land passes (sold for L$).
+- name: PARCEL_MEDIA_COMMAND_AGENT
+  type: number
+  value: '7'
+  comment: Command used with llParcelMediaCommandList to apply the specified media
+    command to the designated agent only.
+- name: PARCEL_MEDIA_COMMAND_AUTO_ALIGN
+  type: number
+  value: '9'
+  comment: Command used with llParcelMediaCommandList to toggle or set the parcel
+    media option 'Auto scale content'.
+- name: PARCEL_MEDIA_COMMAND_DESC
+  type: number
+  value: '12'
+  comment: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+    or set the parcel media description.
+- name: PARCEL_MEDIA_COMMAND_LOOP
+  type: number
+  value: '3'
+  comment: Command used with llParcelMediaCommandList to start the media stream playing
+    from the current frame and have it loop back to the beginning when it reaches
+    the end.
+- name: PARCEL_MEDIA_COMMAND_LOOP_SET
+  type: number
+  value: '13'
+  comment: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+    or set the parcel's media looping variable or loop duration (which may have functionality
+    limitations; see VWR-19712).
+- name: PARCEL_MEDIA_COMMAND_PAUSE
+  type: number
+  value: '1'
+  comment: Command used with llParcelMediaCommandList to pause the media stream on
+    the current frame.
+- name: PARCEL_MEDIA_COMMAND_PLAY
+  type: number
+  value: '2'
+  comment: Command used with llParcelMediaCommandList to play the media stream from
+    its current frame, stopping when the end is reached.
+- name: PARCEL_MEDIA_COMMAND_SIZE
+  type: number
+  value: '11'
+  comment: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+    or set the parcel media pixel resolution.
+- name: PARCEL_MEDIA_COMMAND_STOP
+  type: number
+  value: '0'
+  comment: Command used with llParcelMediaCommandList to stop the media stream and
+    rewind it to the first frame.
+- name: PARCEL_MEDIA_COMMAND_TEXTURE
+  type: number
+  value: '4'
+  comment: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+    or set the parcel's media texture.
+- name: PARCEL_MEDIA_COMMAND_TIME
+  type: number
+  value: '6'
+  comment: Command used with llParcelMediaCommandList to jump to a specific timestamp
+    in the media stream, specified in floating-point seconds.
+- name: PARCEL_MEDIA_COMMAND_TYPE
+  type: number
+  value: '10'
+  comment: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+    or set the parcel media MIME type (e.g., 'text/html').
+- name: PARCEL_MEDIA_COMMAND_UNLOAD
+  type: number
+  value: '8'
+  comment: Command used with llParcelMediaCommandList to completely unload the media
+    and restore the face's original texture.
+- name: PARCEL_MEDIA_COMMAND_URL
+  type: number
+  value: '5'
+  comment: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
+    or set the parcel's media URL.
+- name: PARCEL_SALE_AGENT
+  type: number
+  value: '2'
+  comment: Option used with llSetParcelForSale to specify the agent ID authorized
+    to buy the parcel. If none is set, any agent can purchase it.
+- name: PARCEL_SALE_OBJECTS
+  type: number
+  value: '3'
+  comment: Option used with llSetParcelForSale. If set to TRUE, objects on the parcel
+    are included in the sale.
+- name: PARCEL_SALE_PRICE
+  type: number
+  value: '1'
+  comment: Option used with llSetParcelForSale to set the parcel price. If no authorized
+    agent is set, the price must be greater than 0.
+- name: PARCEL_SALE_OK
+  type: number
+  value: '0'
+  comment: Status code indicating the parcel sale information was successfully set.
+- name: PARCEL_SALE_ERROR_NO_PARCEL
+  type: number
+  value: '1'
+  comment: Error code indicating the parcel could not be found.
+- name: PARCEL_SALE_ERROR_NO_PERMISSIONS
+  type: number
+  value: '2'
+  comment: Error code indicating the script lacks the required permissions to set
+    the parcel sale information.
+- name: PARCEL_SALE_ERROR_IN_ESCROW
+  type: number
+  value: '3'
+  comment: Error code indicating the parcel is in escrow and cannot be put up for
+    sale.
+- name: PARCEL_SALE_ERROR_INVALID_PRICE
+  type: number
+  value: '4'
+  comment: Error code indicating the specified parcel price is invalid (e.g., less
+    than or equal to 0).
+- name: PARCEL_SALE_ERROR_BAD_PARAMS
+  type: number
+  value: '5'
+  comment: Error code indicating the parameters provided to set the parcel sale information
+    are invalid.
+- name: PASSIVE
+  type: number
+  value: '0x4'
+  comment: Identifies static or non-moving in-world objects (which do not consume
+    active server resources). In llDetectedType(), indicates non-physical objects.
+    In llSensor()/llSensorRepeat() filters, searches for non-physical, non-scripted,
+    inactive, or non-moving physical objects.
+- name: PASS_ALWAYS
+  type: number
+  value: '1'
+  comment: Used with event-passing functions (e.g., llPassTouches, llPassCollisions)
+    to ensure events are always passed from the child prim to the root prim, regardless
+    of whether they are handled by child script handlers.
+- name: PASS_IF_NOT_HANDLED
+  type: number
+  value: '0'
+  comment: Used with event-passing functions (default behavior) to pass events from
+    the child prim to the root prim only if there is no script handling the event
+    in the child.
+- name: PASS_NEVER
+  type: number
+  value: '2'
+  comment: Used with event-passing functions to ensure events are never passed from
+    the child prim to the root prim, regardless of whether they are handled by child
+    script handlers.
+- name: PATROL_PAUSE_AT_WAYPOINTS
+  type: number
+  value: '0'
+  comment: Option parameter for llPatrolPoints (defaults to FALSE). If TRUE, the character
+    slows down and momentarily pauses at each waypoint. If FALSE, the character moves
+    to the next waypoint at full speed with no pause.
+- name: PAYMENT_INFO_ON_FILE
+  type: number
+  value: '1'
+  comment: Agent data flag returned by llRequestAgentData indicating if the user has
+    payment information on file.
+- name: PAYMENT_INFO_USED
+  type: number
+  value: '2'
+  comment: Agent data flag returned by llRequestAgentData indicating if the user has
+    ever used their payment information.
+- name: PAY_DEFAULT
+  type: number
+  value: '-2'
+  comment: Used with llSetPayPrice to use the default value for the specified quick
+    pay button.
+- name: PAY_HIDE
+  type: number
+  value: '-1'
+  comment: Used with llSetPayPrice to hide the specified quick pay button completely.
+- name: PERMISSION_DEBIT
+  type: number
+  value: '0x00002'
+  comment: Runtime permission that allows the script to successfully call llGiveMoney
+    or llTransferLindenDollars to debit the owner's account.
+- name: PERMISSION_TAKE_CONTROLS
+  type: number
+  value: '0x00004'
+  comment: Runtime permission that allows the script to successfully call the llTakeControls
+    function to intercept the agent's controls.
+- name: PERMISSION_REMAP_CONTROLS
+  type: number
+  value: '0x00008'
+  comment: (Not yet implemented)
+- name: PERMISSION_TRIGGER_ANIMATION
+  type: number
+  value: '0x00010'
+  comment: Runtime permission that allows the script to start or stop animations on
+    the agent (such as using llStartAnimation).
+- name: PERMISSION_ATTACH
+  type: number
+  value: '0x00020'
+  comment: Runtime permission that allows the script to successfully attach to or
+    detach from the agent using llAttachToAvatar.
+- name: PERMISSION_RELEASE_OWNERSHIP
+  type: number
+  value: '0x00040'
+  comment: (Not yet implemented)
+- name: PERMISSION_CHANGE_LINKS
+  type: number
+  value: '0x00080'
+  comment: Runtime permission that allows the script to successfully create, break,
+    or modify links to other objects using llCreateLink, llBreakLink, or llBreakAllLinks.
+- name: PERMISSION_CHANGE_JOINTS
+  type: number
+  value: '0x00100'
+  comment: (Not yet implemented)
+- name: PERMISSION_CHANGE_PERMISSIONS
+  type: number
+  value: '0x00200'
+  comment: (Not yet implemented)
+- name: PERMISSION_TRACK_CAMERA
+  type: number
+  value: '0x00400'
+  comment: Runtime permission that allows the script to track the agent's camera position
+    and rotation.
+- name: PERMISSION_CONTROL_CAMERA
+  type: number
+  value: '0x00800'
+  comment: Runtime permission that allows the script to control the agent's camera.
+    The agent must be sitting on or attached to the object, and permission is automatically
+    revoked on standing up or detaching.
+- name: PERMISSION_TELEPORT
+  type: number
+  value: '0x01000'
+  comment: Runtime permission required to teleport the agent using the llTeleportAgent
+    function.
+- name: PERMISSION_SILENT_ESTATE_MANAGEMENT
+  type: number
+  value: '0x04000'
+  comment: Runtime permission that allows the script to manage estate access rules
+    via llManageEstateAccess without notifying the object owner of the changes.
+- name: PERMISSION_OVERRIDE_ANIMATIONS
+  type: number
+  value: '0x08000'
+  comment: Runtime permission that allows the script to configure and override default
+    animations on the agent.
+- name: PERMISSION_RETURN_OBJECTS
+  type: number
+  value: '0x10000'
+  comment: Runtime permission required to use the llReturnObjectsByID and llReturnObjectsByOwner
+    functions to return objects from parcels.
+- name: PERMISSION_PRIVILEGED_LAND_ACCESS
+  type: number
+  value: '0x80000'
+  comment: Runtime permission that grants the script privileged access to land parcel
+    functions, which is required to use llSetParcelForSale.
+- name: PERM_ALL
+  type: number
+  value: '0x7FFFFFFF'
+  comment: Permissions mask representing a combination of move, modify, copy, and
+    transfer permissions.
+- name: PERM_COPY
+  type: number
+  value: '0x8000'
+  comment: Permissions mask representing copy permission.
+- name: PERM_MODIFY
+  type: number
+  value: '0x4000'
+  comment: Permissions mask representing modify permission.
+- name: PERM_MOVE
+  type: number
+  value: '0x80000'
+  comment: Permissions mask representing move permission.
+- name: PERM_TRANSFER
+  type: number
+  value: '0x2000'
+  comment: Permissions mask representing transfer permission.
+- name: PI
+  type: number
+  value: '3.14159265'
+  comment: Mathematical constant Pi (3.14159265), representing the number of radians
+    in a half circle (semi-circle). When used in sensor functions, it specifies a
+    full sphere scan.
+- name: PING_PONG
+  type: number
+  value: '0x8'
+  comment: Used with texture animation functions to cause the animation to play forward
+    first, and then in reverse.
+- name: PI_BY_TWO
+  type: number
+  value: '1.57079633'
+  comment: Constant Pi/2 (1.57079633), representing the number of radians in a quarter
+    circle. When used in sensor functions, it specifies a hemisphere scan.
+- name: PRIM_ALLOW_UNSIT
+  type: number
+  value: '39'
+  comment: Prim parameter for allowing or restricting manual standing for avatars
+    seated on this prim within a valid experience. Ignored if the avatar was not seated
+    via llSitOnLink. When restriction is active, participating seated avatars cannot
+    manually stand or select another prim to sit on.
+- name: PRIM_ALPHA_MODE
+  type: number
+  value: '38'
+  comment: Prim parameter used to set diffuse texture alpha rendering mode attributes.
+    Requires face, alpha_mode (PRIM_ALPHA_MODE_BLEND, _NONE, _MASK, or _EMISSIVE),
+    and alpha_cutoff (used only for _MASK) parameters.
+- name: PRIM_ALPHA_MODE_BLEND
+  type: number
+  value: '1'
+  comment: Prim parameter setting for PRIM_ALPHA_MODE. Directs the face to use alpha
+    blending for diffuse texture rendering (if an alpha channel exists). Also used
+    as the default value to clear material settings from a prim face.
+- name: PRIM_ALPHA_MODE_EMISSIVE
+  type: number
+  value: '3'
+  comment: Prim parameter setting for PRIM_ALPHA_MODE. Renders the diffuse texture's
+    alpha channel as an emissivity mask. Pixels render with an emissivity corresponding
+    to their opacity under all lighting conditions (fully opaque pixels effectively
+    render as 'full bright').
+- name: PRIM_ALPHA_MODE_MASK
+  type: number
+  value: '2'
+  comment: Prim parameter setting for PRIM_ALPHA_MODE. Renders the diffuse texture's
+    alpha channel on a binary per-pixel basis; pixels more opaque than the alpha cutoff
+    render as fully opaque, while pixels below the cutoff render as fully transparent.
+- name: PRIM_ALPHA_MODE_NONE
+  type: number
+  value: '0'
+  comment: Prim parameter setting for PRIM_ALPHA_MODE. Directs the face to ignore
+    the alpha channel of the diffuse texture and render as completely opaque (default
+    setting when a material face lacks an alpha channel).
+- name: PRIM_BUMP_BARK
+  type: number
+  value: '4'
+  comment: 'Face bump mapping setting: bark.'
+- name: PRIM_BUMP_BLOBS
+  type: number
+  value: '12'
+  comment: 'Face bump mapping setting: petridish (blobby amoeba-like shapes).'
+- name: PRIM_BUMP_BRICKS
+  type: number
+  value: '5'
+  comment: 'Face bump mapping setting: bricks.'
+- name: PRIM_BUMP_BRIGHT
+  type: number
+  value: '1'
+  comment: 'Face bump mapping setting: brightness (generated from highlights).'
+- name: PRIM_BUMP_CHECKER
+  type: number
+  value: '6'
+  comment: 'Face bump mapping setting: checker.'
+- name: PRIM_BUMP_CONCRETE
+  type: number
+  value: '7'
+  comment: 'Face bump mapping setting: concrete.'
+- name: PRIM_BUMP_DARK
+  type: number
+  value: '2'
+  comment: 'Face bump mapping setting: darkness (generated from lowlights).'
+- name: PRIM_BUMP_DISKS
+  type: number
+  value: '10'
+  comment: 'Face bump mapping setting: discs (packed circles).'
+- name: PRIM_BUMP_GRAVEL
+  type: number
+  value: '11'
+  comment: 'Face bump mapping setting: gravel.'
+- name: PRIM_BUMP_LARGETILE
+  type: number
+  value: '14'
+  comment: 'Face bump mapping setting: stonetile (large tile).'
+- name: PRIM_BUMP_NONE
+  type: number
+  value: '0'
+  comment: 'Face bump mapping setting: none (no bump map).'
+- name: PRIM_BUMP_SHINY
+  type: number
+  value: '19'
+  comment: Prim parameter used to get or set both the shininess and bump mapping settings
+    of a face.
+- name: PRIM_BUMP_SIDING
+  type: number
+  value: '13'
+  comment: 'Face bump mapping setting: siding.'
+- name: PRIM_BUMP_STONE
+  type: number
+  value: '9'
+  comment: 'Face bump mapping setting: cutstone (blocks).'
+- name: PRIM_BUMP_STUCCO
+  type: number
+  value: '15'
+  comment: 'Face bump mapping setting: stucco.'
+- name: PRIM_BUMP_SUCTION
+  type: number
+  value: '16'
+  comment: 'Face bump mapping setting: suction (rings).'
+- name: PRIM_BUMP_TILE
+  type: number
+  value: '8'
+  comment: 'Face bump mapping setting: crustytile.'
+- name: PRIM_BUMP_WEAVE
+  type: number
+  value: '17'
+  comment: 'Face bump mapping setting: weave.'
+- name: PRIM_BUMP_WOOD
+  type: number
+  value: '3'
+  comment: 'Face bump mapping setting: woodgrain.'
+- name: PRIM_CAST_SHADOWS
+  type: number
+  value: '24'
+  comment: Deprecated prim parameter representing shadow casting settings for the
+    primitive.
+- name: PRIM_CLICK_ACTION
+  type: number
+  value: '43'
+  comment: Prim parameter followed by a CLICK_ACTION_* constant to specify the default
+    action taken when a user clicks or touches the prim.
+- name: PRIM_COLLISION_SOUND
+  type: number
+  value: '53'
+  comment: Prim parameter to set the collision sound UUID and volume level for the
+    prim.
+- name: PRIM_COLOR
+  type: number
+  value: '18'
+  comment: "Prim parameter to get or set the Blinn-Phong color and opacity of a face.\n\
+    \ninteger face \u2013 face number or ALL_SIDES\nvector color \u2013 color in RGB\
+    \ <R, G, B> (<0.0, 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white)\nfloat alpha \u2013\
+    \ from 0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)\n"
+- name: PRIM_DAMAGE
+  type: number
+  value: '51'
+  comment: Prim parameter used to get or set the damage amount and damage type delivered
+    by the prim on collision.
+- name: PRIM_DESC
+  type: number
+  value: '28'
+  comment: Prim parameter [PRIM_DESC, string description] to get or set the prim's
+    description (equivalent to llGetObjectDesc/llSetObjectDesc).
+- name: PRIM_FLEXIBLE
+  type: number
+  value: '21'
+  comment: "Prim parameter to get or set the prim's flexible configuration.\n\ninteger\
+    \ boolean \u2013 TRUE enables, FALSE disables\ninteger softness \u2013 ranges\
+    \ from 0 to 3\nfloat gravity \u2013 ranges from -10.0 to 10.0\nfloat friction\
+    \ \u2013 ranges from 0.0 to 10.0\nfloat wind \u2013 ranges from 0.0 to 10.0\n\
+    float tension \u2013 ranges from 0.0 to 10.0\nvector force\n"
+- name: PRIM_FULLBRIGHT
+  type: number
+  value: '20'
+  comment: Prim parameter [PRIM_FULLBRIGHT, integer face, integer boolean] to get
+    or set whether full-bright rendering is enabled on the specified face.
+- name: PRIM_GLOW
+  type: number
+  value: '25'
+  comment: Prim parameter [PRIM_GLOW, integer face, float intensity] to get or set
+    the glow intensity on a face (the compiler integer value is 25 if the named constant
+    is rejected).
+- name: PRIM_GLTF_ALPHA_MODE_BLEND
+  type: number
+  value: '1'
+  comment: 'GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Renders the material
+    with transparency (alpha blending) in linear color space. Transparency from the
+    texture is multiplied by the material''s opacity multiplier. Note: This mode can
+    suffer from depth sorting and performance issues.'
+- name: PRIM_GLTF_ALPHA_MODE_MASK
+  type: number
+  value: '2'
+  comment: GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Renders the material
+    as fully opaque where the alpha value is greater than the alpha cutoff, and fully
+    transparent otherwise.
+- name: PRIM_GLTF_ALPHA_MODE_OPAQUE
+  type: number
+  value: '0'
+  comment: GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Ignores the alpha channel
+    entirely and renders the face material as completely opaque.
+- name: PRIM_GLTF_BASE_COLOR
+  type: number
+  value: '48'
+  comment: Prim parameter to get or set the GLTF base color override of an object's
+    face. Requires face, texture, repeats, offsets, rotation, linear_color (in linear
+    space; use llsRGB2Linear), alpha_mode (PRIM_GLTF_ALPHA_MODE_*), alpha_cutoff,
+    and double_sided arguments.
+- name: PRIM_GLTF_EMISSIVE
+  type: number
+  value: '46'
+  comment: Prim parameter to get or set the GLTF emission override of a face. Requires
+    face, texture, repeats, offsets, rotation, and emissive_tint (specified in linear
+    space; use llsRGB2Linear).
+- name: PRIM_GLTF_METALLIC_ROUGHNESS
+  type: number
+  value: '47'
+  comment: Prim parameter to get or set the GLTF occlusion/metallic/roughness override
+    of a face. Requires face, texture, repeats, offsets, rotation, metallic_factor,
+    and roughness_factor arguments.
+- name: PRIM_GLTF_NORMAL
+  type: number
+  value: '45'
+  comment: Prim parameter to get or set the GLTF normal map override of a face. Requires
+    face, texture, repeats, offsets, and rotation arguments.
+- name: PRIM_HEALTH
+  type: number
+  value: '52'
+  comment: Prim parameter used to get or set the health of the prim. Objects default
+    to 0 health.
+- name: PRIM_HOLE_CIRCLE
+  type: number
+  value: '0x10'
+  comment: Parameter used with certain PRIM_TYPE_* flags to make a circular hole via
+    the hole_shape parameter.
+- name: PRIM_HOLE_DEFAULT
+  type: number
+  value: '0x00'
+  comment: Parameter used with certain PRIM_TYPE_* flags to make a hole of the same
+    shape as the outer shape via the hole_shape parameter.
+- name: PRIM_HOLE_SQUARE
+  type: number
+  value: '0x20'
+  comment: Parameter used with certain PRIM_TYPE_* flags to make a squarish hole via
+    the hole_shape parameter.
+- name: PRIM_HOLE_TRIANGLE
+  type: number
+  value: '0x30'
+  comment: Parameter used with certain PRIM_TYPE_* flags to make a triangular hole
+    via the hole_shape parameter.
+- name: PRIM_LINK_TARGET
+  type: number
+  value: '34'
+  comment: Prim parameter [PRIM_LINK_TARGET, integer link_target] used to get or set
+    properties for multiple linked prims within a single primitive parameters call.
+- name: PRIM_MATERIAL
+  type: number
+  value: '2'
+  comment: Prim parameter [PRIM_MATERIAL, integer PRIM_MATERIAL_*] to get or set the
+    prim's material. The material determines the default collision sound, sprite,
+    friction coefficient, and restitution coefficient (elasticity) without affecting
+    mass.
+- name: PRIM_MATERIAL_DENSITY
+  type: number
+  value: '0x1'
+- name: PRIM_MATERIAL_FLESH
+  type: number
+  value: '4'
+  comment: 'Prim material constant: flesh.'
+- name: PRIM_MATERIAL_FRICTION
+  type: number
+  value: '0x2'
+- name: PRIM_MATERIAL_GLASS
+  type: number
+  value: '2'
+  comment: 'Prim material constant: glass (features very low friction).'
+- name: PRIM_MATERIAL_GRAVITY_MULTIPLIER
+  type: number
+  value: '0x8'
+- name: PRIM_MATERIAL_LIGHT
+  type: number
+  value: '7'
+  comment: Deprecated prim material constant. Light is now a face property instead
+    of a prim property; equivalent functionality is achieved using [PRIM_FULLBRIGHT,
+    ALL_SIDES, TRUE].
+- name: PRIM_MATERIAL_METAL
+  type: number
+  value: '1'
+  comment: 'Prim material constant: metal.'
+- name: PRIM_MATERIAL_PLASTIC
+  type: number
+  value: '5'
+  comment: 'Prim material constant: plastic.'
+- name: PRIM_MATERIAL_RESTITUTION
+  type: number
+  value: '0x4'
+- name: PRIM_MATERIAL_RUBBER
+  type: number
+  value: '6'
+  comment: 'Prim material constant: rubber.'
+- name: PRIM_MATERIAL_STONE
+  type: number
+  value: '0'
+  comment: 'Prim material constant: stone.'
+- name: PRIM_MATERIAL_WOOD
+  type: number
+  value: '3'
+  comment: 'Prim material constant: wood.'
+- name: PRIM_MEDIA_ALT_IMAGE_ENABLE
+  type: number
+  value: '0'
+  comment: 'Boolean. Gets or sets the default image state (the image a user sees before
+    media is active) on a face. The default is specified by the server for that media
+    type. Note: This flag is not currently implemented.'
+- name: PRIM_MEDIA_AUTO_LOOP
+  type: number
+  value: '4'
+  comment: Boolean. Gets or sets whether auto-looping is enabled for the face media.
+- name: PRIM_MEDIA_AUTO_PLAY
+  type: number
+  value: '5'
+  comment: Boolean. Gets or sets whether media auto-plays when a resident is able
+    to view it.
+- name: PRIM_MEDIA_AUTO_SCALE
+  type: number
+  value: '6'
+  comment: Boolean. Gets or sets whether auto-scaling is enabled, which forces the
+    media to fill the entire texture size.
+- name: PRIM_MEDIA_AUTO_ZOOM
+  type: number
+  value: '7'
+  comment: Boolean. Gets or sets whether clicking the media triggers auto-zoom and
+    auto-focus.
+- name: PRIM_MEDIA_CONTROLS
+  type: number
+  value: '1'
+  comment: Integer. Gets or sets the style of media controls (can be set to PRIM_MEDIA_CONTROLS_STANDARD
+    or PRIM_MEDIA_CONTROLS_MINI).
+- name: PRIM_MEDIA_CONTROLS_MINI
+  type: number
+  value: '1'
+  comment: Mini web navigation controls constant; does not include an address bar.
+- name: PRIM_MEDIA_CONTROLS_STANDARD
+  type: number
+  value: '0'
+  comment: Standard web navigation controls constant.
+- name: PRIM_MEDIA_CURRENT_URL
+  type: number
+  value: '2'
+  comment: String. Gets or sets the current URL displayed on the chosen face (maximum
+    1024 characters). Changing this URL triggers media navigation.
+- name: PRIM_MEDIA_FIRST_CLICK_INTERACT
+  type: number
+  value: '8'
+  comment: 'Boolean. Gets or sets what happens when someone click on a playing, but
+    unfocused media face: TRUE: Does the same thing a focused media face does, and
+    forwards the click to the web browser. FALSE: Focuses the media prim so that future
+    clicks are forwarded to the web browser. Note: Viewer settings affect this flag.
+    It works by default on most prims.'
+- name: PRIM_MEDIA_HEIGHT_PIXELS
+  type: number
+  value: '10'
+  comment: Integer. Gets or sets the height of the media in pixels.
+- name: PRIM_MEDIA_HOME_URL
+  type: number
+  value: '3'
+  comment: String. Gets or sets the home URL for the chosen face (maximum 1024 characters).
+- name: PRIM_MEDIA_MAX_HEIGHT_PIXELS
+  type: number
+  value: '2048'
+- name: PRIM_MEDIA_MAX_URL_LENGTH
+  type: number
+  value: '1024'
+- name: PRIM_MEDIA_MAX_WHITELIST_COUNT
+  type: number
+  value: '64'
+- name: PRIM_MEDIA_MAX_WHITELIST_SIZE
+  type: number
+  value: '1024'
+- name: PRIM_MEDIA_MAX_WIDTH_PIXELS
+  type: number
+  value: '2048'
+- name: PRIM_MEDIA_PARAM_MAX
+  type: number
+  value: '14'
+- name: PRIM_MEDIA_PERMS_CONTROL
+  type: number
+  value: '14'
+  comment: Integer. Gets or sets the permissions mask controlling who can see the
+    media control bar (PRIM_MEDIA_PERM_ANYONE, _GROUP, _NONE, or _OWNER).
+- name: PRIM_MEDIA_PERMS_INTERACT
+  type: number
+  value: '13'
+  comment: Integer. Gets or sets the permissions mask controlling who can interact
+    with the media (PRIM_MEDIA_PERM_ANYONE, _GROUP, _NONE, or _OWNER).
+- name: PRIM_MEDIA_PERM_ANYONE
+  type: number
+  value: '4'
+- name: PRIM_MEDIA_PERM_GROUP
+  type: number
+  value: '2'
+- name: PRIM_MEDIA_PERM_NONE
+  type: number
+  value: '0'
+- name: PRIM_MEDIA_PERM_OWNER
+  type: number
+  value: '1'
+- name: PRIM_MEDIA_WHITELIST
+  type: number
+  value: '12'
+  comment: String. Gets or sets the whitelist as a string of escaped, comma-separated
+    URLs (supports up to 64 URLs or 1024 characters, whichever comes first).
+- name: PRIM_MEDIA_WHITELIST_ENABLE
+  type: number
+  value: '11'
+  comment: Boolean. Gets or sets whether media navigation is restricted to the URLs
+    listed in PRIM_MEDIA_WHITELIST.
+- name: PRIM_MEDIA_WIDTH_PIXELS
+  type: number
+  value: '9'
+  comment: Integer. Gets or sets the width of the media in pixels.
+- name: PRIM_NAME
+  type: number
+  value: '27'
+  comment: Prim parameter [PRIM_NAME, string name] to get or set the prim's name (equivalent
+    to llGetObjectName/llSetObjectName).
+- name: PRIM_NORMAL
+  type: number
+  value: '37'
+  comment: Prim parameter to get or set the Blinn-Phong normal map texture settings
+    of a face. Requires face, texture, repeats, offsets, and rotation_in_radians arguments.
+- name: PRIM_OMEGA
+  type: number
+  value: '32'
+  comment: "Prim parameter to get, set, or disable a client-side physical-like rotation\
+    \ (analogous to llTargetOmega).\n\nvector axis \u2013 arbitrary axis to rotate\
+    \ the object around\nfloat spinrate \u2013 rate of rotation in radians per second\n\
+    float gain \u2013 also modulates the final spinrate and disables the rotation\
+    \ behavior if zero\n"
+- name: PRIM_PHANTOM
+  type: number
+  value: '5'
+  comment: Prim parameter [PRIM_PHANTOM, integer boolean] to get or set whether phantom
+    status is enabled.
+- name: PRIM_PHYSICS
+  type: number
+  value: '3'
+  comment: Prim parameter [PRIM_PHYSICS, integer boolean] to get or set whether the
+    object responds to Second Life physics.
+- name: PRIM_PHYSICS_SHAPE_CONVEX
+  type: number
+  value: '2'
+  comment: Physics shape type setting. Uses the convex hull of the prim shape to generate
+    its physics representation (the default for mesh objects).
+- name: PRIM_PHYSICS_SHAPE_NONE
+  type: number
+  value: '1'
+  comment: 'Physics shape type setting. Directs the physics engine to ignore this
+    prim entirely, preventing it from contributing to the linkset''s physics shape.
+    Note: Cannot be applied to the root prim.'
+- name: PRIM_PHYSICS_SHAPE_PRIM
+  type: number
+  value: '0'
+  comment: Physics shape type setting. Uses the actual visible shape of the prim to
+    determine its physics representation (the default for all non-mesh objects).
+- name: PRIM_PHYSICS_SHAPE_TYPE
+  type: number
+  value: '30'
+  comment: Prim parameter used to get or set the type of shape the physics engine
+    uses for the prim (PRIM_PHYSICS_SHAPE_NONE, _PRIM, or _CONVEX). Mainly used for
+    physics optimization.
+- name: PRIM_POINT_LIGHT
+  type: number
+  value: '23'
+  comment: "Prim parameter to configure local lighting.\nAccepts color in linear space\
+    \ (use llsRGB2Linear to convert from sRGB).\n\ninteger boolean \u2013 TRUE enables,\
+    \ FALSE disables\nvector linear_color \u2013 linear color in RGB <R, G, B&> (<0.0,\
+    \ 0.0, 0.0> = black, <1.0, 1.0, 1.0> = white)\nfloat intensity \u2013 ranges from\
+    \ 0.0 to 1.0\nfloat radius \u2013 ranges from 0.1 to 20.0\nfloat falloff \u2013\
+    \ ranges from 0.01 to 2.0\n"
+- name: PRIM_POSITION
+  type: number
+  value: '6'
+  comment: Prim parameter [PRIM_POSITION, vector position] to get or set the position
+    of the prim in region coordinates (or local coordinates depending on the script
+    context).
+- name: PRIM_POS_LOCAL
+  type: number
+  value: '33'
+  comment: Prim parameter [PRIM_POS_LOCAL, vector position] to get or set the local
+    position of a prim (equivalent to llGetLocalPos/llSetPos).
+- name: PRIM_PROJECTOR
+  type: number
+  value: '42'
+  comment: Prim parameter [PRIM_PROJECTOR, string texture, float fov, float focus,
+    float ambiance] to configure light projection settings. If the prim is not configured
+    as a projector, the texture key will return NULL_KEY.
+- name: PRIM_REFLECTION_PROBE
+  type: number
+  value: '44'
+  comment: Prim parameter to configure the object as a custom-placed reflection probe
+    for Image-Based Lighting (IBL). Only affects objects inside its volume of influence.
+- name: PRIM_REFLECTION_PROBE_BOX
+  type: number
+  value: '1'
+  comment: Flag option used with PRIM_REFLECTION_PROBE. When set, the reflection probe
+    volume is a box; when unset, it defaults to a sphere.
+- name: PRIM_REFLECTION_PROBE_DYNAMIC
+  type: number
+  value: '2'
+  comment: Flag option used with PRIM_REFLECTION_PROBE. When set, the probe dynamically
+    includes avatars in its image-based lighting reflections (which carries a rendering
+    performance cost).
+- name: PRIM_REFLECTION_PROBE_MIRROR
+  type: number
+  value: '4'
+  comment: 'Flag option used with PRIM_REFLECTION_PROBE. When set, intersecting low-roughness
+    PBR materials act as mirrors. Note: Mirrors do not reflect avatars unless PRIM_REFLECTION_PROBE_DYNAMIC
+    is also enabled, and they carry a performance cost.'
+- name: PRIM_RENDER_MATERIAL
+  type: number
+  value: '49'
+  comment: 'Prim parameter [PRIM_RENDER_MATERIAL, integer face, string material] to
+    get or set face material settings. Note: Setting this clears most PRIM_GLTF_*
+    properties on the face, except for repeats, offsets, and rotation_in_radians.'
+- name: PRIM_ROTATION
+  type: number
+  value: '8'
+  comment: Prim parameter [PRIM_ROTATION, rotation global_rot] to get or set the global
+    rotation of the prim (equivalent to llGetRot/llSetRot; note that setting this
+    on child prims may be broken).
+- name: PRIM_ROT_LOCAL
+  type: number
+  value: '29'
+  comment: Prim parameter [PRIM_ROT_LOCAL, rotation local_rot] to get or set the local
+    rotation of a prim (equivalent to llGetLocalRot/llSetLocalRot).
+- name: PRIM_SCRIPTED_SIT_ONLY
+  type: number
+  value: '40'
+  comment: Prim parameter restricting manual sitting on this prim. When active, sitting
+    can only be initiated via llSitOnLink; manual sitting attempts fail. This restriction
+    applies even outside experience-enabled regions.
+- name: PRIM_SCULPT_FLAG_ANIMESH
+  type: number
+  value: '32'
+  comment: Read-only flag for PRIM_TYPE_SCULPT to query whether the object is an Animated
+    Mesh (Animesh).
+- name: PRIM_SCULPT_FLAG_INVERT
+  type: number
+  value: '64'
+  comment: Flag for PRIM_TYPE_SCULPT to render the sculpted prim inside-out by inverting
+    the normals of each polygon.
+- name: PRIM_SCULPT_FLAG_MIRROR
+  type: number
+  value: '128'
+  comment: Flag for PRIM_TYPE_SCULPT to render a mirror-image of the sculpted prim,
+    mirrored across the X-axis.
+- name: PRIM_SCULPT_TYPE_CYLINDER
+  type: number
+  value: '4'
+  comment: Sculpt type option for PRIM_TYPE_SCULPT that stitches the left side to
+    the right to produce a cylinder-shaped sculpted prim.
+- name: PRIM_SCULPT_TYPE_MASK
+  type: number
+  value: '7'
+  comment: Bitmask used when parsing sculpted prim properties (PRIM_TYPE_SCULPT) from
+    llGetPrimitiveParams to separate the base sculpt type from modifying flags (invert
+    or mirror).
+- name: PRIM_SCULPT_TYPE_MESH
+  type: number
+  value: '5'
+  comment: Sculpt type option for PRIM_TYPE_SCULPT indicating the object is a uploaded
+    Mesh model.
+- name: PRIM_SCULPT_TYPE_PLANE
+  type: number
+  value: '3'
+  comment: Sculpt type option for PRIM_TYPE_SCULPT that performs no stitching or converging,
+    producing a flat plane-shaped sculpted prim.
+- name: PRIM_SCULPT_TYPE_SPHERE
+  type: number
+  value: '1'
+  comment: Sculpt type option for PRIM_TYPE_SCULPT that stitches the left side to
+    the right and separately converges the top and bottom to produce a sphere-shaped
+    sculpted prim.
+- name: PRIM_SCULPT_TYPE_TORUS
+  type: number
+  value: '2'
+  comment: Sculpt type option for PRIM_TYPE_SCULPT that stitches top-to-bottom and
+    left-to-right to produce a torus-shaped sculpted prim.
+- name: PRIM_SHINY_HIGH
+  type: number
+  value: '3'
+  comment: Sets the highest intensity legacy face shininess setting.
+- name: PRIM_SHINY_LOW
+  type: number
+  value: '1'
+  comment: Sets the lowest intensity legacy face shininess setting.
+- name: PRIM_SHINY_MEDIUM
+  type: number
+  value: '2'
+  comment: Sets a medium intensity legacy face shininess setting.
+- name: PRIM_SHINY_NONE
+  type: number
+  value: '0'
+  comment: Disables the legacy face shininess setting.
+- name: PRIM_SIT_FLAGS
+  type: number
+  value: '50'
+  comment: Prim parameter used to get or set sit-related flags currently active on
+    the prim.
+- name: PRIM_SIT_TARGET
+  type: number
+  value: '41'
+  comment: Prim parameter [PRIM_SIT_TARGET, integer boolean, vector offset, rotation
+    rot] to get or set the prim's sit target. Setting the boolean to FALSE deactivates
+    the target. Unlike llLinkSitTarget, offset <0.0, 0.0, 0.0> can be explicitly set.
+- name: PRIM_SIZE
+  type: number
+  value: '7'
+  comment: Prim parameter [PRIM_SIZE, vector size] to get or set the prim's physical
+    dimensions (equivalent to llGetScale/llSetScale).
+- name: PRIM_SLICE
+  type: number
+  value: '35'
+  comment: Prim parameter [PRIM_SLICE, vector slice] to get or set the prim's slice
+    values (a shape attribute equivalent to advanced cut).
+- name: PRIM_SPECULAR
+  type: number
+  value: '36'
+  comment: Prim parameter to get or set the Blinn-Phong specular map texture settings
+    of a face. Requires face, texture, repeats, offsets, rotation_in_radians, color,
+    glossy, and environment arguments.
+- name: PRIM_TEMP_ON_REZ
+  type: number
+  value: '4'
+  comment: Prim parameter used to get or set the object's temporary status. Temporary
+    objects live until the next garbage collection cycle (about 1 minute), do not
+    count against normal prim limits, but are subject to regional limits.
+- name: PRIM_TEXGEN
+  type: number
+  value: '22'
+  comment: Prim parameter [PRIM_TEXGEN, integer face, integer mode] to get or set
+    the texture mapping mode of the face.
+- name: PRIM_TEXGEN_DEFAULT
+  type: number
+  value: '0'
+  comment: Texture mapping mode setting for PRIM_TEXGEN. Specifies that texture repeat
+    units are measured in texture repeats per face.
+- name: PRIM_TEXGEN_PLANAR
+  type: number
+  value: '1'
+  comment: Texture mapping mode setting for PRIM_TEXGEN. Specifies that texture repeat
+    units are measured in repeats per half-meter (unlike the in-world editor, which
+    measures in repeats per meter).
+- name: PRIM_TEXT
+  type: number
+  value: '26'
+  comment: Prim parameter [PRIM_TEXT, string text, vector color, float alpha] to get
+    or set the object's floating/hover text (equivalent to llSetText).
+- name: PRIM_TEXTURE
+  type: number
+  value: '17'
+  comment: Prim parameter [PRIM_TEXTURE, integer face, string texture, vector repeats,
+    vector offsets, float rotation_in_radians] to get or set the Blinn-Phong diffuse
+    texture settings of a face.
+- name: PRIM_TYPE
+  type: number
+  value: '9'
+  comment: Prim parameter used to get or set the geometric shape type (PRIM_TYPE_*)
+    and its associated parameters.
+- name: PRIM_TYPE_BOX
+  type: number
+  value: '0'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a box and configure
+    its shape properties.
+- name: PRIM_TYPE_CYLINDER
+  type: number
+  value: '1'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a cylinder and
+    configure its shape properties.
+- name: PRIM_TYPE_PRISM
+  type: number
+  value: '2'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a prism and configure
+    its shape properties.
+- name: PRIM_TYPE_RING
+  type: number
+  value: '6'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a ring and configure
+    its shape properties.
+- name: PRIM_TYPE_SCULPT
+  type: number
+  value: '7'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a sculpted prim
+    (sculpty) or mesh of a specific type.
+- name: PRIM_TYPE_SPHERE
+  type: number
+  value: '3'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a sphere and configure
+    its shape properties.
+- name: PRIM_TYPE_TORUS
+  type: number
+  value: '4'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a torus and configure
+    its shape properties.
+- name: PRIM_TYPE_TUBE
+  type: number
+  value: '5'
+  comment: Shape parameter for PRIM_TYPE used to define the prim as a tube and configure
+    its shape properties.
+- name: PROFILE_NONE
+  type: number
+  value: '0'
+  comment: Disables script profiling.
+- name: PROFILE_SCRIPT_MEMORY
+  type: number
+  value: '1'
+  comment: Enables script memory profiling, tracking the maximum amount of memory
+    consumed while it is active.
+- name: PSYS_PART_BF_DEST_COLOR
+  type: number
+  value: '2'
+  comment: Scales the RGBA values by the RGBA values of the destination.
+- name: PSYS_PART_BF_ONE
+  type: number
+  value: '0'
+  comment: PSYS_PART_BF_ONE
+- name: PSYS_PART_BF_ONE_MINUS_DEST_COLOR
+  type: number
+  value: '4'
+  comment: Scales the RGBA values by the inverted RGBA values of the destination.
+- name: PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA
+  type: number
+  value: '9'
+  comment: Scales the RGBA values by the inverted alpha values of the particle source.
+- name: PSYS_PART_BF_ONE_MINUS_SOURCE_COLOR
+  type: number
+  value: '5'
+  comment: Scales the RGBA values by the inverted RGBA values of the particle source.
+- name: PSYS_PART_BF_SOURCE_ALPHA
+  type: number
+  value: '7'
+  comment: Scales the RGBA values by the alpha values of the particle source.
+- name: PSYS_PART_BF_SOURCE_COLOR
+  type: number
+  value: '3'
+  comment: Scales the RGBA values by the RGBA values of the particle source.
+- name: PSYS_PART_BF_ZERO
+  type: number
+  value: '1'
+  comment: Zeros out the source or destination RGBA values.
+- name: PSYS_PART_BLEND_FUNC_DEST
+  type: number
+  value: '25'
+  comment: Integer parameter defining the destination blending function.
+- name: PSYS_PART_BLEND_FUNC_SOURCE
+  type: number
+  value: '24'
+  comment: Integer parameter defining the source blending function.
+- name: PSYS_PART_BOUNCE_MASK
+  type: number
+  value: '0x4'
+  comment: Particle flag causing particles to bounce off a plane at the emitter object's
+    Z height.
+- name: PSYS_PART_EMISSIVE_MASK
+  type: number
+  value: '0x100'
+  comment: Particle flag that makes particles full-bright and unaffected by global
+    lighting (sunlight). Otherwise, particles are lit by current global lighting or
+    local point lights.
+- name: PSYS_PART_END_ALPHA
+  type: number
+  value: '4'
+  comment: Float parameter that determines the ending alpha (transparency) of the
+    particles.
+- name: PSYS_PART_END_COLOR
+  type: number
+  value: '3'
+  comment: Vector parameter <r, g, b> that determines the ending color of the particles.
+- name: PSYS_PART_END_GLOW
+  type: number
+  value: '27'
+  comment: Float parameter that determines the ending glow value of the particles.
+- name: PSYS_PART_END_SCALE
+  type: number
+  value: '6'
+  comment: Vector parameter <sx, sy, z> defining the ending size of the particle billboard
+    in meters (z-axis value is ignored).
+- name: PSYS_PART_FLAGS
+  type: number
+  value: '0'
+  comment: Integer bitfield parameter specifying the simulation flags for emitted
+    particles. Multiple flags can be combined using bitwise OR (|).
+- name: PSYS_PART_FOLLOW_SRC_MASK
+  type: number
+  value: '0x10'
+  comment: Particle flag causing particle positions to remain relative to the position
+    and movement of the emitter. Enabling this flag disables the PSYS_SRC_BURST_RADIUS
+    rule.
+- name: PSYS_PART_FOLLOW_VELOCITY_MASK
+  type: number
+  value: '0x20'
+  comment: Particle flag causing particles to rotate and orient their vertical 'top'
+    toward their direction of movement or emission. Otherwise, they remain vertically
+    oriented with the top of the texture facing up.
+- name: PSYS_PART_INTERP_COLOR_MASK
+  type: number
+  value: '0x1'
+  comment: Particle flag causing the particle's color and alpha to smoothly interpolate
+    from their START values to their END values over its lifetime.
+- name: PSYS_PART_INTERP_SCALE_MASK
+  type: number
+  value: '0x2'
+  comment: Particle flag causing the particle's size/scale to transition from its
+    START setting to its END setting over its lifetime.
+- name: PSYS_PART_MAX_AGE
+  type: number
+  value: '7'
+  comment: Float parameter specifying the lifetime (age in seconds) of an individual
+    particle before it dies.
+- name: PSYS_PART_RIBBON_MASK
+  type: number
+  value: '0x400'
+  comment: Particle flag that joins emitted particles into a continuous ribbon strip.
+    Textures stretch to join adjacent edges. Width is controlled by the 'x' start/end
+    scale; 'y' controls maximum visibility distance. Ribbon segments are not camera-facing,
+    mimic the emitter's Z-axis, and require horizontal movement to render.
+- name: PSYS_PART_START_ALPHA
+  type: number
+  value: '2'
+  comment: Float parameter that determines the starting alpha (transparency) of the
+    particles.
+- name: PSYS_PART_START_COLOR
+  type: number
+  value: '1'
+  comment: Vector parameter <r, g, b> that determines the starting color of the particles.
+- name: PSYS_PART_START_GLOW
+  type: number
+  value: '26'
+  comment: Float parameter that determines the starting glow value of the particles.
+- name: PSYS_PART_START_SCALE
+  type: number
+  value: '5'
+  comment: Vector parameter <sx, sy, z> defining the starting size of the particle
+    billboard in meters (z-axis value is ignored).
+- name: PSYS_PART_TARGET_LINEAR_MASK
+  type: number
+  value: '0x80'
+  comment: Particle flag causing emitted particles to move in a straight, evenly-spaced
+    line toward the PSYS_SRC_TARGET_KEY target. Ignores non-DROP patterns, radius,
+    burst speeds, angles, omega, acceleration, and wind. Combining with bounce while
+    target is below emitter deflects particles upward.
+- name: PSYS_PART_TARGET_POS_MASK
+  type: number
+  value: '0x40'
+  comment: Particle flag causing emitted particles to change course and travel toward
+    the target specified by PSYS_SRC_TARGET_KEY during their lifetime. If no valid
+    or reachable target is set, particles target the emitting prim itself.
+- name: PSYS_PART_WIND_MASK
+  type: number
+  value: '0x8'
+  comment: Particle flag that applies wind as a secondary force on the particles,
+    damping their velocity toward the wind velocity.
+- name: PSYS_SRC_ACCEL
+  type: number
+  value: '8'
+  comment: Vector parameter <x, y, z> specifying the constant acceleration to apply
+    to particles.
+- name: PSYS_SRC_ANGLE_BEGIN
+  type: number
+  value: '22'
+  comment: Float parameter specifying the angle in radians where particles will not
+    be created (for ANGLE patterns).
+- name: PSYS_SRC_ANGLE_END
+  type: number
+  value: '23'
+  comment: Float parameter specifying the ending angle in radians to be filled with
+    particles (for ANGLE patterns). If smaller than angle_begin, their roles are swapped.
+- name: PSYS_SRC_BURST_PART_COUNT
+  type: number
+  value: '15'
+  comment: Integer parameter specifying the number of particles to release in each
+    burst.
+- name: PSYS_SRC_BURST_RADIUS
+  type: number
+  value: '16'
+  comment: Float parameter specifying the radial distance from the emitter's center
+    at which particles are created.
+- name: PSYS_SRC_BURST_RATE
+  type: number
+  value: '13'
+  comment: Float parameter specifying the interval in seconds between particle bursts.
+- name: PSYS_SRC_BURST_SPEED_MAX
+  type: number
+  value: '18'
+  comment: Float parameter specifying the maximum initial speed of emitted particles.
+- name: PSYS_SRC_BURST_SPEED_MIN
+  type: number
+  value: '17'
+  comment: Float parameter specifying the minimum initial speed of emitted particles.
+- name: PSYS_SRC_INNERANGLE
+  type: number
+  value: '10'
+  comment: Float parameter specifying the inner angle of the arc for ANGLE or ANGLE_CONE
+    patterns. The specified inner area will not contain particles.
+- name: PSYS_SRC_MAX_AGE
+  type: number
+  value: '19'
+  comment: Float parameter specifying the active duration of the particle system in
+    seconds (0.0 means forever).
+- name: PSYS_SRC_OBJ_REL_MASK
+  type: number
+  value: '0x1'
+- name: PSYS_SRC_OMEGA
+  type: number
+  value: '21'
+  comment: Vector parameter setting the angular velocity used to rotate the emission
+    axis for ANGLE and ANGLE_CONE patterns.
+- name: PSYS_SRC_OUTERANGLE
+  type: number
+  value: '11'
+  comment: Float parameter specifying the outer angle of the arc for ANGLE or ANGLE_CONE
+    patterns. The area between the outer and inner angles is filled with particles.
+- name: PSYS_SRC_PATTERN
+  type: number
+  value: '9'
+  comment: Integer parameter specifying the generation pattern (PSYS_SRC_PATTERN_*)
+    used to emit particles.
+- name: PSYS_SRC_PATTERN_ANGLE
+  type: number
+  value: '0x04'
+  comment: Emission pattern that sprays particles outward in a flat circular, semi-circular,
+    arc, or ray-shaped 2D area (around the prim's local X-axis) as defined by the
+    start/end and inner/outer angle parameters.
+- name: PSYS_SRC_PATTERN_ANGLE_CONE
+  type: number
+  value: '0x08'
+  comment: Emission pattern that sprays particles outward in a 3D spherical, conical,
+    or ring-shaped area defined by the start/end and inner/outer angle parameters.
+    Can emulate the EXPLODE pattern if angles are set to 0.0 and PI.
+- name: PSYS_SRC_PATTERN_ANGLE_CONE_EMPTY
+  type: number
+  value: '0x10'
+  comment: Incomplete emission pattern that behaves identically to the DROP pattern.
+    Intended to invert the ANGLE parameters to define an empty area where particles
+    are not sprayed.
+- name: PSYS_SRC_PATTERN_DROP
+  type: number
+  value: '0x01'
+  comment: Emission pattern that drops particles at the source position with no initial
+    velocity. Overrides burst radius, minimum speed, and maximum speed settings to
+    0.0.
+- name: PSYS_SRC_PATTERN_EXPLODE
+  type: number
+  value: '0x02'
+  comment: Emission pattern that shoots particles outward in all directions using
+    the burst parameters.
+- name: PSYS_SRC_TARGET_KEY
+  type: number
+  value: '20'
+  comment: Key (UUID) of the target object that particles travel toward when PSYS_PART_TARGET_POS_MASK
+    or PSYS_PART_TARGET_LINEAR_MASK is enabled.
+- name: PSYS_SRC_TEXTURE
+  type: number
+  value: '12'
+  comment: String parameter specifying the inventory name or UUID asset key of the
+    texture used for the particles.
+- name: PUBLIC_CHANNEL
+  type: number
+  value: '0'
+  comment: Integer constant representing the open local chat channel. Passing this
+    to chat functions (llSay, llWhisper, llShout) prints text to the publicly heard
+    chat seen by nearby users and objects.
+- name: PURSUIT_FUZZ_FACTOR
+  type: number
+  value: '3'
+  comment: Option for llPursue that selects a random destination near the PURSUIT_OFFSET
+    (range is 0 to 1, where 1 is most random). Requires a non-zero PURSUIT_OFFSET.
+- name: PURSUIT_GOAL_TOLERANCE
+  type: number
+  value: '5'
+  comment: Option for llPursue defining how close (between 0.25m and 10m) the character
+    must be to consider the goal reached.
+- name: PURSUIT_INTERCEPT
+  type: number
+  value: '4'
+  comment: Option for llPursue specifying whether the pathfinding character attempts
+    to predict and intercept the target's future location.
+- name: PURSUIT_OFFSET
+  type: number
+  value: '1'
+  comment: Option for llPursue specifying a constant position offset relative to the
+    target for the character to navigate toward.
+- name: PU_EVADE_HIDDEN
+  type: number
+  value: '0x07'
+  comment: Path update status code triggered when an llEvade character determines
+    it has successfully hidden from its pursuer.
+- name: PU_EVADE_SPOTTED
+  type: number
+  value: '0x08'
+  comment: Path update status code triggered when an llEvade character switches from
+    hiding to running.
+- name: PU_FAILURE_DYNAMIC_PATHFINDING_DISABLED
+  type: number
+  value: '10'
+  comment: Path update failure code triggered when a character enters a region where
+    dynamic pathfinding has been disabled in the Region Debug Console.
+- name: PU_FAILURE_INVALID_GOAL
+  type: number
+  value: '0x03'
+  comment: Path update failure code triggered when the specified goal is not on the
+    region's navigation mesh (navmesh) and is unreachable.
+- name: PU_FAILURE_INVALID_START
+  type: number
+  value: '0x02'
+  comment: Path update failure code triggered when the character is at an unnavigable
+    starting position (e.g., off the navmesh or too high above it).
+- name: PU_FAILURE_NO_NAVMESH
+  type: number
+  value: '0x09'
+  comment: Path update fatal error triggered when there is no navmesh generated for
+    the region (typically indicates a server failure).
+- name: PU_FAILURE_NO_VALID_DESTINATION
+  type: number
+  value: '0x06'
+  comment: Path update failure code triggered when no reachable destinations remain
+    (e.g., all patrol waypoints are blocked).
+- name: PU_FAILURE_OTHER
+  type: number
+  value: '1000000'
+  comment: Path update failure code representing an unspecified or general failure.
+- name: PU_FAILURE_PARCEL_UNREACHABLE
+  type: number
+  value: '11'
+  comment: Path update failure code triggered when a character is blocked from entering
+    a parcel (e.g., the parcel is full or object entry was disabled after the navmesh
+    was baked).
+- name: PU_FAILURE_TARGET_GONE
+  type: number
+  value: '0x05'
+  comment: Path update failure code triggered when an llPursue or llEvade target can
+    no longer be tracked (e.g., they left the region or went more than ~30m outside
+    region boundaries).
+- name: PU_FAILURE_UNREACHABLE
+  type: number
+  value: '0x04'
+  comment: Path update failure code triggered when a previously valid goal becomes
+    unreachable (e.g., an obstacle blocks the path).
+- name: PU_GOAL_REACHED
+  type: number
+  value: '0x01'
+  comment: Path update status code triggered when the character reaches its goal and
+    either stops or chooses a new goal (if wandering).
+- name: PU_SLOWDOWN_DISTANCE_REACHED
+  type: number
+  value: '0x00'
+  comment: Path update status code triggered when the character enters the slowdown
+    distance near its current goal.
+- name: RAD_TO_DEG
+  type: number
+  value: '57.2957795'
+  comment: Constant 57.2957795 (precise value is 180/PI). Multiply a value in radians
+    by this number to convert it to degrees.
+- name: RCERR_CAST_TIME_EXCEEDED
+  type: number
+  value: '-3'
+  comment: Raycast error indicating the parcel or agent exceeded the maximum allocated
+    raycast time. Waiting a few frames and retrying will usually succeed as resources
+    replenish.
+- name: RCERR_SIM_PERF_LOW
+  type: number
+  value: '-2'
+  comment: Raycast error indicating the request failed due to low simulator performance.
+    Wait before retrying, and if possible, reduce scene complexity.
+- name: RCERR_UNKNOWN
+  type: number
+  value: '-1'
+  comment: Raycast error indicating an unspecified failure.
+- name: RC_DATA_FLAGS
+  type: number
+  value: '2'
+  comment: Flag used with llCastRay to configure returned data.
+- name: RC_DETECT_PHANTOM
+  type: number
+  value: '1'
+  comment: Flag used with llCastRay. If set to TRUE (or non-zero), detects both phantom
+    and volume-detect objects (they cannot be filtered individually). This overrides
+    the RC_REJECT_NONPHYSICAL and RC_REJECT_PHYSICAL settings in RC_REJECT_TYPES.
+- name: RC_GET_LINK_NUM
+  type: number
+  value: '4'
+  comment: Flag used with llCastRay causing the results stride to include the specific
+    link number that was hit.
+- name: RC_GET_NORMAL
+  type: number
+  value: '1'
+  comment: Flag used with llCastRay causing the results stride to include the surface
+    normal vector of the impact point.
+- name: RC_GET_ROOT_KEY
+  type: number
+  value: '2'
+  comment: Flag used with llCastRay that returns the key of the hit object's root
+    prim instead of the hit child prim.
+- name: RC_MAX_HITS
+  type: number
+  value: '3'
+  comment: Flag used with llCastRay to set the maximum number of hits to return (up
+    to 256). To avoid performance issues, keep this value small.
+- name: RC_REJECT_AGENTS
+  type: number
+  value: '1'
+  comment: Flag used with llCastRay to prevent the detection of avatars.
+- name: RC_REJECT_LAND
+  type: number
+  value: '8'
+  comment: Flag used with llCastRay to ignore the actual terrain ground (land).
+- name: RC_REJECT_NONPHYSICAL
+  type: number
+  value: '4'
+  comment: Flag used with llCastRay to ignore non-physical objects.
+- name: RC_REJECT_PHYSICAL
+  type: number
+  value: '2'
+  comment: Flag used with llCastRay to ignore physical objects.
+- name: RC_REJECT_TYPES
+  type: number
+  value: '0'
+  comment: Flag used with llCastRay to define a mask for ignoring specific types of
+    objects and avatars.
+- name: REGION_FLAG_ALLOW_DAMAGE
+  type: number
+  value: '0x1'
+  comment: Flag used with llGetRegionFlags to check if the region is entirely damage-enabled.
+- name: REGION_FLAG_ALLOW_DIRECT_TELEPORT
+  type: number
+  value: '0x100000'
+  comment: Flag used with llGetRegionFlags to check if direct teleportation is allowed
+    in the region.
+- name: REGION_FLAG_BLOCK_FLY
+  type: number
+  value: '0x80000'
+  comment: Flag used with llGetRegionFlags to check if flying is blocked/disabled
+    in the region.
+- name: REGION_FLAG_BLOCK_FLYOVER
+  type: number
+  value: '0x8000000'
+- name: REGION_FLAG_BLOCK_TERRAFORM
+  type: number
+  value: '0x40'
+  comment: Flag used with llGetRegionFlags to check if terraforming is disabled in
+    the region.
+- name: REGION_FLAG_DISABLE_COLLISIONS
+  type: number
+  value: '0x1000'
+  comment: Flag used with llGetRegionFlags to check if collisions have been disabled
+    in the region.
+- name: REGION_FLAG_DISABLE_PHYSICS
+  type: number
+  value: '0x4000'
+  comment: Flag used with llGetRegionFlags to check if physics has been disabled in
+    the region.
+- name: REGION_FLAG_FIXED_SUN
+  type: number
+  value: '0x10'
+  comment: Flag used with llGetRegionFlags to check if the sun's position is fixed
+    in the region.
+- name: REGION_FLAG_RESTRICT_PUSHOBJECT
+  type: number
+  value: '0x400000'
+  comment: Flag used with llGetRegionFlags to check if llPushObject is restricted
+    in the region.
+- name: REGION_FLAG_SANDBOX
+  type: number
+  value: '0x100'
+  comment: Flag used with llGetRegionFlags to check if the region is designated as
+    a sandbox.
+- name: REMOTE_DATA_CHANNEL
+  type: number
+  value: '1'
+- name: REMOTE_DATA_REPLY
+  type: number
+  value: '3'
+- name: REMOTE_DATA_REQUEST
+  type: number
+  value: '2'
+- name: REQUIRE_LINE_OF_SIGHT
+  type: number
+  value: '2'
+  comment: Option flag for llPursue defining whether the character requires a physical
+    line-of-sight to chase the target. When active, it will not target positions blocked
+    by solid obstacles.
+- name: RESTITUTION
+  type: number
+  value: '4'
+  comment: Used with llSetPhysicsMaterial to enable the restitution (bounciness) value
+    (must be between 0.0 and 1.0) which overrides the previous value.
+- name: REVERSE
+  type: number
+  value: '0x4'
+  comment: Used with texture animation functions to cause the animation to play in
+    reverse (from end to start).
+- name: REZ_ACCEL
+  type: number
+  value: '5'
+  comment: Rez parameter specifying a constant acceleration force to apply to the
+    rezzed object (as a [vector force, integer relative] pair). If relative is TRUE,
+    the vector is in local coordinates.
+- name: REZ_DAMAGE
+  type: number
+  value: '8'
+  comment: Rez parameter specifying the float damage amount the rezzed object inflicts
+    on an agent upon collision.
+- name: REZ_DAMAGE_TYPE
+  type: number
+  value: '12'
+  comment: Rez parameter specifying the integer damage type applied on collision (supports
+    DAMAGE_TYPE_* constants, custom types, or a repurposed damage field).
+- name: REZ_FLAGS
+  type: number
+  value: '1'
+  comment: Rez parameter specifying the integer bitfield of flags to apply to the
+    newly created object.
+- name: REZ_FLAG_BLOCK_GRAB_OBJECT
+  type: number
+  value: '0x0080'
+  comment: Rez flag that disables grabbing on the newly rezzed object.
+- name: REZ_FLAG_DIE_ON_COLLIDE
+  type: number
+  value: '0x0008'
+  comment: Rez flag causing the object to die/delete after its first collision.
+- name: REZ_FLAG_DIE_ON_NOENTRY
+  type: number
+  value: '0x0010'
+  comment: Rez flag causing the object to die/delete if it attempts to enter an unauthorized
+    parcel.
+- name: REZ_FLAG_NO_COLLIDE_FAMILY
+  type: number
+  value: '0x0040'
+  comment: Rez flag preventing collision events from triggering when colliding with
+    other objects created by the same rezzer.
+- name: REZ_FLAG_NO_COLLIDE_OWNER
+  type: number
+  value: '0x0020'
+  comment: Rez flag preventing collision events from triggering when colliding with
+    its owner.
+- name: REZ_FLAG_PHANTOM
+  type: number
+  value: '0x0004'
+  comment: Rez flag causing the object to be created as phantom.
+- name: REZ_FLAG_PHYSICAL
+  type: number
+  value: '0x0002'
+  comment: Rez flag causing the object to be created with physics enabled.
+- name: REZ_FLAG_TEMP
+  type: number
+  value: '0x0001'
+  comment: Rez flag causing the object to be created as temporary.
+- name: REZ_LOCK_AXES
+  type: number
+  value: '11'
+  comment: Rez parameter [vector locks] used to prevent the physical object from rotating
+    or spinning around specified axes. Setting a coordinate to a non-zero value locks
+    that axis.
+- name: REZ_OMEGA
+  type: number
+  value: '7'
+  comment: Rez parameter specifying the initial angular velocity (omega) applied to
+    the object. Accepts [vector axis, integer relative, float spin, float gain]. If
+    relative is TRUE, the axis vector is in local coordinates.
+- name: REZ_PARAM
+  type: number
+  value: '0'
+  comment: Rez parameter specifying the integer start parameter passed into the newly
+    rezzed object's on_rez event.
+- name: REZ_PARAM_STRING
+  type: number
+  value: '13'
+  comment: Rez parameter specifying an initialization string (up to 1024 bytes) passed
+    to the root prim of the newly rezzed object, readable via llGetStartString.
+- name: REZ_POS
+  type: number
+  value: '2'
+  comment: Rez parameter [vector position, integer relative, integer at_root] to specify
+    where to rez the object. Can be in region coordinates or relative to the rezzing
+    object, and centered on either the object's center or the root prim.
+- name: REZ_ROT
+  type: number
+  value: '3'
+  comment: Rez parameter specifying the initial rotation to apply to the newly rezzed
+    object. Can be relative to the rezzing object or absolute.
+- name: REZ_SOUND
+  type: number
+  value: '9'
+  comment: Rez parameter [string name_or_uuid, float volume, integer loop] to attach
+    and play a sound from inventory or a UUID asset key. If loop is TRUE, it loops
+    continuously.
+- name: REZ_SOUND_COLLIDE
+  type: number
+  value: '10'
+  comment: Rez parameter [string name_or_uuid, float volume] specifying a sound (from
+    inventory or a UUID asset key) to play upon collision with another object, the
+    ground, or an avatar.
+- name: REZ_TORQUE
+  type: number
+  value: '6'
+- name: REZ_VEL
+  type: number
+  value: '4'
+  comment: Rez parameter specifying the initial velocity to apply to the object. Accepts
+    [vector velocity, integer local, integer inherit]. If inherit is TRUE, it adds
+    the rezzing object's velocity.
+- name: ROTATE
+  type: number
+  value: '0x20'
+  comment: Used with texture animation functions to animate the texture's rotation.
+    Cannot be combined with SCALE.
+- name: SCALE
+  type: number
+  value: '0x40'
+  comment: Used with texture animation functions to animate the texture's scale. Cannot
+    be combined with ROTATE.
+- name: SCRIPTED
+  type: number
+  value: '0x8'
+  comment: Identifies scripted in-world objects. In llDetectedType(), indicates the
+    target has at least one active script. In llSensor()/llSensorRepeat() filters,
+    searches for objects containing active scripts that are currently running.
+- name: SIM_STAT_ACTIVE_SCRIPT_COUNT
+  type: number
+  value: '12'
+  comment: Returns the total number of active scripts in the region.
+- name: SIM_STAT_AGENT_COUNT
+  type: number
+  value: '10'
+  comment: Returns the total number of agents in the region.
+- name: SIM_STAT_AGENT_MS
+  type: number
+  value: '7'
+  comment: Returns the time spent in the 'agent' segment of the simulation frame.
+- name: SIM_STAT_AGENT_UPDATES
+  type: number
+  value: '2'
+  comment: Returns the number of agent updates per second.
+- name: SIM_STAT_AI_MS
+  type: number
+  value: '26'
+  comment: Returns the time spent on the AI step.
+- name: SIM_STAT_ASSET_DOWNLOADS
+  type: number
+  value: '15'
+  comment: Returns the pending asset download count.
+- name: SIM_STAT_ASSET_UPLOADS
+  type: number
+  value: '16'
+  comment: Returns the pending asset upload count.
+- name: SIM_STAT_CHILD_AGENT_COUNT
+  type: number
+  value: '11'
+  comment: Returns the number of child (neighboring) agents in the region.
+- name: SIM_STAT_FRAME_MS
+  type: number
+  value: '3'
+  comment: Returns the total frame time.
+- name: SIM_STAT_IMAGE_MS
+  type: number
+  value: '8'
+  comment: Returns the time spent in the 'image' segment of the simulation frame.
+- name: SIM_STAT_IO_PUMP_MS
+  type: number
+  value: '24'
+  comment: Returns the pump IO time.
+- name: SIM_STAT_NET_MS
+  type: number
+  value: '4'
+  comment: Returns the time spent in the 'network' segment of the simulation frame.
+- name: SIM_STAT_OTHER_MS
+  type: number
+  value: '5'
+  comment: Returns the time spent in the main simulation 'other' segment of the frame,
+    which encapsulates task, script, and miscellaneous updates.
+- name: SIM_STAT_PACKETS_IN
+  type: number
+  value: '13'
+  comment: Returns the average number of incoming packets per second.
+- name: SIM_STAT_PACKETS_OUT
+  type: number
+  value: '14'
+  comment: Returns the average number of outgoing packets per second.
+- name: SIM_STAT_PCT_CHARS_STEPPED
+  type: number
+  value: '0'
+  comment: Returns the percentage of pathfinding characters updated (or skipped) each
+    frame, averaged over the last minute. Corresponds to the 'Characters Updated'
+    stat in the viewer's Statistics Bar.
+- name: SIM_STAT_PHYSICS_FPS
+  type: number
+  value: '1'
+  comment: Returns the physics simulation frames per second (FPS).
+- name: SIM_STAT_PHYSICS_MS
+  type: number
+  value: '6'
+  comment: Returns the time spent in the 'physics' segment of the simulation frame.
+- name: SIM_STAT_PHYSICS_OTHER_MS
+  type: number
+  value: '20'
+  comment: Returns the average update time for the physics 'other' segment.
+- name: SIM_STAT_PHYSICS_SHAPE_MS
+  type: number
+  value: '19'
+  comment: Returns the average update time for the physics 'shape' segment.
+- name: SIM_STAT_PHYSICS_STEP_MS
+  type: number
+  value: '18'
+  comment: Returns the average physics step time.
+- name: SIM_STAT_SCRIPT_EPS
+  type: number
+  value: '21'
+  comment: Returns the number of script events per second.
+- name: SIM_STAT_SCRIPT_MS
+  type: number
+  value: '9'
+  comment: Returns the time spent in the 'script' segment of the simulation frame.
+- name: SIM_STAT_SCRIPT_RUN_PCT
+  type: number
+  value: '25'
+  comment: Returns the percentage of scripts run during the frame.
+- name: SIM_STAT_SLEEP_MS
+  type: number
+  value: '23'
+  comment: Returns the time spent sleeping.
+- name: SIM_STAT_SPARE_MS
+  type: number
+  value: '22'
+  comment: Returns the spare time left after the frame.
+- name: SIM_STAT_UNACKED_BYTES
+  type: number
+  value: '17'
+  comment: Returns the total number of unacknowledged bytes.
+- name: SIT_FLAG_ALLOW_UNSIT
+  type: number
+  value: '0x0002'
+  comment: Sit flag indicating that a seated avatar is allowed to manually stand up
+    (unsit) from a sit target. Applies only to agents who were seated via an LSL script
+    like llSitOnLink.
+- name: SIT_FLAG_NO_COLLIDE
+  type: number
+  value: '0x0010'
+  comment: Sit flag that disables the avatar's collision volume/hitbox while seated
+    on this sit target.
+- name: SIT_FLAG_NO_DAMAGE
+  type: number
+  value: '0x0020'
+  comment: Sit flag that prevents damage from being distributed or forwarded to agents
+    sitting on this sit target.
+- name: SIT_FLAG_SCRIPTED_ONLY
+  type: number
+  value: '0x0004'
+  comment: Sit flag that restricts sits to script-controlled actions only, preventing
+    avatars from manually sitting on this prim.
+- name: SIT_FLAG_SIT_TARGET
+  type: number
+  value: '0x0001'
+  comment: Read-only sit flag indicating whether the prim has an active sit target.
+    Set or cleared using llSitTarget, llLinkSitTarget, or PRIM_SIT_TARGET, and read
+    via llGetLinkSitFlags or PRIM_SIT_FLAGS.
+- name: SIT_INVALID_AGENT
+  type: number
+  value: '-4'
+  comment: Sit error code indicating that the specified agent/avatar ID could not
+    be found or is invalid.
+- name: SIT_INVALID_LINK
+  type: number
+  value: '-5'
+  comment: Sit error code indicating that the link ID does not specify a valid prim,
+    is not found, or resolves to multiple prims.
+- name: SIT_INVALID_OBJECT
+  type: number
+  value: '-7'
+  comment: Sit error code returned when attempting to force an avatar to sit on an
+    invalid target (such as an attachment) that cannot be sat upon.
+- name: SIT_NOT_EXPERIENCE
+  type: number
+  value: '-1'
+  comment: Sit error code returned if the script is not running within a valid experience,
+    lacks a valid experience key, or the experience is not permitted at the current
+    location.
+- name: SIT_NO_ACCESS
+  type: number
+  value: '-6'
+  comment: Sit error code indicating that the avatar lacks access to the parcel where
+    the target prim/linkset is located.
+- name: SIT_NO_EXPERIENCE_PERMISSION
+  type: number
+  value: '-2'
+  comment: Sit error code indicating that the agent has not granted experience permissions
+    to force sits.
+- name: SIT_NO_SIT_TARGET
+  type: number
+  value: '-3'
+  comment: Sit error code indicating that no open or available sit target could be
+    found in the linkset.
+- name: SIT_OK
+  type: number
+  value: '1'
+  comment: Sit error code indicating that the agent was seated successfully.
+- name: SKY_ABSORPTION_CONFIG
+  type: number
+  value: '16'
+- name: SKY_AMBIENT
+  type: number
+  value: '0'
+  comment: Environmental setting for the ambient color used in the scene.
+- name: SKY_BLUE
+  type: number
+  value: '22'
+  comment: Environmental setting containing the colors used to calculate blue density
+    and blue horizon in the sky.
+- name: SKY_CLOUDS
+  type: number
+  value: '2'
+  comment: Environmental cloud parameters including color, coverage percentage, scale,
+    variance, scroll speed (X/Y), density, detail exponents, and default texture status.
+- name: SKY_CLOUD_TEXTURE
+  type: number
+  value: '19'
+  comment: Environmental setting containing the inventory name or UUID of the texture
+    used for the clouds.
+- name: SKY_DENSITY_PROFILE_COUNTS
+  type: number
+  value: '3'
+  comment: Environmental setting representing counts for each density profile type.
+- name: SKY_DOME
+  type: number
+  value: '4'
+  comment: 'Environmental setting containing sky dome parameters: offset, radius,
+    and maximum altitude.'
+- name: SKY_GAMMA
+  type: number
+  value: '5'
+  comment: Environmental setting for the gamma value applied to the scene (repurposed
+    in viewer 7.0+ as the HDR Scale value in the EEP editor).
+- name: SKY_GLOW
+  type: number
+  value: '6'
+  comment: 'Environmental setting for sun and moon glow parameters: size and focus.'
+- name: SKY_HAZE
+  type: number
+  value: '23'
+  comment: Environmental setting containing the values used to calculate the light
+    scattering impact of blue density and blue horizon on the scene.
+- name: SKY_LIGHT
+  type: number
+  value: '8'
+  comment: 'Environmental setting containing lighting parameters: dominant light direction
+    (unit vector), current light color (fade_color in sRGB), and total ambient color
+    (sRGB).'
+- name: SKY_MIE_CONFIG
+  type: number
+  value: '17'
+  comment: Environmental setting for Mie scattering profile parameters.
+- name: SKY_MOON
+  type: number
+  value: '9'
+  comment: 'Environmental moon parameters: rotation, scale, brightness, is_default_texture,
+    direction vector, ambient color, and diffuse color.'
+- name: SKY_MOON_TEXTURE
+  type: number
+  value: '20'
+  comment: Environmental setting containing the inventory name or UUID of the texture
+    used for the moon.
+- name: SKY_PLANET
+  type: number
+  value: '10'
+  comment: 'Environmental planet rendering parameters: planet_radius, sky_bottom_radius,
+    and sky_top_radius.'
+- name: SKY_RAYLEIGH_CONFIG
+  type: number
+  value: '18'
+  comment: Environmental setting for Rayleigh scattering profile parameters.
+- name: SKY_REFLECTION_PROBE_AMBIANCE
+  type: number
+  value: '24'
+  comment: 'Environmental setting for the minimum ambiance value of all reflection
+    probes. Note: Supported in the GLTF Materials project, requiring compatible viewers
+    and testing areas.'
+- name: SKY_REFRACTION
+  type: number
+  value: '11'
+  comment: 'Environmental sky refraction parameters for rainbows and optical effects:
+    moisture_level, droplet_radius, and ice_level.'
+- name: SKY_STAR_BRIGHTNESS
+  type: number
+  value: '13'
+  comment: Environmental setting for the brightness value applied to stars.
+- name: SKY_SUN
+  type: number
+  value: '14'
+  comment: 'Environmental sun parameters: rotation, scale, color, is_default_texture,
+    direction vector, ambient color, and diffuse color.'
+- name: SKY_SUN_TEXTURE
+  type: number
+  value: '21'
+  comment: Environmental setting containing the inventory name or UUID of the texture
+    used for the sun.
+- name: SKY_TEXTURE_DEFAULTS
+  type: number
+  value: '1'
+  comment: Environmental check returning 1 if the sky textures are set to their default
+    values, or 0 if they use custom textures.
+- name: SKY_TRACKS
+  type: number
+  value: '15'
+  comment: Environmental setting containing the track altitudes used for sky transitions
+    in the region.
+- name: SMOOTH
+  type: number
+  value: '0x10'
+  comment: Used with texture animation functions to cause the animation to slide smoothly
+    in the X direction (or transition smoothly in SCALE/ROTATE modes) instead of making
+    instant frame changes.
+- name: SOUND_LOOP
+  type: number
+  value: '0x01'
+  comment: Sound playback option that loops the sound continuously on the prim until
+    stopped.
+- name: SOUND_PLAY
+  type: number
+  value: '0x00'
+  comment: Sound playback option (default) that plays the sound once, attached to
+    the prim.
+- name: SOUND_SYNC
+  type: number
+  value: '0x04'
+  comment: Sound playback option that synchronizes playback to the nearest active
+    sound master (see llLoopSoundMaster).
+- name: SOUND_TRIGGER
+  type: number
+  value: '0x02'
+  comment: Sound playback option that triggers a non-attached sound once at the prim's
+    current location (does not move with the prim). This flag overrides all other
+    sound playback options.
+- name: SQRT2
+  type: number
+  value: '1.41421356'
+  comment: Mathematical constant representing the square root of 2 (1.41421356).
+- name: STATUS_BLOCK_GRAB
+  type: number
+  value: '0x40'
+  comment: Status flag (default FALSE) that blocks click-and-drag grab movements on
+    unlinked prims or the root prim of a linkset. Useful for preventing physical objects
+    from being trivially disturbed.
+- name: STATUS_BLOCK_GRAB_OBJECT
+  type: number
+  value: '0x400'
+  comment: Status flag that blocks click-and-drag grab movements on all prims across
+    the entire linkset.
+- name: STATUS_BOUNDS_ERROR
+  type: number
+  value: '1002'
+  comment: Status code indicating that one or more arguments passed to the function
+    had a bounds error.
+- name: STATUS_CAST_SHADOWS
+  type: number
+  value: '0x200'
+  comment: Unused legacy status flag intended to configure an object's ability to
+    cast shadows.
+- name: STATUS_DIE_AT_EDGE
+  type: number
+  value: '0x80'
+  comment: Status flag (default TRUE) that causes the object to be deleted (and not
+    returned) if it goes off-world (useful for bullets or rockets). Overridden by
+    STATUS_RETURN_AT_EDGE.
+- name: STATUS_DIE_AT_NO_ENTRY
+  type: number
+  value: '0x800'
+  comment: Status flag (default FALSE) that causes the object to be deleted if it
+    attempts to enter an unauthorized or full parcel. No-copy objects ignore this
+    setting and remain in-world.
+- name: STATUS_INTERNAL_ERROR
+  type: number
+  value: '1999'
+  comment: Status code indicating an internal error occurred.
+- name: STATUS_MALFORMED_PARAMS
+  type: number
+  value: '1000'
+  comment: Status code indicating the function was called with malformed parameters.
+- name: STATUS_NOT_FOUND
+  type: number
+  value: '1003'
+  comment: Status code indicating that the specified object or item was not found.
+- name: STATUS_NOT_SUPPORTED
+  type: number
+  value: '1004'
+  comment: Status code indicating the requested feature is not supported.
+- name: STATUS_OK
+  type: number
+  value: '0'
+  comment: Status code indicating the function call completed successfully.
+- name: STATUS_PHANTOM
+  type: number
+  value: '0x10'
+  comment: Status flag (default FALSE) that makes the entire object phantom/non-colliding
+    when set to TRUE, allowing avatars and objects to pass through it. It is a good
+    idea to use this for most objects that move or rotate, but are non-physical. It
+    is also useful for simulating volumetric lighting.
+- name: STATUS_PHYSICS
+  type: number
+  value: '0x1'
+  comment: Status flag (default FALSE) that controls whether the object responds to
+    physical interactions, gravity, and forces.
+- name: STATUS_RETURN_AT_EDGE
+  type: number
+  value: '0x100'
+  comment: Status flag causing the object to be returned to its owner when it goes
+    off-world, overriding STATUS_DIE_AT_EDGE.
+- name: STATUS_ROTATE_X
+  type: number
+  value: '0x2'
+  comment: Status flag (default TRUE) that allows physical rotation on the object's
+    local X-axis. Setting to FALSE prevents physical rotation around the local X-axis.
+    For example, a sit-and-spin device spins around the Z axis (up) but not around
+    the X or Y axes.
+- name: STATUS_ROTATE_Y
+  type: number
+  value: '0x4'
+  comment: Status flag (default TRUE) that allows physical rotation on the object's
+    local Y-axis. Setting to FALSE prevents physical rotation around the local Y-axis.
+    For example, a sit-and-spin device spins around the Z axis (up) but not around
+    the X or Y axes.
+- name: STATUS_ROTATE_Z
+  type: number
+  value: '0x8'
+  comment: Status flag (default TRUE) that allows physical rotation on the object's
+    local Z-axis. Setting to FALSE prevents physical rotation around the local Z-axis.
+- name: STATUS_SANDBOX
+  type: number
+  value: '0x20'
+  comment: Status flag (default FALSE) that restricts the object's physical movement
+    to within its creation region and a short distance (10 to 20 meters) from its
+    creation point to prevent it from escaping.
+- name: STATUS_TYPE_MISMATCH
+  type: number
+  value: '1001'
+  comment: Status code indicating that one or more arguments passed to the function
+    had a type mismatch.
+- name: STATUS_WHITELIST_FAILED
+  type: number
+  value: '2001'
+  comment: Status code indicating a media domain whitelist check has failed.
+- name: STRING_TRIM
+  type: number
+  value: '0x03'
+  comment: Trims whitespace off both the beginning and the end of the string.
+- name: STRING_TRIM_HEAD
+  type: number
+  value: '0x01'
+  comment: Trims whitespace/spaces off the beginning of the string.
+- name: STRING_TRIM_TAIL
+  type: number
+  value: '0x02'
+  comment: Trims whitespace/spaces off the end of the string.
+- name: TARGETED_EMAIL_OBJECT_OWNER
+  type: number
+  value: '0x02'
+  comment: Flag used with llTargetedEmail to send the email message to the owner of
+    the calling object.
+- name: TARGETED_EMAIL_ROOT_CREATOR
+  type: number
+  value: '0x01'
+  comment: Flag used with llTargetedEmail to send the email message to the creator
+    of the root object.
+- name: TERRAIN_DETAIL_1
+  type: number
+  value: '0'
+  comment: Terrain parameter used with llSetGroundTexture to set the texture or material
+    (via UUID, inventory name, or default NULL_KEY/empty string) for terrain detail
+    layer 1.
+- name: TERRAIN_DETAIL_2
+  type: number
+  value: '1'
+  comment: Terrain parameter used with llSetGroundTexture to set the texture or material
+    (via UUID, inventory name, or default NULL_KEY/empty string) for terrain detail
+    layer 2.
+- name: TERRAIN_DETAIL_3
+  type: number
+  value: '2'
+  comment: Terrain parameter used with llSetGroundTexture to set the texture or material
+    (via UUID, inventory name, or default NULL_KEY/empty string) for terrain detail
+    layer 3.
+- name: TERRAIN_DETAIL_4
+  type: number
+  value: '3'
+  comment: Terrain parameter used with llSetGroundTexture to set the texture or material
+    (via UUID, inventory name, or default NULL_KEY/empty string) for terrain detail
+    layer 4.
+- name: TERRAIN_HEIGHT_RANGE_NE
+  type: number
+  value: '7'
+  comment: Terrain parameter used with llSetGroundTexture to set the north-east height
+    range for texture blending. Specifies low as the maximum height for texture 1,
+    high as the minimum height for texture 4, and lets textures 2 and 3 mix in between.
+- name: TERRAIN_HEIGHT_RANGE_NW
+  type: number
+  value: '6'
+  comment: Terrain parameter used with llSetGroundTexture to set the north-west height
+    range for texture blending. Specifies low as the maximum height for texture 1,
+    high as the minimum height for texture 4, and lets textures 2 and 3 mix in between.
+- name: TERRAIN_HEIGHT_RANGE_SE
+  type: number
+  value: '5'
+  comment: Terrain parameter used with llSetGroundTexture to set the south-east height
+    range for texture blending. Specifies low as the maximum height for texture 1,
+    high as the minimum height for texture 4, and lets textures 2 and 3 mix in between.
+- name: TERRAIN_HEIGHT_RANGE_SW
+  type: number
+  value: '4'
+  comment: Terrain parameter used with llSetGroundTexture to set the south-west height
+    range for texture blending. Specifies low as the maximum height for texture 1,
+    high as the minimum height for texture 4, and lets textures 2 and 3 mix in between.
+- name: TERRAIN_PBR_OFFSET_1
+  type: number
+  value: '16'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV offset vector
+    (ignoring the Z component) for drawing terrain layer 1. Only works for PBR textures.
+- name: TERRAIN_PBR_OFFSET_2
+  type: number
+  value: '17'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV offset vector
+    (ignoring the Z component) for drawing terrain layer 2. Only works for PBR textures.
+- name: TERRAIN_PBR_OFFSET_3
+  type: number
+  value: '18'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV offset vector
+    (ignoring the Z component) for drawing terrain layer 3. Only works for PBR textures.
+- name: TERRAIN_PBR_OFFSET_4
+  type: number
+  value: '19'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV offset vector
+    (ignoring the Z component) for drawing terrain layer 4. Only works for PBR textures.
+- name: TERRAIN_PBR_ROTATION_1
+  type: number
+  value: '12'
+  comment: Terrain parameter used with llSetGroundTexture to set the rotation of the
+    PBR texture for layer 1, in radians. Only works for PBR textures.
+- name: TERRAIN_PBR_ROTATION_2
+  type: number
+  value: '13'
+  comment: Terrain parameter used with llSetGroundTexture to set the rotation of the
+    PBR texture for layer 2, in radians. Only works for PBR textures.
+- name: TERRAIN_PBR_ROTATION_3
+  type: number
+  value: '14'
+  comment: Terrain parameter used with llSetGroundTexture to set the rotation of the
+    PBR texture for layer 3, in radians. Only works for PBR textures.
+- name: TERRAIN_PBR_ROTATION_4
+  type: number
+  value: '15'
+  comment: Terrain parameter used with llSetGroundTexture to set the rotation of the
+    PBR texture for layer 4, in radians. Only works for PBR textures.
+- name: TERRAIN_PBR_SCALE_1
+  type: number
+  value: '8'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV scale vector
+    (repeats per meter, ignoring the Z component) for terrain layer 1. Only works
+    for PBR textures.
+- name: TERRAIN_PBR_SCALE_2
+  type: number
+  value: '9'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV scale vector
+    (repeats per meter, ignoring the Z component) for terrain layer 2. Only works
+    for PBR textures.
+- name: TERRAIN_PBR_SCALE_3
+  type: number
+  value: '10'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV scale vector
+    (repeats per meter, ignoring the Z component) for terrain layer 3. Only works
+    for PBR textures.
+- name: TERRAIN_PBR_SCALE_4
+  type: number
+  value: '11'
+  comment: Terrain parameter used with llSetGroundTexture to set the UV scale vector
+    (repeats per meter, ignoring the Z component) for terrain layer 4. Only works
+    for PBR textures.
+- name: TEXTURE_BLANK
+  type: uuid
+  value: uuid("5748decc-f629-461c-9a36-a35a221fe21f")
+  comment: Asset UUID representing the default 'Blank' texture.
+- name: TEXTURE_DEFAULT
+  type: uuid
+  value: uuid("89556747-24cb-43ed-920b-47caed15465f")
+- name: TEXTURE_MEDIA
+  type: uuid
+  value: uuid("8b5fec65-8d8d-9dc5-cda8-8fdf2716e361")
+  comment: Asset UUID representing the default 'Default Media' texture.
+- name: TEXTURE_PLYWOOD
+  type: uuid
+  value: uuid("89556747-24cb-43ed-920b-47caed15465f")
+  comment: Asset UUID representing the default 'Plywood' texture.
+- name: TEXTURE_TRANSPARENT
+  type: uuid
+  value: uuid("8dcd4a48-2d37-4909-9f78-f7a9eb4ef903")
+  comment: Asset UUID representing the '*Default Transparent Texture' in the library
+    (included with viewers).
+- name: TOUCH_INVALID_FACE
+  type: number
+  value: '-1'
+  comment: Value returned by llDetectedTouchFace when the touch position is not valid.
+- name: TOUCH_INVALID_TEXCOORD
+  type: vector
+  value: vector(-1.0, -1.0, 0.0)
+  comment: Value returned by llDetectedTouchUV and llDetectedTouchST when the touch
+    position is not valid.
+- name: TOUCH_INVALID_VECTOR
+  type: vector
+  value: vector(0.0, 0.0, 0.0)
+  comment: Value returned by llDetectedTouchPos, llDetectedTouchNormal, and llDetectedTouchBinormal
+    when the touch position is not valid.
+- name: TP_ROUTING_BLOCKED
+  type: number
+  value: '0'
+  comment: Teleport routing setting indicating that direct teleporting is blocked
+    on the parcel.
+- name: TP_ROUTING_FREE
+  type: number
+  value: '2'
+  comment: Teleport routing setting indicating that teleports are unrestricted on
+    the parcel.
+- name: TP_ROUTING_LANDINGP
+  type: number
+  value: '1'
+  comment: Teleport routing setting indicating that teleports are routed to the parcel's
+    landing point (if one has been set).
+- name: TRANSFER_BAD_OPTS
+  type: number
+  value: '-1'
+  comment: Inventory transfer error code indicating that an invalid option was passed
+    in the options list.
+- name: TRANSFER_BAD_ROOT
+  type: number
+  value: '-5'
+  comment: Inventory transfer error code indicating that the root path specified in
+    TRANSFER_DEST was invalid or resolved to nothing.
+- name: TRANSFER_DEST
+  type: number
+  value: '0'
+  comment: Inventory option specifying the destination root folder to transfer inventory
+    into.
+- name: TRANSFER_FLAGS
+  type: number
+  value: '1'
+  comment: Inventory parameter specifying flags to control the behavior of inventory
+    transfers.
+- name: TRANSFER_FLAG_COPY
+  type: number
+  value: '0x0004'
+  comment: Inventory transfer flag that copies the transferred object and places it
+    in the recipient's inventory (implies TRANSFER_FLAG_TAKE).
+- name: TRANSFER_FLAG_RESERVED
+  type: number
+  value: '0x0001'
+  comment: Inventory transfer flag reserved for future expansion; do not use.
+- name: TRANSFER_FLAG_TAKE
+  type: number
+  value: '0x0002'
+  comment: Inventory transfer flag that automatically removes the object from the
+    world and places it in the recipient's inventory once accepted.
+- name: TRANSFER_NO_ATTACHMENT
+  type: number
+  value: '-7'
+  comment: Inventory transfer error code indicating ownership of an attached object
+    cannot be transferred.
+- name: TRANSFER_NO_ITEMS
+  type: number
+  value: '-4'
+  comment: Inventory transfer error code indicating that the list was empty or contained
+    only non-transferable items.
+- name: TRANSFER_NO_PERMS
+  type: number
+  value: '-6'
+  comment: Inventory transfer error code indicating the object lacks transfer permissions.
+- name: TRANSFER_NO_TARGET
+  type: number
+  value: '-2'
+  comment: Inventory transfer error code indicating the receiving agent could not
+    be found in the current region.
+- name: TRANSFER_OK
+  type: number
+  value: '0'
+  comment: Status code indicating that the inventory transfer was successful or the
+    transfer offer was successfully made.
+- name: TRANSFER_THROTTLE
+  type: number
+  value: '-3'
+  comment: Inventory transfer error code indicating that the transfer rate has exceeded
+    the inventory transfer throttle.
+- name: TRAVERSAL_TYPE
+  type: number
+  value: '7'
+  comment: Pathfinding parameter specifying the character's movement traversal type.
+    Expects TRAVERSAL_TYPE_SLOW (default), _FAST, or _NONE.
+- name: TRAVERSAL_TYPE_FAST
+  type: number
+  value: '1'
+- name: TRAVERSAL_TYPE_NONE
+  type: number
+  value: '2'
+- name: TRAVERSAL_TYPE_SLOW
+  type: number
+  value: '0'
+- name: TWO_PI
+  type: number
+  value: '6.28318530'
+  comment: Mathematical constant representing the number of radians in a full circle
+    (6.28318530, twice the value of PI).
+- name: TYPE_FLOAT
+  type: number
+  value: '2'
+  comment: Variable type constant indicating the list entry or value is a float.
+- name: TYPE_INTEGER
+  type: number
+  value: '1'
+  comment: Variable type constant indicating the list entry or value is an integer.
+- name: TYPE_INVALID
+  type: number
+  value: '0'
+  comment: Variable type constant indicating the list entry or value is invalid.
+- name: TYPE_KEY
+  type: number
+  value: '4'
+  comment: Variable type constant indicating the list entry or value is a key.
+- name: TYPE_ROTATION
+  type: number
+  value: '6'
+  comment: Variable type constant indicating the list entry or value is a rotation.
+- name: TYPE_STRING
+  type: number
+  value: '3'
+  comment: Variable type constant indicating the list entry or value is a string.
+- name: TYPE_VECTOR
+  type: number
+  value: '5'
+  comment: Variable type constant indicating the list entry or value is a vector.
+- name: URL_REQUEST_DENIED
+  type: string
+  value: '"URL_REQUEST_DENIED"'
+- name: URL_REQUEST_GRANTED
+  type: string
+  value: '"URL_REQUEST_GRANTED"'
+- name: VEHICLE_ANGULAR_DEFLECTION_EFFICIENCY
+  type: number
+  value: '32'
+  comment: Vehicle float parameter (range 0.0 to 1.0) acting as a scalar to modulate
+    the strength of angular deflection, reorienting the vehicle's preferred axis toward
+    its true velocity.
+- name: VEHICLE_ANGULAR_DEFLECTION_TIMESCALE
+  type: number
+  value: '33'
+  comment: Vehicle float parameter specifying the exponential timescale for the vehicle
+    to achieve full angular deflection, reorienting its preferred axis of motion to
+    match its true velocity.
+- name: VEHICLE_ANGULAR_FRICTION_TIMESCALE
+  type: number
+  value: '17'
+  comment: Vehicle vector parameter specifying the timescales (range [0.07, infinity)
+    seconds per axis) for the exponential decay of angular velocity about the vehicle's
+    preferred axes (at, left, up).
+- name: VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE
+  type: number
+  value: '35'
+  comment: Vehicle float parameter specifying the exponential timescale (in seconds)
+    for the angular motor's magnitude and effectiveness to decay toward zero.
+- name: VEHICLE_ANGULAR_MOTOR_DIRECTION
+  type: number
+  value: '19'
+  comment: Vehicle vector parameter specifying the direction and magnitude of the
+    angular velocity (in radians per second) that the vehicle's angular motor attempts
+    to achieve.
+- name: VEHICLE_ANGULAR_MOTOR_TIMESCALE
+  type: number
+  value: '34'
+  comment: Vehicle float parameter specifying the exponential timescale for the vehicle's
+    angular motor to achieve full power and velocity.
+- name: VEHICLE_BANKING_EFFICIENCY
+  type: number
+  value: '38'
+  comment: Vehicle float parameter (range -1.0 to 1.0) controlling banking efficiency,
+    where negative values lean out of turns and positive values lean into turns. This
+    parameter makes banking affect steering; use angular motors to bank. 0.0 means
+    no banking.
+- name: VEHICLE_BANKING_MIX
+  type: number
+  value: '39'
+  comment: Vehicle float parameter (range 0.0 (static) to 1.0) (dynamic) controlling
+    the mix between static banking (scales only with roll angle) and dynamic banking
+    (additionally scales with linear speed).
+- name: VEHICLE_BANKING_TIMESCALE
+  type: number
+  value: '40'
+  comment: Vehicle float parameter specifying the exponential timescale for the banking
+    behavior to take full effect. This is another way to scale the strength of the
+    banking effect, however it affects the term that is proportional to the difference
+    between what the banking behavior is trying to do, and what the vehicle is actually
+    doing.
+- name: VEHICLE_BUOYANCY
+  type: number
+  value: '27'
+  comment: Vehicle float parameter (range -1.0 to 1.0) defining buoyancy, where -1.0
+    represents double gravity and 1.0 represents full anti-gravity.
+- name: VEHICLE_FLAG_BLOCK_INTERFERENCE
+  type: number
+  value: '0x400'
+  comment: Vehicle flag that prevents attachments worn by passengers from pushing
+    the vehicle via llPushObject or other scripting functions.
+- name: VEHICLE_FLAG_CAMERA_DECOUPLED
+  type: number
+  value: '0x200'
+  comment: Vehicle flag used with mouselook steering/banking. When set, the passenger's
+    mouselook camera rotates independently of the vehicle's orientation.
+- name: VEHICLE_FLAG_HOVER_GLOBAL_HEIGHT
+  type: number
+  value: '0x10'
+  comment: Vehicle flag that forces the hover behavior to maintain a global height
+    rather than hovering relative to the ground or water.
+- name: VEHICLE_FLAG_HOVER_TERRAIN_ONLY
+  type: number
+  value: '0x8'
+  comment: Vehicle flag that forces the hover behavior to ignore water height and
+    hover exclusively relative to the terrain/land.
+- name: VEHICLE_FLAG_HOVER_UP_ONLY
+  type: number
+  value: '0x20'
+  comment: Vehicle flag preventing hover from pushing downward, allowing hovering
+    vehicles to jump or fly above their designated hover height.
+- name: VEHICLE_FLAG_HOVER_WATER_ONLY
+  type: number
+  value: '0x4'
+  comment: Vehicle flag that forces the hover behavior to ignore terrain height and
+    hover exclusively relative to water.
+- name: VEHICLE_FLAG_LIMIT_MOTOR_UP
+  type: number
+  value: '0x40'
+  comment: Vehicle flag that prevents ground vehicles from motoring upward into the
+    sky. When combined with banking, banking strength decays when the vehicle is airborne
+    (no longer colliding) to prevent steering mid-jump.
+- name: VEHICLE_FLAG_LIMIT_ROLL_ONLY
+  type: number
+  value: '0x2'
+  comment: Vehicle flag for vehicles with a vertical attractor that need to climb
+    or dive, allowing airplanes to use the banking feature.
+- name: VEHICLE_FLAG_MOUSELOOK_BANK
+  type: number
+  value: '0x100'
+  comment: Vehicle flag that enables mouselook control, remapping left-right camera
+    motions (yaw) to rotations about the vehicle's local X-axis.
+- name: VEHICLE_FLAG_MOUSELOOK_STEER
+  type: number
+  value: '0x80'
+  comment: Vehicle flag that enables steering via mouse, directing the angular motor
+    to align the vehicle's local X-axis with the direction of the client-side camera.
+- name: VEHICLE_FLAG_NO_DEFLECTION_UP
+  type: number
+  value: '0x1'
+  comment: Vehicle flag that prevents linear deflection parallel to the world Z-axis,
+    preventing ground vehicles (such as bumper cars) from climbing into the sky.
+- name: VEHICLE_FLAG_NO_FLY_UP
+  type: number
+  value: '0x1'
+  comment: Obsolete legacy name for VEHICLE_FLAG_NO_DEFLECTION_UP.
+- name: VEHICLE_HOVER_EFFICIENCY
+  type: number
+  value: '25'
+  comment: Vehicle float parameter (range 0.0 to 1.0) controlling hover damping, where
+    0.0 is bouncy and 1.0 is critically damped.
+- name: VEHICLE_HOVER_HEIGHT
+  type: number
+  value: '24'
+  comment: Vehicle float parameter specifying the height at which the vehicle attempts
+    to hover. Set to 0.0 to disable hover.
+- name: VEHICLE_HOVER_TIMESCALE
+  type: number
+  value: '26'
+  comment: Vehicle float parameter specifying the timescale (period of time in seconds)
+    for the vehicle to achieve its hover height.
+- name: VEHICLE_LINEAR_DEFLECTION_EFFICIENCY
+  type: number
+  value: '28'
+  comment: Vehicle float parameter (range 0.0 to 1.0) modulating the efficiency and
+    strength of linear deflection. That is, its a simple scalar for modulating the
+    strength of linear deflection.
+- name: VEHICLE_LINEAR_DEFLECTION_TIMESCALE
+  type: number
+  value: '29'
+  comment: Vehicle float parameter specifying the exponential timescale for the vehicle
+    to redirect its linear velocity along its preferred X-axis. It is another way
+    to specify how much time it takes for the vehicle's linear velocity to be redirected
+    to its preferred axis of motion.
+- name: VEHICLE_LINEAR_FRICTION_TIMESCALE
+  type: number
+  value: '16'
+  comment: Vehicle vector parameter specifying the timescales (range [0.07, infinity)
+    seconds per axis) for the exponential decay of linear velocity along the vehicle's
+    preferred axes (at, left, up).
+- name: VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE
+  type: number
+  value: '31'
+  comment: Vehicle float parameter specifying the exponential timescale (in seconds)
+    for the linear motor's magnitude and effectiveness to decay toward zero.
+- name: VEHICLE_LINEAR_MOTOR_DIRECTION
+  type: number
+  value: '18'
+  comment: Vehicle vector parameter specifying the direction and magnitude of the
+    linear velocity (range [0, 30] m/s) that the vehicle's linear motor attempts to
+    achieve.
+- name: VEHICLE_LINEAR_MOTOR_OFFSET
+  type: number
+  value: '20'
+  comment: Vehicle vector parameter specifying the offset from the vehicle's center
+    of mass where the linear motor force is applied.
+- name: VEHICLE_LINEAR_MOTOR_TIMESCALE
+  type: number
+  value: '30'
+  comment: Vehicle float parameter specifying the exponential timescale for the vehicle
+    to reach its full linear motor velocity.
+- name: VEHICLE_REFERENCE_FRAME
+  type: number
+  value: '44'
+  comment: Vehicle rotation parameter setting the orientation of the vehicle's preferred
+    axes of motion (at, left, up) relative to its local geometric frame (x, y, z).
+- name: VEHICLE_TYPE_AIRPLANE
+  type: number
+  value: '4'
+  comment: Vehicle type constant for aircraft that use linear deflection for lift,
+    banking to turn, and no hover.
+- name: VEHICLE_TYPE_BALLOON
+  type: number
+  value: '5'
+  comment: Vehicle type constant for balloons that use hover and friction but no deflection.
+- name: VEHICLE_TYPE_BOAT
+  type: number
+  value: '3'
+  comment: Vehicle type constant for boats that hover over water with high friction
+    and minor angular deflection.
+- name: VEHICLE_TYPE_CAR
+  type: number
+  value: '2'
+  comment: Vehicle type constant for land vehicles that bounce along the ground and
+    rely on external controls or timer events to drive their motors.
+- name: VEHICLE_TYPE_NONE
+  type: number
+  value: '0'
+  comment: Constant used to disable and turn off vehicle physics support on the object.
+- name: VEHICLE_TYPE_SLED
+  type: number
+  value: '1'
+  comment: Vehicle type constant for sliding vehicles that bump along the ground and
+    prefer to move along their local X-axis.
+- name: VEHICLE_VERTICAL_ATTRACTION_EFFICIENCY
+  type: number
+  value: '36'
+  comment: Vehicle float parameter (range 0.0 to 1.0) controlling vertical attraction
+    stability (0.0 is wobbly/bouncy, 1.0 is critically damped/firm) to keep the vehicle
+    upright.
+- name: VEHICLE_VERTICAL_ATTRACTION_TIMESCALE
+  type: number
+  value: '37'
+  comment: Vehicle float parameter specifying the exponential timescale (in seconds)
+    for the vehicle to rotate and align its local Z-axis (up) with the world Z-axis
+    (vertical).
+- name: VERTICAL
+  type: number
+  value: '0'
+  comment: Constant indicating that the collision capsule orientation for a pathfinding
+    character is vertical.
+- name: WANDER_PAUSE_AT_WAYPOINTS
+  type: number
+  value: '0'
+  comment: Option parameter for llWanderWithin specifying whether the character should
+    pause briefly after reaching each wander waypoint.
+- name: WATER_BLUR_MULTIPLIER
+  type: number
+  value: '100'
+  comment: Environmental setting specifying the multiplier applied to blur the scene
+    when underwater.
+- name: WATER_FOG
+  type: number
+  value: '101'
+  comment: 'Environmental underwater fog parameters: color, density exponent, and
+    modulation.'
+- name: WATER_FRESNEL
+  type: number
+  value: '102'
+  comment: 'Environmental water surface Fresnel scattering parameters: offset and
+    scale.'
+- name: WATER_NORMAL_SCALE
+  type: number
+  value: '104'
+  comment: Environmental setting specifying the scaling vector applied to the water
+    normal map.
+- name: WATER_NORMAL_TEXTURE
+  type: number
+  value: '107'
+  comment: Environmental setting containing the inventory name or UUID of the normal
+    map texture used for water waves.
+- name: WATER_REFRACTION
+  type: number
+  value: '105'
+  comment: 'Environmental water surface refraction scale factors: scale_above and
+    scale_below.'
+- name: WATER_TEXTURE_DEFAULTS
+  type: number
+  value: '103'
+  comment: Environmental check returning 1 if default water wave maps are used, or
+    0 if a custom texture is set.
+- name: WATER_WAVE_DIRECTION
+  type: number
+  value: '106'
+  comment: Environmental wave direction vectors (X is east/west, Y is north/south)
+    specifying speeds and directions for both large and small waves.
+- name: XP_ERROR_EXPERIENCES_DISABLED
+  type: number
+  value: '2'
+  comment: Region currently has experiences disabled.
+- name: XP_ERROR_EXPERIENCE_DISABLED
+  type: number
+  value: '8'
+  comment: Experience owner has temporarily disabled the experience.
+- name: XP_ERROR_EXPERIENCE_SUSPENDED
+  type: number
+  value: '9'
+  comment: Experience has been suspended by Linden Lab customer support.
+- name: XP_ERROR_INVALID_EXPERIENCE
+  type: number
+  value: '7'
+  comment: Script is associated with an experience that no longer exists.
+- name: XP_ERROR_INVALID_PARAMETERS
+  type: number
+  value: '3'
+  comment: One of the string arguments was too big to fit in the key-value store.
+- name: XP_ERROR_KEY_NOT_FOUND
+  type: number
+  value: '14'
+  comment: Requested key does not exist.
+- name: XP_ERROR_MATURITY_EXCEEDED
+  type: number
+  value: '16'
+  comment: Content rating of the experience exceeds that of the region.
+- name: XP_ERROR_NONE
+  type: number
+  value: '0'
+  comment: No error was detected.
+- name: XP_ERROR_NOT_FOUND
+  type: number
+  value: '6'
+  comment: Sim was unable to verify the validity of the experience. Retrying after
+    a short wait is advised.
+- name: XP_ERROR_NOT_PERMITTED
+  type: number
+  value: '4'
+  comment: This experience is not allowed to run by the requested agent, or experience
+    permissions were denied by the user.
+- name: XP_ERROR_NOT_PERMITTED_LAND
+  type: number
+  value: '17'
+  comment: Experience is blocked or not enabled for this land, or is not allowed to
+    run in the current region.
+- name: XP_ERROR_NO_EXPERIENCE
+  type: number
+  value: '5'
+  comment: This script is not associated with an experience.
+- name: XP_ERROR_QUOTA_EXCEEDED
+  type: number
+  value: '11'
+  comment: An attempt to write data to the key-value store failed due to the data
+    quota being met.
+- name: XP_ERROR_REQUEST_PERM_TIMEOUT
+  type: number
+  value: '18'
+  comment: Request for experience permissions was ignored and the request timed out
+    without modification.
+- name: XP_ERROR_RETRY_UPDATE
+  type: number
+  value: '15'
+  comment: A checked update failed due to an out of date request.
+- name: XP_ERROR_STORAGE_EXCEPTION
+  type: number
+  value: '13'
+  comment: Unable to communicate with the key-value store, or attempted to create
+    a key that already exists.
+- name: XP_ERROR_STORE_DISABLED
+  type: number
+  value: '12'
+  comment: Key-value store is currently disabled on this region.
+- name: XP_ERROR_THROTTLED
+  type: number
+  value: '1'
+  comment: Call failed due to too many recent calls.
+- name: XP_ERROR_UNKNOWN_ERROR
+  type: number
+  value: '10'
+  comment: An unknown error occurred that is not covered by any of the other predetermined
+    error states.
+- name: ZERO_ROTATION
+  type: quaternion
+  value: rotation(0.0, 0.0, 0.0, 1.0)
+  comment: A rotation constant representing an identity rotation (causes no change).
+    This is the default value for rotation variables.
+- name: ZERO_VECTOR
+  type: vector
+  value: vector(0.0, 0.0, 0.0)
+  comment: A vector constant representing <0.0, 0.0, 0.0>. This is the default value
+    for vector variables.
+controls:
+  do:
+    tooltip: 'Lua do block: do ... end'
+  if:
+    tooltip: 'Lua if statement: if condition then ... end'
+  then:
+    tooltip: 'Lua then keyword: introduces the block executed when an if condition
+      is true.'
+  else:
+    tooltip: 'Lua else keyword: specifies the alternative block in an if/else statement.'
+  elseif:
+    tooltip: 'Lua elseif keyword: provides an additional conditional branch in an
+      if statement.'
+  end:
+    tooltip: 'Lua end keyword: closes control structures like if, do, while, for,
+      and function.'
+  for:
+    tooltip: 'Lua for loop: for var = start, end, step do ... end'
+  return:
+    tooltip: 'Lua return statement: returns a value from a function.'
+  while:
+    tooltip: 'Lua while loop: while condition do ... end'
+  repeat:
+    tooltip: 'Lua repeat loop: repeat ... until condition'
+  until:
+    tooltip: 'Lua until keyword: ends a repeat loop by testing a condition.'
+  function:
+    tooltip: 'Lua function keyword: begins a function definition.'
+  break:
+    tooltip: 'Lua break statement: exits the nearest loop.'
+  continue:
+    tooltip: 'Luau continue statement: skip to the next loop iteration.'
+  local:
+    tooltip: 'Lua local keyword: declares a local variable or function.'
+  export:
+    tooltip: 'Luau export keyword: declares a type that can be used in outside this
+      module.'
+  in:
+    tooltip: 'Lua in keyword: used in generic for loops to iterate over elements.'
+  not:
+    tooltip: 'Lua not operator: performs logical negation.'
+  and:
+    tooltip: 'Lua and operator: performs logical conjunction.'
+  or:
+    tooltip: 'Lua or operator: performs logical disjunction.'
+builtin-types:
+  any:
+    tooltip: The unspecified type. Disables type-checking. Use unknown instead to
+      use type-checking.
+  boolean:
+    tooltip: 'Boolean: represents a true or false value.'
+  buffer:
+    tooltip: Read-write binary data.
+  never:
+    tooltip: The empty type that contains no values.
+  number:
+    tooltip: "Double\u2011precision floating point number."
+  string:
+    tooltip: Read-only binary data. Usually UTF-8-encoded text.
+  thread:
+    tooltip: Represents a coroutine.
+  unknown:
+    tooltip: The union of every type. Similar to any without disabling type-checking.
+metamethods:
+- name: __add
+  comment: Defines behavior for the addition (+) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand of the addition.
+  - name: right
+    type: any
+    comment: The right operand of the addition.
+  return-type: any
+- name: __call
+  comment: Called when the table or object is called as if it were a function.
+  type-parameters:
+  - A...
+  - R...
+  type: '<A..., R...>(self: {}, A...) -> R...'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The table being invoked.
+  - name: '...'
+    type: A...
+    comment: The arguments passed to the call.
+  return-type: R...
+- name: __concat
+  comment: Defines behavior for the concatenation (..) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand or object to concatenate.
+  - name: right
+    type: any
+    comment: The right operand or object to concatenate.
+  return-type: any
+- name: __div
+  comment: Defines behavior for the division (/) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand of the division (dividend).
+  - name: right
+    type: any
+    comment: The right operand of the division (divisor).
+  return-type: any
+- name: __eq
+  comment: Defines behavior for the equality (==) operator.
+  type: '(left: {}, right: {}) -> boolean'
+  parameters:
+  - name: left
+    type: '{}'
+    comment: The first value to compare.
+  - name: right
+    type: '{}'
+    comment: The second value to compare.
+  return-type: boolean
+- name: __idiv
+  comment: Defines behavior for the floor division (//) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand of the floor division.
+  - name: right
+    type: any
+    comment: The right operand of the floor division.
+  return-type: any
+- name: __index
+  comment: Called when looking up a key that does not exist in the table.
+  type: '((self: {}, key: any) -> any) | { [any]: any }'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The table being accessed.
+  - name: key
+    type: any
+    comment: The key that was not found in the table.
+  return-type: any
+  variants:
+  - comment: Called as a function fallback when looking up a key that does not exist
+      in the table.
+    type: '(self: {}, key: any) -> any'
+    parameters:
+    - name: self
+      type: '{}'
+      comment: The table being accessed.
+    - name: key
+      type: any
+      comment: The key that was not found in the table.
+    return-type: any
+  - comment: A fallback dictionary/table used to search for missing keys.
+    type: '{ [any]: any }'
+    return-type: any
+- name: __iter
+  comment: Called before generalized iteration begins on a table or userdata. Returns
+    an iterator generator function, a state object, and an initial control variable.
+  type-parameters:
+  - S
+  - K
+  - V...
+  type: '<S, K, V...>(self: {}) -> ((state: S, index: K) -> (K?, V...), S, K)'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The table or object being iterated.
+  return-type: '((state: S, index: K) -> (K?, V...), S, K)'
+- name: __jsonhint
+  comment: String property used by lljson.encode to enforce table formatting rules.
+  type: '"array" | "object"'
+- name: __le
+  comment: Defines behavior for the less-than-or-equal-to (<=) operator.
+  type: '(left: {}, right: {}) -> boolean'
+  parameters:
+  - name: left
+    type: '{}'
+    comment: The left operand of the comparison.
+  - name: right
+    type: '{}'
+    comment: The right operand of the comparison.
+  return-type: boolean
+- name: __len
+  comment: Defines behavior for the length (#) operator.
+  type: '(self: {}) -> number'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The object whose length is being measured.
+  return-type: number
+- name: __lt
+  comment: Defines behavior for the less-than (<) operator.
+  type: '(left: {}, right: {}) -> boolean'
+  parameters:
+  - name: left
+    type: '{}'
+    comment: The left operand of the comparison.
+  - name: right
+    type: '{}'
+    comment: The right operand of the comparison.
+  return-type: boolean
+- name: __metatable
+  comment: Protects the metatable. If present, getmetatable returns this value, and
+    setmetatable will raise an error.
+  type: any
+- name: __mod
+  comment: Defines behavior for the modulo (%) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand (dividend).
+  - name: right
+    type: any
+    comment: The right operand (divisor).
+  return-type: any
+- name: __mode
+  comment: Controls weak mapping of table elements. Valid values are 'k' (weak keys),
+    'v' (weak values), or 'kv' (both).
+  type: '"k" | "v" | "kv"'
+- name: __mul
+  comment: Defines behavior for the multiplication (*) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand of the multiplication.
+  - name: right
+    type: any
+    comment: The right operand of the multiplication.
+  return-type: any
+- name: __newindex
+  comment: Called when assigning a value to a key that does not exist in the table.
+  type: '((self: {}, key: any, value: any) -> ()) | { [any]: any }'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The table being assigned.
+  - name: key
+    type: any
+    comment: The key being created.
+  - name: value
+    type: any
+    comment: The value being assigned to the key.
+  return-type: ()
+  variants:
+  - comment: Called as a function fallback when assigning a value to a key that does
+      not exist in the table.
+    type: '(self: {}, key: any, value: any) -> ()'
+    parameters:
+    - name: self
+      type: '{}'
+      comment: The table being assigned.
+    - name: key
+      type: any
+      comment: The key being created.
+    - name: value
+      type: any
+      comment: The value being assigned to the key.
+    return-type: ()
+  - comment: A fallback dictionary/table where new key-value assignments are forwarded.
+    type: '{ [any]: any }'
+    return-type: ()
+- name: __pow
+  comment: Defines behavior for the exponentiation (^) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The base value.
+  - name: right
+    type: any
+    comment: The exponent value.
+  return-type: any
+- name: __sub
+  comment: Defines behavior for the subtraction (-) operator.
+  type: '(left: any, right: any) -> any'
+  parameters:
+  - name: left
+    type: any
+    comment: The left operand of the subtraction (minuend).
+  - name: right
+    type: any
+    comment: The right operand of the subtraction (subtrahend).
+  return-type: any
+- name: __tojson
+  comment: Called during JSON serialization (with lljson.encode or lljson.slencode).
+    Returns an alternative representation of the table to be serialized in its place.
+  type: '(self: {}, ctx: { mode: "json" | "sljson", tight: boolean }) -> any'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The table being serialized.
+  - name: ctx
+    type: '{ mode: "json" | "sljson", tight: boolean }'
+    comment: Context table containing metadata about the current serialization process,
+      including 'mode' ('json' or 'sljson') and 'tight' (boolean).
+  return-type: any
+- name: __tostring
+  comment: Called by tostring to convert the value to a string.
+  type: '(self: {}) -> string'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The object being converted to a string.
+  return-type: string
+- name: __unm
+  comment: Defines behavior for the unary negation (-) operator.
+  type: '(self: {}) -> any'
+  parameters:
+  - name: self
+    type: '{}'
+    comment: The value being negated.
+  return-type: any
+builtin-constants:
+- name: nil
+  type: nil
+  value: nil
+  comment: 'Lua nil: represents the absence of a useful value.'
+- name: 'true'
+  type: boolean
+  value: 'true'
+  comment: 'Lua true: Boolean true value.'
+- name: 'false'
+  type: boolean
+  value: 'false'
+  comment: 'Lua false: Boolean false value.'

--- a/lsl_definitions/generators/slua.py
+++ b/lsl_definitions/generators/slua.py
@@ -256,3 +256,36 @@ def gen_selene_yml(definitions: LSLDefinitions, slua_definitions: SLuaDefinition
     noalias_dumper.ignore_aliases = lambda self, data: True
     yaml.dump(selene, file, sort_keys=False, Dumper=noalias_dumper)
     return file.getvalue()
+
+
+@register("slua_definitions")
+def gen_slua_definitions(definitions: LSLDefinitions, slua_definitions: SLuaDefinitions) -> str:
+    """Generate SLua definitions file"""
+    quaternion_module = slua_definitions.get_module("quaternion")
+    rotation_module = SLuaModule(
+        name="rotation",
+        comment=quaternion_module.comment,
+        callable=quaternion_module.callable,
+        constants=quaternion_module.constants,
+        functions=quaternion_module.functions,
+    )
+    slua_definitions.modules.append(rotation_module)
+
+    file = io.StringIO()
+    file.write(
+        """# Second Life SLua (Server Lua) standard library definitions
+#
+# increment only when the file format changes, not just the content
+"""
+    )
+
+    noalias_dumper = yaml.dumper.SafeDumper
+    noalias_dumper.ignore_aliases = lambda self, data: True
+    yaml.dump(
+        slua_definitions.to_definition_dict(),
+        file,
+        Dumper=noalias_dumper,
+        sort_keys=False,
+    )
+
+    return file.getvalue()

--- a/lsl_definitions/slua.py
+++ b/lsl_definitions/slua.py
@@ -11,7 +11,7 @@ import llsd
 import yaml
 
 from lsl_definitions.rulesets import BuilderMethod, BuilderSpec, expand_spp_builder
-from lsl_definitions.utils import Deprecated, remove_worthless
+from lsl_definitions.utils import Deprecated, remove_nones, remove_worthless
 
 if TYPE_CHECKING:
     from typing import Literal
@@ -42,6 +42,16 @@ class SLuaProperty:
 
     def to_luau_def(self) -> str:
         return f"{self.name}: {self.type}"
+
+    def to_definition_dict(self) -> dict:
+        result = {"name": self.name, "type": self.type}
+        if self.value is not None:
+            result["value"] = self.value
+        if self.comment:
+            result["comment"] = self.comment
+        if self.modifiable != "read-only":
+            result["modifiable"] = self.modifiable
+        return result
 
 
 @dataclasses.dataclass
@@ -75,6 +85,22 @@ class SLuaParameter:
                 return f"...: {self.type}"
         else:
             return f"{self.name}: {self.type}"
+
+    def to_definition_dict(self) -> dict:
+        result = {"name": self.name}
+        if self.type is not None:
+            result["type"] = self.type
+        if self.comment:
+            result["comment"] = self.comment
+        if self.optional is not None:
+            result["optional"] = self.optional
+        if self.observes is not None:
+            result["observes"] = self.observes
+        if self.selene_type is not None:
+            result["selene-type"] = self.selene_type
+        if self.default_value is not None:
+            result["default-value"] = self.default_value
+        return result
 
     @property
     def formatted_comment(self) -> str:
@@ -144,6 +170,31 @@ class SLuaFunctionBase(abc.ABC):
 @dataclasses.dataclass
 class SLuaFunctionOverload(SLuaFunctionBase):
     pass
+
+
+def _deprecated_to_definition(deprecated: Deprecated | None) -> bool | dict | None:
+    if deprecated is None:
+        return None
+    if deprecated.reason is None and deprecated.use is None and deprecated.selene_replace is None:
+        return True
+    return remove_nones(
+        reason=deprecated.reason,
+        use=deprecated.use,
+        **({"selene-replace": deprecated.selene_replace} if deprecated.selene_replace else {}),
+    )
+
+
+def _function_signature_to_definition(func: SLuaFunctionBase) -> dict:
+    result: dict = {}
+    if func.type_parameters:
+        result["type-parameters"] = func.type_parameters
+    if func.parameters:
+        result["parameters"] = [p.to_definition_dict() for p in func.parameters]
+    if func.return_type != "()":
+        result["return-type"] = func.return_type
+    if func.comment:
+        result["comment"] = func.comment
+    return result
 
 
 @dataclasses.dataclass
@@ -232,6 +283,29 @@ class SLuaFunction(SLuaFunctionBase):
         f.write(self.typechecker_flags.comment_string)
         f.write("\n")
 
+    def to_definition_dict(self) -> dict:
+        result = _function_signature_to_definition(self)
+        result["name"] = self.name
+        if self.overloads:
+            result["overloads"] = [_function_signature_to_definition(o) for o in self.overloads]
+        deprecated = _deprecated_to_definition(self.deprecated)
+        if deprecated is not None:
+            result["deprecated"] = deprecated
+        if self.local_only:
+            result["local-only"] = True
+        if self.slua_removed:
+            result["slua-removed"] = True
+        if self.must_use:
+            result["must-use"] = True
+        typechecker: dict = {}
+        if self.typechecker_flags.builtin:
+            typechecker["builtin"] = True
+        if self.typechecker_flags.magic:
+            typechecker["magic"] = True
+        if typechecker:
+            result["typechecker"] = typechecker
+        return result
+
 
 @dataclasses.dataclass
 class SLuaTypeAlias:
@@ -255,6 +329,18 @@ class SLuaTypeAlias:
     def to_luau_def(self) -> str:
         export_str = "export " if self.export else ""
         return f"{export_str}type {self.name} = {self.definition}"
+
+    def to_definition_dict(self) -> dict:
+        result = {
+            "name": self.name,
+            "definition": self.definition,
+            "selene-type": self.selene_type,
+        }
+        if self.comment:
+            result["comment"] = self.comment
+        if self.export:
+            result["export"] = True
+        return result
 
 
 @dataclasses.dataclass
@@ -306,6 +392,22 @@ class SLuaClassDeclaration:
             f"  setmetatable((nil :: any) :: {self.instance_type}, (nil :: any) :: {mt_name})\n"
         )
         f.write(")\n\n")
+
+    def to_definition_dict(self) -> dict:
+        result = {"name": self.name}
+        if self.comment:
+            result["comment"] = self.comment
+        if self.instance_type is not None:
+            result["instance-type"] = self.instance_type
+        if self.export:
+            result["export"] = True
+        if self.properties:
+            result["properties"] = [p.to_definition_dict() for p in self.properties]
+        if self.functions:
+            result["functions"] = [f.to_definition_dict() for f in self.functions]
+        if self.methods:
+            result["methods"] = [f.to_definition_dict() for f in self.methods]
+        return result
 
 
 @dataclasses.dataclass
@@ -359,6 +461,18 @@ declare {self.name}: """)
             func.write_luau_table_def(f, indent=1)
         f.write("}\n\n")
 
+    def to_definition_dict(self) -> dict:
+        result = {"name": self.name}
+        if self.comment:
+            result["comment"] = self.comment
+        if self.callable is not None:
+            result["callable"] = self.callable.to_definition_dict()
+        if self.constants:
+            result["constants"] = [c.to_definition_dict() for c in self.constants]
+        if self.functions:
+            result["functions"] = [f.to_definition_dict() for f in self.functions]
+        return result
+
 
 @dataclasses.dataclass
 class SLuaDefinitions:
@@ -393,6 +507,22 @@ class SLuaDefinitions:
             if m.name == name:
                 return m
         return None
+
+    def to_definition_dict(self) -> dict:
+        return {
+            "version": "1.0.0",
+            "base-classes": [c.to_definition_dict() for c in self.base_classes],
+            "type-aliases": [a.to_definition_dict() for a in self.type_aliases],
+            "classes": [c.to_definition_dict() for c in self.classes],
+            "global-variables": [v.to_definition_dict() for v in self.global_variables],
+            "functions": [f.to_definition_dict() for f in self.functions],
+            "modules": [m.to_definition_dict() for m in self.modules],
+            "constants": [c.to_definition_dict() for c in self.global_constants],
+            "controls": self.controls,
+            "builtin-types": self.builtin_types,
+            "metamethods": list(self.metamethods.values()),
+            "builtin-constants": [c.to_definition_dict() for c in self.builtin_constants],
+        }
 
     def get_class(self, name: str) -> SLuaClassDeclaration | None:
         for c in self.classes:


### PR DESCRIPTION
Add a version of `slua_definitions` to the generated output, that has all the content generated from lsl_defintitions included.

Partially resolves #162 Would still need LL implementation to have this file be served in the capabilities instead of the incomplete one.
