### PR TITLE
Luau 0.713 Magic `pcall`

### DIFF
--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -309,7 +309,7 @@ declare loadstring: nil
 declare function newproxy(mt: boolean?): any
 -- declare function next<K, V>(t: {[K]: V}, i: K?): (K?, V) -- builtin
 -- declare function pairs<K, V>(t: {[K]: V}): (({[K]: V}, K?) -> (K?, V), {[K]: V}, K) -- builtin
-declare function pcall<A..., R...>(f: (A...) -> R..., ...: A...): (boolean, R...)
+-- declare function pcall<A..., R...>(f: (A...) -> R..., ...: A...): (boolean, R...) -- magic type
 declare function print<T...>(...: T...): ()
 declare function rawequal<T1, T2>(a: T1, b: T2): boolean
 declare function rawget<K, V>(t: {[K]: V}, k: K): V?

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -503,6 +503,7 @@ functions:
     comment: Arguments to pass to the function.
     type: A...
   return-type: (boolean, R...)
+  typechecker: {magic: true}
 - name: print
   comment: Prints all arguments to standard output using Tab as a separator.
   type-parameters: [T...]


### PR DESCRIPTION
In Luau 0.713, `pcall` gained a magic type function. See the release notes for it's documentation:
- https://github.com/luau-lang/luau/pull/2308

This is marked ready to review 
Despite SLua not having merged Luau 0.713, this is marked ready for review because it's generated file changes are entirely backwards compatable with Luau 0.710