### PR TITLE
Adding info to constants

### DIFF
--- a/lsl_definitions.schema.json
+++ b/lsl_definitions.schema.json
@@ -444,6 +444,76 @@
                             "markdownDescription": "Override the auto-generated property alias for this constant when used as a table-ruleset key. Must be a valid Lua identifier (lowercase, underscores).",
                             "type": "string",
                             "pattern": "^[a-z][a-z0-9_]*$"
+                        },
+                        "range": {
+                            "markdownDescription": "An array with the start and end values.",
+                            "items": {
+                                "type": ["number", "string", "integer"]
+                            },
+                            "maxItems": 2,
+                            "minItems": 2,
+                            "type": "array"
+                        },
+                        "default": {
+                            "markdownDescription": "The default value.",
+                            "type": ["number", "string", "integer", "boolean"]
+                        },
+                        "enum": {
+                            "markdownDescription": "A category of constants valid for this value.",
+                            "type": "string"
+                        },
+                        "details": {
+                            "markdownDescription": "Additional information.",
+                            "type": "string"
+                        },
+                        "access": {
+                            "markdownDescription": "Access mode. 'arg' is always an argument. 'read' is used only when reading. 'write' is used only when writing.",
+                            "enum": ["arg", "read", "write", "read/write"],
+                            "type": "string"
+                        },
+                        "values": {
+                            "markdownDescription": "A list of values associated to the constant.",
+                            "type": "array",
+                            "items": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "properties": {
+                                    "name": {
+                                        "markdownDescription": "The name of this value.",
+                                        "type": "string"
+                                    },
+                                    "value-type": {
+                                        "markdownDescription": "For constants used as rule tags in list-based APIs: the type of the value that follows this constant in the list. Uses the same vocabulary as ruleset param types. 'string-csv' accepts a {string} array and serializes it as an escaped comma-separated string. 'string-map' accepts a {[string]: string} table and emits one tag/key/value triple per entry.",
+                                        "enum": ["integer", "float", "string", "vector", "rotation", "boolean", "asset", "key", "string-csv", "string-map", "string-multi"]
+                                    },
+                                    "range": {
+                                        "markdownDescription": "An array with the start and end values.",
+                                        "items": {
+                                            "type": ["number", "string", "integer"]
+                                        },
+                                        "maxItems": 2,
+                                        "minItems": 2,
+                                        "type": "array"
+                                    },
+                                    "default": {
+                                        "markdownDescription": "The default value.",
+                                        "type": ["number", "string", "integer", "boolean"]
+                                    },
+                                    "enum": {
+                                        "markdownDescription": "A category of constants valid for this value.",
+                                        "type": "string"
+                                    },
+                                    "details": {
+                                        "markdownDescription": "Additional information.",
+                                        "type": "string"
+                                    },
+                                    "access": {
+                                        "markdownDescription": "Access mode. 'arg' is always an argument. 'read' is used only when reading. 'write' is used only when writing.",
+                                        "enum": ["arg", "read", "write", "read/write"],
+                                        "type": "string"
+                                    }
+                                }
+                            }
                         }
                     },
                     "required": [

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -1022,84 +1022,152 @@ constants:
       avatar's viewer.
     type: integer
     value: 1
+    values:
+      - name: open_map
+        value-type: boolean
+      - name: focus_map
+        value-type: boolean
   CAMERA_ACTIVE:
     member-of: [CameraParam]
     tooltip: Option flag used with llSetCameraParams to turn scripted control of the
       camera on or off.
     type: integer
     value: 12
+    values:
+      - name: isActive
+        value-type: boolean
+        default: false
   CAMERA_BEHINDNESS_ANGLE:
     member-of: [CameraParam]
     tooltip: Sets the angle in degrees within which the camera is not constrained by
       changes in target rotation.
     type: integer
     value: 8
+    values:
+      - name: degrees
+        value-type: float
+        range: [0, 180]
+        default: 10
   CAMERA_BEHINDNESS_LAG:
     member-of: [CameraParam]
     tooltip: Sets how strongly the camera is forced to stay behind the target if
       outside of the behindness angle.
     type: integer
     value: 9
+    values:
+      - name: seconds
+        value-type: float
+        range: [0, 3]
+        default: 0
   CAMERA_DISTANCE:
     member-of: [CameraParam]
     tooltip: Sets how far away the camera wants to be from its target.
     type: integer
     value: 7
+    values:
+      - name: meters
+        value-type: float
+        range: [0.5, 50]
+        default: 3
   CAMERA_FOCUS:
     member-of: [CameraParam]
     tooltip: Sets camera focus (target position) in region coordinates.
     type: integer
     value: 17
+    values:
+      - name: position
+        value-type: vector
   CAMERA_FOCUS_LAG:
     member-of: [CameraParam]
     tooltip: Sets how much the camera lags as it aims toward the target.
     type: integer
     value: 6
+    values:
+      - name: seconds
+        value-type: float
+        range: [0, 3]
+        default: 0.1
   CAMERA_FOCUS_LOCKED:
     member-of: [CameraParam]
     tooltip: Option flag used with llSetCameraParams to lock the camera focus so it
       does not move.
     type: integer
     value: 22
+    values:
+      - name: isLocked
+        value-type: boolean
+        default: false
   CAMERA_FOCUS_OFFSET:
     member-of: [CameraParam]
     tooltip: Adjusts the camera focus position relative to the target.
     type: integer
     value: 1
+    values:
+      - name: meters
+        value-type: vector
+        range: ["<-10,-10,-10>", "<10,10,10>"]
+        default: <0,0,0>
   CAMERA_FOCUS_THRESHOLD:
     member-of: [CameraParam]
     tooltip: Sets the radius of a sphere around the camera's target position within
       which its focus is not affected by target motion.
     type: integer
     value: 11
+    values:
+      - name: meters
+        value-type: float
+        range: [0, 4]
+        default: 1
   CAMERA_PITCH:
     member-of: [CameraParam]
     tooltip: Adjusts the angular amount that the camera aims straight ahead versus
       straight down, maintaining the same distance (analogous to 'incidence').
     type: integer
     value: 0
+    values:
+      - name: degrees
+        value-type: float
+        range: [-45, 80]
+        default: 0
   CAMERA_POSITION:
     member-of: [CameraParam]
     tooltip: Sets camera position in region coordinates.
     type: integer
     value: 13
+    values:
+      - name: position
+        value-type: vector
   CAMERA_POSITION_LAG:
     member-of: [CameraParam]
     tooltip: Sets how much the camera lags as it moves toward its ideal position.
     type: integer
     value: 5
+    values:
+      - name: seconds
+        value-type: float
+        range: [0, 3]
+        default: 0.1
   CAMERA_POSITION_LOCKED:
     member-of: [CameraParam]
     tooltip: Option flag used with llSetCameraParams to lock the camera position so
       it does not move.
     type: integer
     value: 21
+    values:
+      - name: isLocked
+        value-type: boolean
+        default: false
   CAMERA_POSITION_THRESHOLD:
     member-of: [CameraParam]
     tooltip: Sets the radius of a sphere around the camera's ideal position within
       which it is not affected by target motion.
     type: integer
     value: 10
+    values:
+      - name: meters
+        value-type: float
+        range: [0, 3]
+        default: 1
   CHANGED_ALLOWED_DROP:
     member-of: [ChangeType]
     tooltip: Object inventory changed because a user other than the owner (or
@@ -1188,6 +1256,8 @@ constants:
       (though potentially more stuttery) movement. Default is TRUE.
     type: integer
     value: 14
+    value-type: boolean
+    default: true
   CHARACTER_AVOIDANCE_MODE:
     member-of: [CharacterParam]
     tooltip: Specifies which objects a pathfinding character avoids (other
@@ -1196,6 +1266,9 @@ constants:
       for both categories.
     type: integer
     value: 5
+    value-type: integer
+    enum: CharacterAvoidanceMode
+    default: AVOID_CHARACTERS | AVOID_DYNAMIC_OBSTACLES
   CHARACTER_CMD_JUMP:
     member-of: [CharacterCommand]
     tooltip: Makes the character jump. Requires a height parameter between 0.1m and
@@ -1219,6 +1292,9 @@ constants:
       character.
     type: integer
     value: 1
+    value-type: float
+    range: [0.2, 40]
+    default: 6
   CHARACTER_DESIRED_TURN_SPEED:
     member-of: [CharacterParam]
     tooltip: Specifies the character's maximum speed while turning about the Z-axis
@@ -1226,6 +1302,9 @@ constants:
       a character may turn at higher speeds under certain conditions.
     type: integer
     value: 12
+    value-type: float
+    range: [0.02, 40]
+    default: 6
   CHARACTER_LENGTH:
     member-of: [CharacterParam]
     tooltip: Sets the collision capsule length for a pathfinding character. If the
@@ -1233,16 +1312,24 @@ constants:
       twice the radius plus 0.1m.
     type: integer
     value: 3
+    value-type: float
+    range: [0, 10]
   CHARACTER_MAX_ACCEL:
     member-of: [CharacterParam]
     tooltip: Specifies the character's maximum acceleration rate (default is 20 m/s²).
     type: integer
     value: 8
+    value-type: float
+    range: [0.5, 40]
+    default: 20
   CHARACTER_MAX_DECEL:
     member-of: [CharacterParam]
     tooltip: Specifies the character's maximum deceleration rate (default is 30 m/s²).
     type: integer
     value: 9
+    value-type: float
+    range: [0.5, 60]
+    default: 30
   CHARACTER_MAX_SPEED:
     member-of: [CharacterParam]
     tooltip: Specifies the character's maximum speed (must be between 0.2 and 50
@@ -1251,12 +1338,18 @@ constants:
       TRAVERSAL_TYPE_FAST mode.
     type: integer
     value: 13
+    value-type: float
+    range: [1, 40]
+    default: 20
   CHARACTER_MAX_TURN_RADIUS:
     member-of: [CharacterParam]
     tooltip: Specifies the character's turn radius when traveling at
       CHARACTER_DESIRED_TURN_SPEED (default is 1.25 meters).
     type: integer
     value: 10
+    value-type: float
+    range: [0.1, 10]
+    default: 1.25
   CHARACTER_ORIENTATION:
     member-of: [CharacterParam]
     tooltip: Specifies the orientation of the collision capsule for a pathfinding
@@ -1264,12 +1357,17 @@ constants:
       and HORIZONTAL.
     type: integer
     value: 4
+    value-type: integer
+    enum: CharacterOrientation
+    default: VERTICAL
   CHARACTER_RADIUS:
     member-of: [CharacterParam]
     tooltip: Sets the collision capsule radius used to define the size of a
       pathfinding character.
     type: integer
     value: 2
+    value-type: float
+    range: [0.125, 5]
   CHARACTER_STAY_WITHIN_PARCEL:
     member-of: [CharacterParam]
     tooltip: Determines whether a character is restricted to its starting parcel
@@ -1279,6 +1377,7 @@ constants:
       pushed out, it can re-enter but cannot voluntarily leave again.
     type: integer
     value: 15
+    value-type: boolean
   CHARACTER_TYPE:
     member-of: [CharacterParam, GetClosestNavPointParam, GetStaticPathParam]
     tooltip: Specifies the preferred surface and terrain terrain-type for the
@@ -1287,6 +1386,9 @@ constants:
       along a road prefer type C).
     type: integer
     value: 6
+    value-type: integer
+    enum: CharacterType
+    default: CHARACTER_TYPE_NONE
   CHARACTER_TYPE_A:
     member-of: [CharacterType]
     tooltip: Used for pathfinding character types that prefer movement consistent
@@ -1683,6 +1785,17 @@ constants:
       secs_since_midnight (seconds elapsed since the last day cycle midnight)."
     type: integer
     value: 200
+    values:
+      - name: day_length
+        value-type: integer
+        details: Number of seconds in the environments day cycle.
+      - name: day_offset
+        value-type: integer
+        details: Number of seconds day cycle is offset from GMT.
+      - name: secs_since_midnight
+        value-type: float
+        details: Number of seconds elapsed since the last day cycle midnight.
+    access: read
   ENV_INVALID_AGENT:
     member-of: [EnvironmentError]
     tooltip: Unable to find the specified agent, or could not find an agent with the
@@ -1820,6 +1933,8 @@ constants:
     tooltip: Flags used to control which attachments are returned.
     type: integer
     value: 2
+    value-type: integer
+    enum: AttachedListFilterFlag
   FILTER_FLAG_HUDS:
     member-of: [AttachedListFilterFlag]
     tooltip: Filter flag used with llGetAttachedListFiltered to include HUDs with
@@ -1831,12 +1946,16 @@ constants:
     tooltip: Filter parameter used to include a specific attachment point.
     type: integer
     value: 1
+    value-type: integer
+    enum: AttachPoint
   FORCE_DIRECT_PATH:
     member-of: [CharacterNavigateParam]
     tooltip: Forces the pathfinding character to navigate in a straight line toward
       the specified position (can be set to TRUE or FALSE).
     type: integer
     value: 1
+    value-type: boolean
+    default: false
   FRICTION:
     member-of: [PhysicsMaterialParam]
     tooltip: Used with llSetPhysicsMaterial to enable the friction override. The
@@ -1984,18 +2103,23 @@ constants:
     tooltip: ''
     type: integer
     value: '2'
+    value-type: boolean
   GCNP_RADIUS:
     member-of: [GetClosestNavPointParam]
     tooltip: Used with llGetClosestNavPoint to limit how far out to search for a
       navigation point.
     type: integer
     value: 0
+    value-type: float
+    default: 20
   GCNP_STATIC:
     member-of: [GetClosestNavPointParam]
     tooltip: Used with llGetClosestNavPoint to specify that the test should use the
       static navmesh, ignoring all dynamic obstacles.
     type: integer
     value: 1
+    value-type: boolean
+    default: false
   GRAVITY_MULTIPLIER:
     member-of: [PhysicsMaterialParam]
     tooltip: Used with llSetPhysicsMaterial to enable the gravity multiplier
@@ -2016,6 +2140,7 @@ constants:
     type: integer
     value: 8
     value-type: string-multi
+    default: text/plain;charset=utf-8
   HTTP_BODY_MAXLENGTH:
     member-of: [HTTPRequestParam]
     pretty-name: max_body_length
@@ -2025,6 +2150,7 @@ constants:
     type: integer
     value: 2
     value-type: integer
+    default: 2048
   HTTP_BODY_TRUNCATED:
     member-of: [HTTPResponseError]
     tooltip: Indicates the response body truncation point in bytes.
@@ -2047,6 +2173,7 @@ constants:
     type: integer
     value: 9
     value-type: boolean
+    default: false
   HTTP_METHOD:
     member-of: [HTTPRequestParam]
     tooltip: Specifies the HTTP method ('GET', 'POST', 'PUT', or 'DELETE') for the
@@ -2054,6 +2181,7 @@ constants:
     type: integer
     value: 0
     value-type: string
+    default: GET
   HTTP_MIMETYPE:
     member-of: [HTTPRequestParam]
     tooltip: Specifies the request Content-Type MIME type. Text types should define
@@ -2062,6 +2190,7 @@ constants:
     type: integer
     value: 1
     value-type: string
+    default: text/plain;charset=utf-8
   HTTP_PRAGMA_NO_CACHE:
     member-of: [HTTPRequestParam]
     tooltip: "Controls whether the 'Pragma: no-cache' header is sent with the HTTP
@@ -2070,6 +2199,7 @@ constants:
     type: integer
     value: 6
     value-type: boolean
+    default: true
   HTTP_USER_AGENT:
     member-of: [HTTPRequestParam]
     tooltip: Appends a custom string to the default LSL User-Agent header value.
@@ -2086,6 +2216,7 @@ constants:
     type: integer
     value: 4
     value-type: boolean
+    default: true
   HTTP_VERIFY_CERT:
     member-of: [HTTPRequestParam]
     tooltip: If set to TRUE, the server's SSL certificate must be verifiable using a
@@ -2094,6 +2225,7 @@ constants:
     type: integer
     value: 3
     value-type: boolean
+    default: true
   IMG_USE_BAKED_AUX1:
     tooltip: ''
     type: string
@@ -2329,6 +2461,8 @@ constants:
       KFM_CMD_PLAY, or KFM_CMD_PAUSE to play, stop, or pause the motion.
     type: integer
     value: 0
+    value-type: integer
+    enum: KeyframedMotionCommand
   KFM_DATA:
     member-of: [KeyframedMotionParam]
     tooltip: Option flag in llSetKeyframedMotion followed by a bitwise combination
@@ -2336,6 +2470,9 @@ constants:
       both rotation and translation data must be provided.
     type: integer
     value: 2
+    value-type: integer
+    enum: KeyframedMotionData
+    default: KFM_ROTATION | KFM_TRANSLATION
   KFM_FORWARD:
     member-of: [KeyframedMotionMode]
     tooltip: Playback mode used with KFM_MODE in llSetKeyframedMotion (default). It
@@ -2356,6 +2493,9 @@ constants:
       KFM_FORWARD). Must be specified when the keyframe list is provided.
     type: integer
     value: 1
+    value-type: integer
+    enum: KeyframedMotionMode
+    default: KFM_FORWARD
   KFM_PING_PONG:
     member-of: [KeyframedMotionMode]
     tooltip: Playback mode used with KFM_MODE in llSetKeyframedMotion.
@@ -2649,6 +2789,8 @@ constants:
     tooltip: ''
     type: integer
     value: 2
+    value-type: float
+    range: [0.1, 10]
   NULL_KEY:
     tooltip: A special string constant used as a null or empty key value.
     type: string
@@ -2661,6 +2803,8 @@ constants:
       Plus, or -1 if the target is not an avatar.
     type: integer
     value: 41
+    value-type: integer
+    details: "Max.length: 1"
   OBJECT_ANIMATED_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails. For an object, returns a boolean
@@ -2668,6 +2812,8 @@ constants:
       the total number of 'Animated Mesh' attachments worn.
     type: integer
     value: 39
+    value-type: integer
+    details: "Max.length: 1"
   OBJECT_ANIMATED_SLOTS_AVAILABLE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the avatar's available
@@ -2675,6 +2821,8 @@ constants:
       avatar).
     type: integer
     value: 40
+    value-type: integer
+    details: "Max.length: 2"
   OBJECT_ATTACHED_POINT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails. Returns the integer attachment point
@@ -2682,6 +2830,9 @@ constants:
       (e.g., an avatar or unattached object).
     type: integer
     value: 19
+    value-type: integer
+    enum: AttachPoint
+    details: "Local: llGetAttached   Max.length: 11"
   OBJECT_ATTACHED_SLOTS_AVAILABLE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get an avatar's available
@@ -2689,6 +2840,8 @@ constants:
       are available.
     type: integer
     value: 35
+    value-type: integer
+    details: "Max.length: 2"
   OBJECT_BODY_SHAPE_TYPE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve a float representing the
@@ -2697,6 +2850,9 @@ constants:
       male). Returns -1.0 if not an avatar or if no data is available.
     type: integer
     value: 26
+    value-type: float
+    range: [0, 1]
+    details: "Max.length: 9"
   OBJECT_CHARACTER_TIME:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the average CPU time (in
@@ -2704,6 +2860,8 @@ constants:
       Returns 0 for non-characters.
     type: integer
     value: 17
+    value-type: float
+    details: "Alternatives: Pathfinding characters   Max.length: 15"
   OBJECT_CLICK_ACTION:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the click action of a prim.
@@ -2711,6 +2869,9 @@ constants:
       0).
     type: integer
     value: 28
+    value-type: integer
+    enum: ClickAction
+    details: "Max.length: 3"
   OBJECT_CREATION_TIME:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the object's creation time
@@ -2719,18 +2880,24 @@ constants:
       for avatars.
     type: integer
     value: 36
+    value-type: string
+    details: "Max.length: 27"
   OBJECT_CREATOR:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the key of the prim's creator.
       Returns NULL_KEY if the ID is an avatar.
     type: integer
     value: 8
+    value-type: key
+    details: "Local: llGetCreator   Alternatives: Creator   Max.length: 36"
   OBJECT_DAMAGE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the amount of damage a
       prim inflicts upon collision.
     type: integer
     value: 51
+    value-type: float
+    details: "Local: llGetPrimitiveParams and PRIM_DAMAGE"
   OBJECT_DAMAGE_TYPE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the type of damage a prim
@@ -2738,12 +2905,17 @@ constants:
       constant, a custom type, or a value repurposed by a combat system.
     type: integer
     value: 52
+    value-type: integer
+    enum: DamageType
+    details: "Local: llGetPrimitiveParams and PRIM_DAMAGE"
   OBJECT_DESC:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the prim's description.
       Returns an empty string if the ID is an avatar.
     type: integer
     value: 2
+    value-type: string
+    details: "Local: llGetObjectDesc   Max.length: 127"
   OBJECT_GROUP:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the prim's group key. Returns
@@ -2751,18 +2923,24 @@ constants:
       to get an avatar's active group).
     type: integer
     value: 7
+    value-type: key
+    details: "Alternatives: Group   Max.length: 36"
   OBJECT_GROUP_TAG:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get an avatar's active group
       tag/title. Returns an empty string if the target is not an avatar.
     type: integer
     value: 33
+    value-type: string
+    details: "Max.length: 20"
   OBJECT_HEALTH:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the current health value
       of an avatar or prim.
     type: integer
     value: 50
+    value-type: float
+    details: "Local: llGetPrimitiveParams and PRIM_HEALTH / llGetHealth"
   OBJECT_HOVER_HEIGHT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the dynamic hover height of an
@@ -2770,6 +2948,9 @@ constants:
       available; does not reflect the shape's 'Hover' slider.
     type: integer
     value: 25
+    value-type: float
+    range: [-2, 2]
+    details: "Max.length: 9"
   OBJECT_LAST_OWNER_ID:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the key of the previous owner.
@@ -2778,41 +2959,56 @@ constants:
       and re-rezzed.
     type: integer
     value: 27
+    value-type: key
+    details: "Max.length: 36"
   OBJECT_LINK_NUMBER:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the index of the prim within
       its linkset, or 0 if unlinked.
     type: integer
     value: 46
+    value-type: integer
+    details: "Local: llGetLinkNumber"
   OBJECT_LOCKED:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get a boolean, indicating if the object is locked.
     type: integer
     value: 55
+    value-type: boolean
   OBJECT_MASS:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the total mass (in
       kilograms) of the object's linkset.
     type: integer
     value: 43
+    value-type: float
+    details: "Local: llGetMassMKS"
   OBJECT_MATERIAL:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the physics material of
       the object, returning an integer matching a PRIM_MATERIAL_* constant.
     type: integer
     value: 42
+    value-type: integer
+    enum: PhysicsMaterialPreset
+    details: "Local: llGetPrimitiveParams and PRIM_MATERIAL"
   OBJECT_NAME:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the prim's name, or the legacy
       name if the target is an avatar.
     type: integer
     value: 1
+    value-type: string
+    details: "Local: llGetObjectName   Alternatives: llKey2Name /
+      llDetectedName   Max.length: 63"
   OBJECT_OMEGA:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the rotational (angular)
       velocity of an object in radians per second.
     type: integer
     value: 29
+    value-type: vector
+    details: "Local: llGetOmega   Max.length: 36"
   OBJECT_OWNER:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the owner's key. If the target
@@ -2820,24 +3016,64 @@ constants:
       NULL_KEY.
     type: integer
     value: 6
+    value-type: key
+    details: "Local: llGetOwner   Alternatives: llDetectedOwner /
+      llGetOwnerKey   Max.length: 36"
   OBJECT_PATHFINDING_TYPE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the pathfinding setting of an
       object in the region, returning an integer matching an OPT_* constant.
     type: integer
     value: 20
+    value-type: integer
+    enum: ObjectPathfindingType
+    details: "Alternatives: Pathfinding types   Max.length: 11"
   OBJECT_PERMS:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the permissions of the
       object as five integers.
     type: integer
     value: 53
+    values:
+      - name: base
+        value-type: integer
+        enum: AssetPermission
+      - name: owner
+        value-type: integer
+        enum: AssetPermission
+      - name: group
+        value-type: integer
+        enum: AssetPermission
+      - name: everyone
+        value-type: integer
+        enum: AssetPermission
+      - name: next_owner
+        value-type: integer
+        enum: AssetPermission
+    details: "Local: llGetObjectPermMask"
   OBJECT_PERMS_COMBINED:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the permissions of the
       object combined with all of its inventory items as five integers.
     type: integer
     value: 54
+    values:
+      - name: base
+        value-type: integer
+        enum: AssetPermission
+      - name: owner
+        value-type: integer
+        enum: AssetPermission
+      - name: group
+        value-type: integer
+        enum: AssetPermission
+      - name: everyone
+        value-type: integer
+        enum: AssetPermission
+      - name: next_owner
+        value-type: integer
+        enum: AssetPermission
+    details: "Local: llGetObjectPermMask"
   OBJECT_PHANTOM:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get a boolean indicating if
@@ -2845,6 +3081,8 @@ constants:
       attachment.
     type: integer
     value: 22
+    value-type: boolean
+    details: "Local: llGetStatus PRIM_PHANTOM   Max.length: 1"
   OBJECT_PHYSICS:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get a boolean indicating if
@@ -2852,11 +3090,15 @@ constants:
       attachment.
     type: integer
     value: 21
+    value-type: boolean
+    details: "Local: llGetStatus PRIM_PHYSICS   Max.length: 1"
   OBJECT_PHYSICS_COST:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the physics cost of the object.
     type: integer
     value: 16
+    value-type: float
+    details: "Alternatives: Physics cost   Max.length: 15"
   OBJECT_POS:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the prim's position in region
@@ -2864,18 +3106,25 @@ constants:
       relative to the script's region.
     type: integer
     value: 3
+    value-type: vector
+    details: "Local: llGetPos   Alternatives: llDetectedPos   Max.length: 37"
   OBJECT_PRIM_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the prim count of the object.
       Note that the script and target object must be owned by the same owner.
     type: integer
     value: 30
+    value-type: integer
+    details: "Local: llGetNumberOfPrims   Alternatives:
+      llGetObjectPrimCount   Max.length: 3"
   OBJECT_PRIM_EQUIVALENCE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the prim equivalence of the
       object.
     type: integer
     value: 13
+    value-type: integer
+    details: "Alternatives: Calculating land impact   Max.length: 11"
   OBJECT_RENDER_WEIGHT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the render weight (Avatar
@@ -2883,6 +3132,9 @@ constants:
       objects, -1 if unknown, and is capped at 500,000.
     type: integer
     value: 24
+    value-type: integer
+    range: [0, 500000]
+    details: "Alternatives: Avatar_Rendering_Cost   Max.length: 6"
   OBJECT_RETURN_PARCEL:
     member-of: [ReturnObjectsScope]
     tooltip: Scope flag used with llReturnObjectsByOwner to return all objects on
@@ -2910,12 +3162,15 @@ constants:
       avatar that rezzed the target object.
     type: integer
     value: 32
+    value-type: key
+    details: "Max.length: 36"
   OBJECT_REZ_TIME:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to retrieve the timestamp of when the
       object was rezzed.
     type: integer
     value: 45
+    value-type: string
   OBJECT_ROOT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the ID of the root prim. For
@@ -2923,22 +3178,30 @@ constants:
       the avatar's own ID if not sitting).
     type: integer
     value: 18
+    value-type: key
+    details: "Local: llGetLinkKey   Max.length: 36"
   OBJECT_ROT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the prim's rotation.
     type: integer
     value: 4
+    value-type: rotation
+    details: "Local: llGetRot   Alternatives: llDetectedRot   Max.length: 48"
   OBJECT_RUNNING_SCRIPT_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the total number of running
       scripts attached to the target object or agent.
     type: integer
     value: 9
+    value-type: integer
+    details: "Local: llGetScriptState   Max.length: 11"
   OBJECT_SCALE:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the size (scale) of the object.
     type: integer
     value: 47
+    value-type: vector
+    details: "Local: llGetScale"
   OBJECT_SCRIPT_MEMORY:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the allocated script memory
@@ -2946,6 +3209,8 @@ constants:
       recomputed every 10-20 seconds.
     type: integer
     value: 11
+    value-type: integer
+    details: "Max.length: 11"
   OBJECT_SCRIPT_TIME:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the average script CPU time
@@ -2953,6 +3218,8 @@ constants:
       since entering the region if present for less than 30 minutes.
     type: integer
     value: 12
+    value-type: float
+    details: "Alternatives: Top Scripts   Max.length: 15"
   OBJECT_SELECT_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the total number of
@@ -2960,53 +3227,71 @@ constants:
       target is an avatar.
     type: integer
     value: 37
+    value-type: integer
+    details: "Max.length: 3"
   OBJECT_SERVER_COST:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the server cost of the object.
     type: integer
     value: 14
+    value-type: float
+    details: "Alternatives: Server cost   Max.length: 15"
   OBJECT_SIT_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the total number of agents
       sitting on any links in the object. Returns 0 if the target is an avatar.
     type: integer
     value: 38
+    value-type: integer
+    details: "Max.length: 3"
   OBJECT_STREAMING_COST:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the streaming (download) cost
       of the object.
     type: integer
     value: 15
+    value-type: float
+    details: "Alternatives: Streaming (download) cost   Max.length: 15"
   OBJECT_TEMP_ATTACHED:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get a boolean indicating whether
       the object is temporarily attached.
     type: integer
     value: 34
+    value-type: boolean
+    details: "Max.length: 1"
   OBJECT_TEMP_ON_REZ:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get a boolean indicating if
       temporary-on-rez is enabled for the object.
     type: integer
     value: 23
+    value-type: boolean
+    details: "Local: PRIM_TEMP_ON_REZ   Max.length: 1"
   OBJECT_TEXT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the floating (hover) text
       displayed above the object.
     type: integer
     value: 44
+    value-type: string
+    details: "Local: llGetPrimitiveParams and PRIM_TEXT"
   OBJECT_TEXT_ALPHA:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the alpha value of the
       floating (hover) text displayed above the object.
     type: integer
     value: 49
+    value-type: float
+    details: "Local: llGetPrimitiveParams and PRIM_TEXT"
   OBJECT_TEXT_COLOR:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the color vector of the
       floating (hover) text displayed above the object.
     type: integer
     value: 48
+    value-type: vector
+    details: "Local: llGetPrimitiveParams and PRIM_TEXT"
   OBJECT_TOTAL_INVENTORY_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the total number of inventory
@@ -3014,12 +3299,16 @@ constants:
       the same owner.
     type: integer
     value: 31
+    value-type: integer
+    details: "Local: llGetInventoryNumber(INVENTORY_ALL)   Max.length: 10"
   OBJECT_TOTAL_SCRIPT_COUNT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get the total number of scripts
       (both running and stopped) attached to the target object or agent.
     type: integer
     value: 10
+    value-type: integer
+    details: "Local: llGetInventoryNumber   Max.length: 11"
   OBJECT_UNKNOWN_DETAIL:
     tooltip: Flag returned by llGetObjectDetails when an invalid flag is requested.
     type: integer
@@ -3030,11 +3319,14 @@ constants:
       target object.
     type: integer
     value: 5
+    value-type: vector
+    details: "Local: llGetVel   Alternatives: llDetectedVel   Max.length: 36"
   OBJECT_VOLUME_DETECT:
     member-of: [ObjectDetailsParam]
     tooltip: Flag used with llGetObjectDetails to get a boolean, indicating if the object is VolumeDetect.
     type: integer
     value: 56
+    value-type: boolean
   OPT_AVATAR:
     member-of: [ObjectPathfindingType]
     tooltip: Returned for avatars.
@@ -3083,18 +3375,22 @@ constants:
       PRIM_GLTF_ALPHA_MODE_BLEND.
     type: integer
     value: 2
+    value-type: float
   OVERRIDE_GLTF_BASE_ALPHA_MASK:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
       cutoff level on the face(s) when the alpha mode is set to mask.
     type: integer
     value: 4
+    value-type: float
   OVERRIDE_GLTF_BASE_ALPHA_MODE:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the alpha
       mode on the face(s) to one of the valid blend modes.
     type: integer
     value: 3
+    value-type: integer
+    enum: GLTFAlphaMode
   OVERRIDE_GLTF_BASE_COLOR_FACTOR:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the
@@ -3102,30 +3398,37 @@ constants:
       llsRGB2Linear to convert colors from Blinn-Phong to PBR.
     type: integer
     value: 1
+    value-type: vector
   OVERRIDE_GLTF_BASE_DOUBLE_SIDED:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides. If set to TRUE,
       the texture on the face(s) will be rendered as double-sided.
     type: integer
     value: 5
+    value-type: boolean
   OVERRIDE_GLTF_EMISSIVE_FACTOR:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides to set the tint
       (specified in linear RGB) used for the emissive texture on the face(s).
     type: integer
     value: 8
+    value-type: vector
   OVERRIDE_GLTF_METALLIC_FACTOR:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides to adjust the
       metallic factor on the specified face(s) to a value between 0 and 1.
     type: integer
     value: 6
+    value-type: float
+    range: [0, 1]
   OVERRIDE_GLTF_ROUGHNESS_FACTOR:
     member-of: [GLTFOverride]
     tooltip: GLTF override setting used with llSetLinkGLTFOverrides to adjust the
       roughness factor on the specified face(s) to a value between 0 and 1.
     type: integer
     value: 7
+    value-type: float
+    range: [0, 1]
   PARCEL_COUNT_GROUP:
     member-of: [ParcelPrimCountCategory]
     tooltip: Used with llGetParcelPrimCount to get the total land impact of objects
@@ -3169,54 +3472,64 @@ constants:
       square meters (sqm).
     type: integer
     value: 4
+    value-type: integer
   PARCEL_DETAILS_DESC:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the description of the
       parcel (up to 127 characters).
     type: integer
     value: 1
+    value-type: string
   PARCEL_DETAILS_FLAGS:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the parcel flags set on
       this parcel (see llGetParcelFlags for listings and meanings).
     type: integer
     value: 12
+    value-type: integer
+    enum: ParcelFlag
   PARCEL_DETAILS_GROUP:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the parcel group's
       36-character key.
     type: integer
     value: 3
+    value-type: key
   PARCEL_DETAILS_ID:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the parcel's 36-character
       UUID/key.
     type: integer
     value: 5
+    value-type: key
   PARCEL_DETAILS_LANDING_LOOKAT:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the lookat vector set for
       the landing point (teleport routing) on this parcel, if any.
     type: integer
     value: 10
+    value-type: vector
   PARCEL_DETAILS_LANDING_POINT:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the landing point vector
       set for this parcel, if any.
     type: integer
     value: 9
+    value-type: vector
   PARCEL_DETAILS_NAME:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the name of the parcel
       (up to 63 characters).
     type: integer
     value: 0
+    value-type: string
   PARCEL_DETAILS_OWNER:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the parcel owner's
       36-character key.
     type: integer
     value: 2
+    value-type: key
   PARCEL_DETAILS_PRIM_CAPACITY:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the total prim capacity
@@ -3224,6 +3537,7 @@ constants:
       same-parcel-only and/or sim-wide reporting).
     type: integer
     value: 7
+    value-type: integer
   PARCEL_DETAILS_PRIM_USED:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the total prim usage on
@@ -3231,6 +3545,7 @@ constants:
       prim counts by owner, group, or temporary status).
     type: integer
     value: 8
+    value-type: integer
   PARCEL_DETAILS_SCRIPT_DANGER:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to check if the script is in danger
@@ -3238,12 +3553,14 @@ constants:
       parcel; see llScriptDanger.
     type: integer
     value: 13
+    value-type: boolean
   PARCEL_DETAILS_SEE_AVATARS:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the 'See and chat with
       residents on this parcel' avatar visibility setting.
     type: integer
     value: 6
+    value-type: boolean
   PARCEL_DETAILS_TP_ROUTING:
     member-of: [ParcelDetailsParam]
     tooltip: Flag used with llGetParcelDetails to retrieve the teleport routing
@@ -3251,6 +3568,8 @@ constants:
       2 = TP_ROUTING_FREE; rules are only enforced if a landing point is set).
     type: integer
     value: 11
+    value-type: integer
+    enum: ParcelTeleportRouting
   PARCEL_FLAG_ALLOW_ALL_OBJECT_ENTRY:
     member-of: [ParcelFlag]
     tooltip: Flag used with llGetParcelFlags to check if the parcel allows all
@@ -3360,18 +3679,23 @@ constants:
       command to the designated agent only.
     type: integer
     value: 7
+    value-type: key
+    access: write
   PARCEL_MEDIA_COMMAND_AUTO_ALIGN:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to toggle or set the parcel
       media option 'Auto scale content'.
     type: integer
     value: 9
+    value-type: boolean
+    access: write
   PARCEL_MEDIA_COMMAND_DESC:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
     tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
       or set the parcel media description.
     type: integer
     value: 12
+    value-type: string
   PARCEL_MEDIA_COMMAND_LOOP:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to start the media stream
@@ -3379,6 +3703,7 @@ constants:
       it reaches the end.
     type: integer
     value: 3
+    access: write
   PARCEL_MEDIA_COMMAND_LOOP_SET:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
     tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
@@ -3386,78 +3711,96 @@ constants:
       have functionality limitations; see VWR-19712).
     type: integer
     value: 13
+    value-type: float
   PARCEL_MEDIA_COMMAND_PAUSE:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to pause the media stream on
       the current frame.
     type: integer
     value: 1
+    access: write
   PARCEL_MEDIA_COMMAND_PLAY:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to play the media stream
       from its current frame, stopping when the end is reached.
     type: integer
     value: 2
+    access: write
   PARCEL_MEDIA_COMMAND_SIZE:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
     tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
       or set the parcel media pixel resolution.
     type: integer
     value: 11
+    values:
+      - name: x
+        value-type: integer
+      - name: y
+        value-type: integer
   PARCEL_MEDIA_COMMAND_STOP:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to stop the media stream and
       rewind it to the first frame.
     type: integer
     value: 0
+    access: write
   PARCEL_MEDIA_COMMAND_TEXTURE:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
     tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
       or set the parcel's media texture.
     type: integer
     value: 4
+    value-type: asset
   PARCEL_MEDIA_COMMAND_TIME:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to jump to a specific
       timestamp in the media stream, specified in floating-point seconds.
     type: integer
     value: 6
+    value-type: float
+    access: write
   PARCEL_MEDIA_COMMAND_TYPE:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
     tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
       or set the parcel media MIME type (e.g., 'text/html').
     type: integer
     value: 10
+    value-type: string
   PARCEL_MEDIA_COMMAND_UNLOAD:
     member-of: [ParcelMediaCommand]
     tooltip: Command used with llParcelMediaCommandList to completely unload the
       media and restore the face's original texture.
     type: integer
     value: 8
+    access: write
   PARCEL_MEDIA_COMMAND_URL:
     member-of: [ParcelMediaCommand, ParcelMediaQuery]
     tooltip: Command used with llParcelMediaCommandList or llParcelMediaQuery to get
       or set the parcel's media URL.
     type: integer
     value: 5
+    value-type: string
   PARCEL_SALE_AGENT:
     member-of: [ParcelSaleParam]
     tooltip: Option used with llSetParcelForSale to specify the agent ID authorized
       to buy the parcel. If none is set, any agent can purchase it.
     type: integer
     value: 2
+    value-type: key
   PARCEL_SALE_OBJECTS:
     member-of: [ParcelSaleParam]
     tooltip: Option used with llSetParcelForSale. If set to TRUE, objects on the
       parcel are included in the sale.
     type: integer
     value: 3
+    value-type: boolean
   PARCEL_SALE_PRICE:
     member-of: [ParcelSaleParam]
     tooltip: Option used with llSetParcelForSale to set the parcel price. If no
       authorized agent is set, the price must be greater than 0.
     type: integer
     value: 1
+    value-type: integer
   PARCEL_SALE_OK:
     member-of: [ParcelSaleError]
     tooltip: Status code indicating the parcel sale information was successfully set.
@@ -3529,6 +3872,8 @@ constants:
       the character moves to the next waypoint at full speed with no pause.
     type: integer
     value: 0
+    value-type: boolean
+    default: false
   PAYMENT_INFO_ON_FILE:
     member-of: [AgentDataPaymentInfo]
     tooltip: Agent data flag returned by llRequestAgentData indicating if the user
@@ -3707,6 +4052,7 @@ constants:
       seated avatars cannot manually stand or select another prim to sit on.
     type: integer
     value: 39
+    value-type: boolean
   PRIM_ALPHA_MODE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter used to set diffuse texture alpha rendering mode
@@ -3714,6 +4060,17 @@ constants:
       _MASK, or _EMISSIVE), and alpha_cutoff (used only for _MASK) parameters.
     type: integer
     value: 38
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: alpha_mode
+        value-type: integer
+        enum: AlphaMode
+      - name: mask_cutoff
+        value-type: integer
+        range: [0, 255]
   PRIM_ALPHA_MODE_BLEND:
     member-of: [AlphaMode]
     tooltip: Prim parameter setting for PRIM_ALPHA_MODE. Directs the face to use
@@ -3806,6 +4163,17 @@ constants:
       settings of a face.
     type: integer
     value: 19
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: shiny
+        value-type: integer
+        enum: PrimShiny
+      - name: bump
+        value-type: integer
+        enum: PrimBump
   PRIM_BUMP_SIDING:
     member-of: [PrimBump]
     tooltip: "Face bump mapping setting: siding."
@@ -3849,18 +4217,26 @@ constants:
       primitive.
     type: integer
     value: 24
+    value-type: boolean
   PRIM_CLICK_ACTION:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter followed by a CLICK_ACTION_* constant to specify the
       default action taken when a user clicks or touches the prim.
     type: integer
     value: 43
+    value-type: integer
+    enum: ClickAction
   PRIM_COLLISION_SOUND:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to set the collision sound UUID and volume level for the
       prim.
     type: integer
     value: 53
+    values:
+      - name: sound
+        value-type: asset
+      - name: volume
+        value-type: float
   PRIM_COLOR:
     member-of: [PrimParam, PrimParamGet]
     tooltip: |
@@ -3871,18 +4247,38 @@ constants:
       float alpha – from 0.0 (clear) to 1.0 (solid) (0.0 <= alpha <= 1.0)
     type: integer
     value: 18
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: color
+        value-type: vector
+        details: "Color: llGetColor."
+      - name: alpha
+        value-type: float
+        range: [0, 1]
+        details: "Alpha: llGetAlpha."
   PRIM_DAMAGE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter used to get or set the damage amount and damage type
       delivered by the prim on collision.
     type: integer
     value: 51
+    values:
+      - name: damage
+        value-type: float
+      - name: damage_type
+        value-type: integer
+        enum: DamageType
   PRIM_DESC:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_DESC, string description] to get or set the prim's
       description (equivalent to llGetObjectDesc/llSetObjectDesc).
     type: integer
     value: 28
+    value-type: string
+    details: "Description: llGetObjectDesc."
   PRIM_FLEXIBLE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: |
@@ -3897,12 +4293,39 @@ constants:
       vector force
     type: integer
     value: 21
+    values:
+      - name: enabled
+        value-type: boolean
+      - name: softness
+        value-type: integer
+        range: [0, 3]
+      - name: gravity
+        value-type: float
+        range: [-10, 10]
+      - name: friction
+        value-type: float
+        range: [0, 10]
+      - name: wind
+        value-type: float
+        range: [0, 10]
+      - name: tension
+        value-type: float
+        range: [0, 10]
+      - name: force
+        value-type: vector
   PRIM_FULLBRIGHT:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_FULLBRIGHT, integer face, integer boolean] to get
       or set whether full-bright rendering is enabled on the specified face.
     type: integer
     value: 20
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: enabled
+        value-type: boolean
   PRIM_GLOW:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_GLOW, integer face, float intensity] to get or set
@@ -3910,6 +4333,14 @@ constants:
       named constant is rejected).
     type: integer
     value: 25
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: intensity
+        value-type: float
+        range: [0, 1]
   PRIM_GLTF_ALPHA_MODE_BLEND:
     member-of: [GLTFAlphaMode]
     tooltip: "GLTF alpha mode setting for PRIM_GLTF_BASE_COLOR. Renders the material
@@ -3939,6 +4370,34 @@ constants:
       (PRIM_GLTF_ALPHA_MODE_*), alpha_cutoff, and double_sided arguments.
     type: integer
     value: 48
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+      - name: repeats
+        value-type: vector
+        range: ["<-10000,-10000,0>", "<10000,10000,0>"]
+      - name: offsets
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: rotation_in_radians
+        value-type: float
+      - name: color
+        value-type: vector
+      - name: alpha
+        value-type: float
+        range: [0, 1]
+      - name: gltf_alpha_mode
+        value-type: integer
+        enum: GLTFAlphaMode
+      - name: alpha_mask_cutoff
+        value-type: float
+        range: [0, 1]
+      - name: double_sided
+        value-type: boolean
   PRIM_GLTF_EMISSIVE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to get or set the GLTF emission override of a face.
@@ -3946,6 +4405,23 @@ constants:
       (specified in linear space; use llsRGB2Linear).
     type: integer
     value: 46
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+      - name: repeats
+        value-type: vector
+        range: ["<-10000,-10000,0>", "<10000,10000,0>"]
+      - name: offsets
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: rotation_in_radians
+        value-type: float
+      - name: emissive_tint
+        value-type: vector
   PRIM_GLTF_METALLIC_ROUGHNESS:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to get or set the GLTF occlusion/metallic/roughness
@@ -3953,18 +4429,55 @@ constants:
       metallic_factor, and roughness_factor arguments.
     type: integer
     value: 47
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+      - name: repeats
+        value-type: vector
+        range: ["<-10000,-10000,0>", "<10000,10000,0>"]
+      - name: offsets
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: rotation_in_radians
+        value-type: float
+      - name: metallic_factor
+        value-type: float
+        range: [0, 1]
+      - name: roughness_factor
+        value-type: float
+        range: [0, 1]
   PRIM_GLTF_NORMAL:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to get or set the GLTF normal map override of a face.
       Requires face, texture, repeats, offsets, and rotation arguments.
     type: integer
     value: 45
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+      - name: repeats
+        value-type: vector
+        range: ["<-10000,-10000,0>", "<10000,10000,0>"]
+      - name: offsets
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: rotation_in_radians
+        value-type: float
   PRIM_HEALTH:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter used to get or set the health of the prim. Objects
       default to 0 health.
     type: integer
     value: 52
+    value-type: float
   PRIM_HOLE_CIRCLE:
     member-of: [PrimTypeHole]
     tooltip: Parameter used with certain PRIM_TYPE_* flags to make a circular hole
@@ -3996,6 +4509,9 @@ constants:
       parameters call.
     type: integer
     value: 34
+    value-type: integer
+    enum: Links
+    access: arg
   PRIM_MATERIAL:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_MATERIAL, integer PRIM_MATERIAL_*] to get or set
@@ -4004,6 +4520,8 @@ constants:
       without affecting mass.
     type: integer
     value: 2
+    value-type: integer
+    enum: PhysicsMaterialPreset
   PRIM_MATERIAL_DENSITY:
     member-of: [PhysicsMaterialParam]
     private: true
@@ -4122,6 +4640,7 @@ constants:
     type: integer
     value: 1
     value-type: integer
+    enum: PrimMediaControl
   PRIM_MEDIA_CONTROLS_MINI:
     member-of: [PrimMediaControl]
     tooltip: Mini web navigation controls constant; does not include an address bar.
@@ -4194,6 +4713,7 @@ constants:
     type: integer
     value: 14
     value-type: integer
+    enum: PrimMediaPerm
   PRIM_MEDIA_PERMS_INTERACT:
     member-of: [PrimMediaParam]
     tooltip: Integer. Gets or sets the permissions mask controlling who can interact
@@ -4201,6 +4721,7 @@ constants:
     type: integer
     value: 13
     value-type: integer
+    enum: PrimMediaPerm
   PRIM_MEDIA_PERM_ANYONE:
     member-of: [PrimMediaPerm]
     tooltip: ''
@@ -4250,6 +4771,8 @@ constants:
       (equivalent to llGetObjectName/llSetObjectName).
     type: integer
     value: 27
+    value-type: string
+    details: "Name: llGetObjectName."
   PRIM_NORMAL:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to get or set the Blinn-Phong normal map texture
@@ -4257,6 +4780,21 @@ constants:
       rotation_in_radians arguments.
     type: integer
     value: 37
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+      - name: repeats
+        value-type: vector
+        range: ["<-100,-100,0>", "<100,100,0>"]
+      - name: offsets
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: rotation_in_radians
+        value-type: float
   PRIM_OMEGA:
     member-of: [PrimParam, PrimParamGet]
     tooltip: |
@@ -4267,18 +4805,30 @@ constants:
       float gain – also modulates the final spinrate and disables the rotation behavior if zero
     type: integer
     value: 32
+    values:
+      - name: axis
+        value-type: vector
+        details: llTargetOmega
+      - name: spinrate
+        value-type: float
+      - name: gain
+        value-type: float
   PRIM_PHANTOM:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_PHANTOM, integer boolean] to get or set whether
       phantom status is enabled.
     type: integer
     value: 5
+    value-type: boolean
+    details: "Phantom status: llGetStatus."
   PRIM_PHYSICS:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_PHYSICS, integer boolean] to get or set whether
       the object responds to Second Life physics.
     type: integer
     value: 3
+    value-type: boolean
+    details: "Physics status: llGetStatus."
   PRIM_PHYSICS_SHAPE_CONVEX:
     member-of: [PhysicsShapeType]
     tooltip: Physics shape type setting. Uses the convex hull of the prim shape to
@@ -4306,6 +4856,8 @@ constants:
       used for physics optimization.
     type: integer
     value: 30
+    value-type: integer
+    enum: PhysicsShapeType
   PRIM_POINT_LIGHT:
     member-of: [PrimParam, PrimParamGet]
     tooltip: |
@@ -4319,6 +4871,20 @@ constants:
       float falloff – ranges from 0.01 to 2.0
     type: integer
     value: 23
+    values:
+      - name: enabled
+        value-type: boolean
+      - name: linear_color
+        value-type: vector
+      - name: intensity
+        value-type: float
+        range: [0, 1]
+      - name: radius
+        value-type: float
+        range: [0.1, 20]
+      - name: falloff
+        value-type: float
+        range: [0, 2]
   PRIM_POSITION:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_POSITION, vector position] to get or set the
@@ -4326,12 +4892,16 @@ constants:
       on the script context).
     type: integer
     value: 6
+    value-type: vector
+    details: "Global position: llGetPos."
   PRIM_POS_LOCAL:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_POS_LOCAL, vector position] to get or set the
       local position of a prim (equivalent to llGetLocalPos/llSetPos).
     type: integer
     value: 33
+    value-type: vector
+    details: "Local position: llGetLocalPos."
   PRIM_PROJECTOR:
     member-of: [PrimParam]
     # llGetPrimitiveParams cannot read PRIM_PROJECTOR:
@@ -4342,6 +4912,15 @@ constants:
       configured as a projector, the texture key will return NULL_KEY.
     type: integer
     value: 42
+    values:
+      - name: texture
+        value-type: string
+      - name: fov
+        value-type: float
+      - name: focus
+        value-type: float
+      - name: ambiance
+        value-type: float
   PRIM_REFLECTION_PROBE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to configure the object as a custom-placed reflection
@@ -4349,6 +4928,18 @@ constants:
       volume of influence.
     type: integer
     value: 44
+    values:
+      - name: enabled
+        value-type: boolean
+      - name: ambiance
+        value-type: float
+        range: [0, 100]
+      - name: clip_distance
+        value-type: float
+        range: [0, 1024]
+      - name: flags
+        value-type: integer
+        enum: ReflectionProbeType
   PRIM_REFLECTION_PROBE_BOX:
     member-of: [ReflectionProbeType]
     tooltip: Flag option used with PRIM_REFLECTION_PROBE. When set, the reflection
@@ -4378,6 +4969,14 @@ constants:
       rotation_in_radians."
     type: integer
     value: 49
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: render_material
+        value-type: asset
+        details: "Material: llGetRenderMaterial."
   PRIM_ROTATION:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_ROTATION, rotation global_rot] to get or set the
@@ -4385,12 +4984,16 @@ constants:
       setting this on child prims may be broken).
     type: integer
     value: 8
+    value-type: rotation
+    details: "Global rotation: llGetRot."
   PRIM_ROT_LOCAL:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_ROT_LOCAL, rotation local_rot] to get or set the
       local rotation of a prim (equivalent to llGetLocalRot/llSetLocalRot).
     type: integer
     value: 29
+    value-type: rotation
+    details: "Local rotation: llGetLocalRot."
   PRIM_SCRIPTED_SIT_ONLY:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter restricting manual sitting on this prim. When active,
@@ -4398,6 +5001,7 @@ constants:
       fail. This restriction applies even outside experience-enabled regions.
     type: integer
     value: 40
+    value-type: boolean
   PRIM_SCULPT_FLAG_ANIMESH:
     member-of: [PrimTypeSculptFlag]
     tooltip: Read-only flag for PRIM_TYPE_SCULPT to query whether the object is an
@@ -4480,6 +5084,8 @@ constants:
       the prim.
     type: integer
     value: 50
+    value-type: integer
+    enum: SitFlag
   PRIM_SIT_TARGET:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_SIT_TARGET, integer boolean, vector offset,
@@ -4488,18 +5094,31 @@ constants:
       0.0> can be explicitly set.
     type: integer
     value: 41
+    values:
+      - name: sit_target
+        value-type: boolean
+        details: "Sit target: llSitTarget."
+      - name: offset
+        value-type: vector
+      - name: rot
+        value-type: rotation
   PRIM_SIZE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_SIZE, vector size] to get or set the prim's
       physical dimensions (equivalent to llGetScale/llSetScale).
     type: integer
     value: 7
+    value-type: vector
+    details: "Size: llGetScale."
+    range: ["<0.01,0.01,0.01>", "<64,64,64>"]
   PRIM_SLICE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_SLICE, vector slice] to get or set the prim's
       slice values (a shape attribute equivalent to advanced cut).
     type: integer
     value: 35
+    value-type: vector
+    range: ["<0,0,0>", "<1,1,0>"]
   PRIM_SPECULAR:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter to get or set the Blinn-Phong specular map texture
@@ -4507,6 +5126,29 @@ constants:
       rotation_in_radians, color, glossy, and environment arguments.
     type: integer
     value: 36
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+      - name: repeats
+        value-type: vector
+        range: ["<-100,-100,0>", "<100,100,0>"]
+      - name: offsets
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: rotation_in_radians
+        value-type: float
+      - name: color
+        value-type: vector
+      - name: glossiness
+        value-type: integer
+        range: [0, 255]
+      - name: environment
+        value-type: integer
+        range: [0, 255]
   PRIM_TEMP_ON_REZ:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter used to get or set the object's temporary status.
@@ -4515,12 +5157,22 @@ constants:
       regional limits.
     type: integer
     value: 4
+    value-type: boolean
+    details: Temporary attribute.
   PRIM_TEXGEN:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_TEXGEN, integer face, integer mode] to get or set
       the texture mapping mode of the face.
     type: integer
     value: 22
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: mode
+        value-type: integer
+        enum: PrimTexgen
   PRIM_TEXGEN_DEFAULT:
     member-of: [PrimTexgen]
     tooltip: Texture mapping mode setting for PRIM_TEXGEN. Specifies that texture
@@ -4540,6 +5192,14 @@ constants:
       get or set the object's floating/hover text (equivalent to llSetText).
     type: integer
     value: 26
+    values:
+      - name: text
+        value-type: string
+      - name: color
+        value-type: vector
+      - name: alpha
+        value-type: float
+        range: [0, 1]
   PRIM_TEXTURE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter [PRIM_TEXTURE, integer face, string texture, vector
@@ -4547,60 +5207,259 @@ constants:
       Blinn-Phong diffuse texture settings of a face.
     type: integer
     value: 17
+    values:
+      - name: face
+        value-type: integer
+        enum: Faces
+        access: arg
+      - name: texture
+        value-type: asset
+        details: "Texture: llGetTexture."
+      - name: repeats
+        value-type: vector
+        range: ["<-100,-100,0>", "<100,100,0>"]
+        details: "Repeats: llGetTextureScale."
+      - name: offsets
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+        details: "Offset: llGetTextureOffset."
+      - name: rotation_in_radians
+        value-type: float
+        details: "Rotation: llGetTextureRot."
   PRIM_TYPE:
     member-of: [PrimParam, PrimParamGet]
     tooltip: Prim parameter used to get or set the geometric shape type
       (PRIM_TYPE_*) and its associated parameters.
     type: integer
     value: 9
+    value-type: integer
+    enum: PrimType
   PRIM_TYPE_BOX:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a box and
       configure its shape properties.
     type: integer
     value: 0
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: top_size
+        value-type: vector
+        range: ["<0,0,0>", "<2,2,0>"]
+      - name: top_shear
+        value-type: vector
+        range: ["<-0.5,-0.5,0>", "<0.5,0.5,0>"]
   PRIM_TYPE_CYLINDER:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a cylinder and
       configure its shape properties.
     type: integer
     value: 1
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: top_size
+        value-type: vector
+        range: ["<0,0,0>", "<2,2,0>"]
+      - name: top_shear
+        value-type: vector
+        range: ["<-0.5,-0.5,0>", "<0.5,0.5,0>"]
   PRIM_TYPE_PRISM:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a prism and
       configure its shape properties.
     type: integer
     value: 2
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: top_size
+        value-type: vector
+        range: ["<0,0,0>", "<2,2,0>"]
+      - name: top_shear
+        value-type: vector
+        range: ["<-0.5,-0.5,0>", "<0.5,0.5,0>"]
   PRIM_TYPE_RING:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a ring and
       configure its shape properties.
     type: integer
     value: 6
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: hole_size
+        value-type: vector
+        range: ["<0.05,0.05,0>", "<1,0.5,0>"]
+      - name: top_shear
+        value-type: vector
+        range: ["<-0.5,-0.5,0>", "<0.5,0.5,0>"]
+      - name: advanced_cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: taper
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: revolutions
+        value-type: float
+        range: [1, 4]
+      - name: radius_offset
+        value-type: float
+      - name: skew
+        value-type: float
+        range: [-1, 1]
   PRIM_TYPE_SCULPT:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a sculpted
       prim (sculpty) or mesh of a specific type.
     type: integer
     value: 7
+    values:
+      - name: map
+        value-type: asset
+      - name: type
+        value-type: integer
+        enum: PrimTypeSculpt
   PRIM_TYPE_SPHERE:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a sphere and
       configure its shape properties.
     type: integer
     value: 3
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: dimple
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
   PRIM_TYPE_TORUS:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a torus and
       configure its shape properties.
     type: integer
     value: 4
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: hole_size
+        value-type: vector
+        range: ["<0.05,0.05,0>", "<1,0.5,0>"]
+      - name: top_shear
+        value-type: vector
+        range: ["<-0.5,-0.5,0>", "<0.5,0.5,0>"]
+      - name: advanced_cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: taper
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: revolutions
+        value-type: float
+        range: [1, 4]
+      - name: radius_offset
+        value-type: float
+      - name: skew
+        value-type: float
+        range: [-1, 1]
   PRIM_TYPE_TUBE:
     member-of: [PrimType]
     tooltip: Shape parameter for PRIM_TYPE used to define the prim as a tube and
       configure its shape properties.
     type: integer
     value: 5
+    values:
+      - name: hole_shape
+        value-type: integer
+        enum: PrimTypeHole
+      - name: cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: hollow
+        value-type: float
+        range: [0, 0.95]
+      - name: twist
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: hole_size
+        value-type: vector
+        range: ["<0.05,0.05,0>", "<1,0.5,0>"]
+      - name: top_shear
+        value-type: vector
+        range: ["<-0.5,-0.5,0>", "<0.5,0.5,0>"]
+      - name: advanced_cut
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,0>"]
+      - name: taper
+        value-type: vector
+        range: ["<-1,-1,0>", "<1,1,0>"]
+      - name: revolutions
+        value-type: float
+        range: [1, 4]
+      - name: radius_offset
+        value-type: float
+      - name: skew
+        value-type: float
+        range: [-1, 1]
   PROFILE_NONE:
     member-of: [ScriptProfileMode]
     tooltip: Disables script profiling.
@@ -4658,12 +5517,16 @@ constants:
     type: integer
     value: 25
     value-type: integer
+    enum: ParticleBlendFunc
+    default: PSYS_PART_BF_ONE_MINUS_SOURCE_ALPHA
   PSYS_PART_BLEND_FUNC_SOURCE:
     member-of: [ParticleParam]
     tooltip: Integer parameter defining the source blending function.
     type: integer
     value: 24
     value-type: integer
+    enum: ParticleBlendFunc
+    default: PSYS_PART_BF_SOURCE_ALPHA
   PSYS_PART_BOUNCE_MASK:
     member-of: [ParticleFlag]
     tooltip: Particle flag causing particles to bounce off a plane at the emitter
@@ -4685,6 +5548,7 @@ constants:
     type: integer
     value: 4
     value-type: float
+    range: [0, 1]
   PSYS_PART_END_COLOR:
     member-of: [ParticleParam]
     pretty-name: color_end
@@ -4700,6 +5564,7 @@ constants:
     type: integer
     value: 27
     value-type: float
+    range: [0, 1]
   PSYS_PART_END_SCALE:
     member-of: [ParticleParam]
     pretty-name: scale_end
@@ -4708,6 +5573,7 @@ constants:
     type: integer
     value: 6
     value-type: vector
+    range: ["<0.03125,0.03125,0>", "<4,4,0>"]
   PSYS_PART_FLAGS:
     member-of: [ParticleParam]
     tooltip: Integer bitfield parameter specifying the simulation flags for emitted
@@ -4715,6 +5581,7 @@ constants:
     type: integer
     value: 0
     value-type: integer
+    enum: ParticleFlag
   PSYS_PART_FOLLOW_SRC_MASK:
     member-of: [ParticleFlag]
     tooltip: Particle flag causing particle positions to remain relative to the
@@ -4750,6 +5617,7 @@ constants:
     type: integer
     value: 7
     value-type: float
+    range: [0, 30]
   PSYS_PART_RIBBON_MASK:
     member-of: [ParticleFlag]
     tooltip: Particle flag that joins emitted particles into a continuous ribbon
@@ -4767,6 +5635,7 @@ constants:
     type: integer
     value: 2
     value-type: float
+    range: [0, 1]
   PSYS_PART_START_COLOR:
     member-of: [ParticleParam]
     pretty-name: color_begin
@@ -4782,6 +5651,7 @@ constants:
     type: integer
     value: 26
     value-type: float
+    range: [0, 1]
   PSYS_PART_START_SCALE:
     member-of: [ParticleParam]
     pretty-name: scale_begin
@@ -4790,6 +5660,7 @@ constants:
     type: integer
     value: 5
     value-type: vector
+    range: ["<0.03125,0.03125,0>", "<4,4,0>"]
   PSYS_PART_TARGET_LINEAR_MASK:
     member-of: [ParticleFlag]
     tooltip: Particle flag causing emitted particles to move in a straight,
@@ -4820,6 +5691,7 @@ constants:
     type: integer
     value: 8
     value-type: vector
+    range: ["<-100,-100,-100>", "<100,100,100>"]
   PSYS_SRC_ANGLE_BEGIN:
     member-of: [ParticleParam]
     tooltip: Float parameter specifying the angle in radians where particles will
@@ -4890,6 +5762,7 @@ constants:
     tooltip: ''
     type: integer
     value: '0x1'
+    value-type: integer
   PSYS_SRC_OMEGA:
     member-of: [ParticleParam]
     tooltip: Vector parameter setting the angular velocity used to rotate the
@@ -4913,6 +5786,7 @@ constants:
     type: integer
     value: 9
     value-type: integer
+    enum: ParticleSourcePattern
   PSYS_SRC_PATTERN_ANGLE:
     member-of: [ParticleSourcePattern]
     tooltip: Emission pattern that sprays particles outward in a flat circular,
@@ -4976,24 +5850,33 @@ constants:
       non-zero PURSUIT_OFFSET.
     type: integer
     value: 3
+    value-type: float
+    range: [0, 1]
+    default: 0
   PURSUIT_GOAL_TOLERANCE:
     member-of: [CharacterPursueParam]
     tooltip: Option for llPursue defining how close (between 0.25m and 10m) the
       character must be to consider the goal reached.
     type: integer
     value: 5
+    value-type: float
+    range: [0.25, 10]
   PURSUIT_INTERCEPT:
     member-of: [CharacterPursueParam]
     tooltip: Option for llPursue specifying whether the pathfinding character
       attempts to predict and intercept the target's future location.
     type: integer
     value: 4
+    value-type: boolean
+    default: false
   PURSUIT_OFFSET:
     member-of: [CharacterPursueParam]
     tooltip: Option for llPursue specifying a constant position offset relative to
       the target for the character to navigate toward.
     type: integer
     value: 1
+    value-type: vector
+    default: ZERO_VECTOR
   PU_EVADE_HIDDEN:
     member-of: [CharacterPathUpdateType]
     tooltip: Path update status code triggered when an llEvade character determines
@@ -5103,6 +5986,9 @@ constants:
     tooltip: Flag used with llCastRay to configure returned data.
     type: integer
     value: 2
+    value-type: integer
+    enum: RayCastData
+    default: 0
   RC_DETECT_PHANTOM:
     member-of: [RayCastParam]
     tooltip: Flag used with llCastRay. If set to TRUE (or non-zero), detects both
@@ -5111,6 +5997,8 @@ constants:
       in RC_REJECT_TYPES.
     type: integer
     value: 1
+    value-type: boolean
+    default: false
   RC_GET_LINK_NUM:
     member-of: [RayCastData]
     tooltip: Flag used with llCastRay causing the results stride to include the
@@ -5135,6 +6023,8 @@ constants:
       (up to 256). To avoid performance issues, keep this value small.
     type: integer
     value: 3
+    value-type: integer
+    default: 1
   RC_REJECT_AGENTS:
     member-of: [RayCastRejectType]
     tooltip: Flag used with llCastRay to prevent the detection of avatars.
@@ -5161,6 +6051,9 @@ constants:
       of objects and avatars.
     type: integer
     value: 0
+    value-type: integer
+    enum: RayCastRejectType
+    default: 0
   REGION_FLAG_ALLOW_DAMAGE:
     member-of: [RegionFlag]
     tooltip: Flag used with llGetRegionFlags to check if the region is entirely
@@ -5245,6 +6138,8 @@ constants:
       target positions blocked by solid obstacles.
     type: integer
     value: 2
+    value-type: boolean
+    default: false
   RESTITUTION:
     member-of: [PhysicsMaterialParam]
     tooltip: Used with llSetPhysicsMaterial to enable the restitution (bounciness)
@@ -5264,12 +6159,18 @@ constants:
       TRUE, the vector is in local coordinates.
     type: integer
     value: 5
+    values:
+      - name: force
+        value-type: vector
+      - name: local
+        value-type: boolean
   REZ_DAMAGE:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the float damage amount the rezzed object
       inflicts on an agent upon collision.
     type: integer
     value: 8
+    value-type: float
   REZ_DAMAGE_TYPE:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the integer damage type applied on collision
@@ -5277,12 +6178,16 @@ constants:
       field).
     type: integer
     value: 12
+    value-type: integer
+    enum: DamageType
   REZ_FLAGS:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the integer bitfield of flags to apply to the
       newly created object.
     type: integer
     value: 1
+    value-type: integer
+    enum: RezFlag
   REZ_FLAG_BLOCK_GRAB_OBJECT:
     member-of: [RezFlag]
     tooltip: Rez flag that disables grabbing on the newly rezzed object.
@@ -5333,6 +6238,7 @@ constants:
       non-zero value locks that axis.
     type: integer
     value: 11
+    value-type: vector
   REZ_OMEGA:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the initial angular velocity (omega) applied
@@ -5340,12 +6246,22 @@ constants:
       gain]. If relative is TRUE, the axis vector is in local coordinates.
     type: integer
     value: 7
+    values:
+      - name: axis
+        value-type: vector
+      - name: local
+        value-type: boolean
+      - name: spin
+        value-type: float
+      - name: gain
+        value-type: float
   REZ_PARAM:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the integer start parameter passed into the
       newly rezzed object's on_rez event.
     type: integer
     value: 0
+    value-type: integer
   REZ_PARAM_STRING:
     member-of: [RezParam]
     tooltip: Rez parameter specifying an initialization string (up to 1024 bytes)
@@ -5353,6 +6269,7 @@ constants:
       llGetStartString.
     type: integer
     value: 13
+    value-type: string
   REZ_POS:
     member-of: [RezParam]
     tooltip: Rez parameter [vector position, integer relative, integer at_root] to
@@ -5361,12 +6278,24 @@ constants:
       root prim.
     type: integer
     value: 2
+    values:
+      - name: pos
+        value-type: vector
+      - name: relative
+        value-type: boolean
+      - name: at_root
+        value-type: boolean
   REZ_ROT:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the initial rotation to apply to the newly
       rezzed object. Can be relative to the rezzing object or absolute.
     type: integer
     value: 3
+    values:
+      - name: rot
+        value-type: rotation
+      - name: relative
+        value-type: boolean
   REZ_SOUND:
     member-of: [RezParam]
     tooltip: Rez parameter [string name_or_uuid, float volume, integer loop] to
@@ -5374,6 +6303,13 @@ constants:
       TRUE, it loops continuously.
     type: integer
     value: 9
+    values:
+      - name: sound
+        value-type: asset
+      - name: volume
+        value-type: float
+      - name: loop
+        value-type: boolean
   REZ_SOUND_COLLIDE:
     member-of: [RezParam]
     tooltip: Rez parameter [string name_or_uuid, float volume] specifying a sound
@@ -5381,12 +6317,18 @@ constants:
       object, the ground, or an avatar.
     type: integer
     value: 10
+    values:
+      - name: sound
+        value-type: asset
+      - name: volume
+        value-type: float
   REZ_TORQUE:
     member-of: [RezParam]
     private: true
     tooltip: ''
     type: integer
     value: 6
+    value-type: vector
   REZ_VEL:
     member-of: [RezParam]
     tooltip: Rez parameter specifying the initial velocity to apply to the object.
@@ -5394,6 +6336,13 @@ constants:
       TRUE, it adds the rezzing object's velocity.
     type: integer
     value: 4
+    values:
+      - name: velocity
+        value-type: vector
+      - name: local
+        value-type: boolean
+      - name: inherit
+        value-type: boolean
   ROTATE:
     member-of: [TextureAnimMode]
     tooltip: Used with texture animation functions to animate the texture's
@@ -5643,12 +6592,18 @@ constants:
     tooltip: Environmental setting for the ambient color used in the scene.
     type: integer
     value: 0
+    value-type: vector
   SKY_BLUE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting containing the colors used to calculate blue
       density and blue horizon in the sky.
     type: integer
     value: 22
+    values:
+      - name: blue_density
+        value-type: vector
+      - name: blue_horizon
+        value-type: vector
   SKY_CLOUDS:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental cloud parameters including color, coverage percentage,
@@ -5656,12 +6611,46 @@ constants:
       default texture status.
     type: integer
     value: 2
+    values:
+      - name: color
+        value-type: vector
+        details: The color used for the clouds.
+      - name: coverage
+        value-type: float
+        range: [0, 1]
+        details: The coverage percentage.
+      - name: scale
+        value-type: float
+        range: [0, 3]
+        details: The scaling applied to the cloud textures.
+      - name: variance
+        value-type: float
+        range: [0, 1]
+        details: A randomizing factor applied to the main cloud layer.
+      - name: scroll
+        value-type: vector
+        range: ["<-50,-50,0>", "<50,50,0>"]
+        details: The scroll speed of the clouds (X is east/west, Y is north/south, Z is
+          unused).
+      - name: density
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,3>"]
+        details: The X/Y and D parameter used to generate cloud density.
+      - name: detail
+        value-type: vector
+        range: ["<0,0,0>", "<1,1,1>"]
+        details: The X/Y and D parameter used to generate cloud details.
+      - name: is_default
+        value-type: boolean
+        access: read
   SKY_CLOUD_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting containing the inventory name or UUID of the
       texture used for the clouds.
     type: integer
     value: 19
+    value-type: asset
+    access: write
   SKY_DENSITY_PROFILE_COUNTS:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
@@ -5674,23 +6663,51 @@ constants:
       and maximum altitude."
     type: integer
     value: 4
+    values:
+      - name: offset
+        value-type: float
+        range: [0, 1]
+      - name: radius
+        value-type: float
+        range: [1000, 2000]
+      - name: max_altitude
+        value-type: float
+        range: [0, 10000]
   SKY_GAMMA:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting for the gamma value applied to the scene
       (repurposed in viewer 7.0+ as the HDR Scale value in the EEP editor).
     type: integer
     value: 5
+    value-type: float
+    range: [0, 20]
   SKY_GLOW:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental setting for sun and moon glow parameters: size and focus."
     type: integer
     value: 6
+    values:
+      - name: glow_size
+        value-type: float
+        range: [0.2, 40]
+      - name: glow_focus
+        value-type: float
+        range: [-10, 10]
   SKY_HAZE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting containing the values used to calculate the light
       scattering impact of blue density and blue horizon on the scene.
     type: integer
     value: 23
+    values:
+      - name: density
+        value-type: float
+      - name: horizon
+        value-type: float
+      - name: density_multiplier
+        value-type: float
+      - name: distance_multiplier
+        value-type: float
   SKY_LIGHT:
     member-of: [EnvironmentParamReadOnly]
     tooltip: "Environmental setting containing lighting parameters: dominant light
@@ -5698,6 +6715,20 @@ constants:
       total ambient color (sRGB)."
     type: integer
     value: 8
+    values:
+      - name: light_direction
+        value-type: vector
+        details: "light_direction: A unit vector indicating the direction of the
+          dominant light source."
+      - name: fade_color
+        value-type: vector
+        details: "fade_color: A color vector representing the current color of the light
+          emitted from the dominant light source (in sRGB space)."
+      - name: total_ambient
+        value-type: vector
+        details: "total_ambient: A color vector representing the current ambient color
+          in use in the scene (in sRGB space)."
+    access: read
   SKY_MIE_CONFIG:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
@@ -5710,18 +6741,57 @@ constants:
       is_default_texture, direction vector, ambient color, and diffuse color."
     type: integer
     value: 9
+    values:
+      - name: rot
+        value-type: rotation
+        details: The current rotation applied to the moon.
+      - name: scale
+        value-type: float
+        range: [0.25, 20]
+        details: The current scale applied to the moon's texture.
+      - name: brightness
+        value-type: float
+        range: [0, 1]
+        details: The moon's brightness.
+      - name: is_default_texture
+        value-type: boolean
+        access: read
+      - name: direction
+        value-type: vector
+        details: A unit vector pointing at the moon.
+        access: read
+      - name: ambient_color
+        value-type: vector
+        details: The ambient color of the moon.
+        access: read
+      - name: diffuse_color
+        value-type: vector
+        details: The diffuse color applied to the moon.
+        access: read
   SKY_MOON_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting containing the inventory name or UUID of the
       texture used for the moon.
     type: integer
     value: 20
+    value-type: asset
+    access: write
   SKY_PLANET:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental planet rendering parameters: planet_radius,
       sky_bottom_radius, and sky_top_radius."
     type: integer
     value: 10
+    values:
+      - name: planet_radius
+        value-type: float
+        range: [1000, 32768]
+      - name: sky_bottom_radius
+        value-type: float
+        range: [1000, 32768]
+      - name: sky_top_radius
+        value-type: float
+        range: [1000, 32768]
   SKY_RAYLEIGH_CONFIG:
     private: true
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
@@ -5735,41 +6805,98 @@ constants:
       compatible viewers and testing areas."
     type: integer
     value: 24
+    value-type: float
+    range: [0, 10]
   SKY_REFRACTION:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental sky refraction parameters for rainbows and optical
       effects: moisture_level, droplet_radius, and ice_level."
     type: integer
     value: 11
+    values:
+      - name: moisture_level
+        value-type: float
+        range: [0, 1]
+      - name: droplet_radius
+        value-type: float
+        range: [5, 1000]
+      - name: ice_level
+        value-type: float
+        range: [0, 1]
   SKY_STAR_BRIGHTNESS:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting for the brightness value applied to stars.
     type: integer
     value: 13
+    value-type: float
+    range: [0, 500]
   SKY_SUN:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental sun parameters: rotation, scale, color,
       is_default_texture, direction vector, ambient color, and diffuse color."
     type: integer
     value: 14
+    values:
+      - name: rot
+        value-type: rotation
+        details: The current rotation applied to the sun.
+      - name: scale
+        value-type: float
+        range: [0.25, 20]
+        details: The current scale applied to the sun's texture.
+      - name: sun_color
+        value-type: vector
+      - name: is_default_texture
+        value-type: boolean
+        access: read
+      - name: direction
+        value-type: vector
+        details: A unit vector pointing at the sun.
+        access: read
+      - name: ambient_color
+        value-type: vector
+        details: The ambient color of the sun.
+        access: read
+      - name: diffuse_color
+        value-type: vector
+        details: The diffuse color applied to the sun.
+        access: read
   SKY_SUN_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting containing the inventory name or UUID of the
       texture used for the sun.
     type: integer
     value: 21
+    value-type: asset
+    access: write
   SKY_TEXTURE_DEFAULTS:
     member-of: [EnvironmentParamReadOnly]
     tooltip: Environmental check returning 1 if the sky textures are set to their
       default values, or 0 if they use custom textures.
     type: integer
     value: 1
+    values:
+      - name: bloom_is_default
+        value-type: boolean
+      - name: halo_is_default
+        value-type: boolean
+      - name: rainbow_is_default
+        value-type: boolean
+    access: read
   SKY_TRACKS:
     member-of: [EnvironmentParamReadOnly]
     tooltip: Environmental setting containing the track altitudes used for sky
       transitions in the region.
     type: integer
     value: 15
+    values:
+      - name: sky2
+        value-type: float
+      - name: sky3
+        value-type: float
+      - name: sky4
+        value-type: float
+    access: read
   SMOOTH:
     member-of: [TextureAnimMode]
     tooltip: Used with texture animation functions to cause the animation to slide
@@ -5968,6 +7095,7 @@ constants:
       terrain detail layer 1.
     type: integer
     value: 0
+    value-type: asset
   TERRAIN_DETAIL_2:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the texture or
@@ -5975,6 +7103,7 @@ constants:
       terrain detail layer 2.
     type: integer
     value: 1
+    value-type: asset
   TERRAIN_DETAIL_3:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the texture or
@@ -5982,6 +7111,7 @@ constants:
       terrain detail layer 3.
     type: integer
     value: 2
+    value-type: asset
   TERRAIN_DETAIL_4:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the texture or
@@ -5989,6 +7119,7 @@ constants:
       terrain detail layer 4.
     type: integer
     value: 3
+    value-type: asset
   TERRAIN_HEIGHT_RANGE_NE:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the north-east
@@ -5997,6 +7128,11 @@ constants:
       and 3 mix in between.
     type: integer
     value: 7
+    values:
+      - name: low
+        value-type: float
+      - name: high
+        value-type: float
   TERRAIN_HEIGHT_RANGE_NW:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the north-west
@@ -6005,6 +7141,11 @@ constants:
       and 3 mix in between.
     type: integer
     value: 6
+    values:
+      - name: low
+        value-type: float
+      - name: high
+        value-type: float
   TERRAIN_HEIGHT_RANGE_SE:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the south-east
@@ -6013,6 +7154,11 @@ constants:
       and 3 mix in between.
     type: integer
     value: 5
+    values:
+      - name: low
+        value-type: float
+      - name: high
+        value-type: float
   TERRAIN_HEIGHT_RANGE_SW:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the south-west
@@ -6021,6 +7167,11 @@ constants:
       and 3 mix in between.
     type: integer
     value: 4
+    values:
+      - name: low
+        value-type: float
+      - name: high
+        value-type: float
   TERRAIN_PBR_OFFSET_1:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV offset
@@ -6028,6 +7179,7 @@ constants:
       for PBR textures.
     type: integer
     value: 16
+    value-type: vector
   TERRAIN_PBR_OFFSET_2:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV offset
@@ -6035,6 +7187,7 @@ constants:
       for PBR textures.
     type: integer
     value: 17
+    value-type: vector
   TERRAIN_PBR_OFFSET_3:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV offset
@@ -6042,6 +7195,7 @@ constants:
       for PBR textures.
     type: integer
     value: 18
+    value-type: vector
   TERRAIN_PBR_OFFSET_4:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV offset
@@ -6049,30 +7203,35 @@ constants:
       for PBR textures.
     type: integer
     value: 19
+    value-type: vector
   TERRAIN_PBR_ROTATION_1:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the rotation of
       the PBR texture for layer 1, in radians. Only works for PBR textures.
     type: integer
     value: 12
+    value-type: float
   TERRAIN_PBR_ROTATION_2:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the rotation of
       the PBR texture for layer 2, in radians. Only works for PBR textures.
     type: integer
     value: 13
+    value-type: float
   TERRAIN_PBR_ROTATION_3:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the rotation of
       the PBR texture for layer 3, in radians. Only works for PBR textures.
     type: integer
     value: 14
+    value-type: float
   TERRAIN_PBR_ROTATION_4:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the rotation of
       the PBR texture for layer 4, in radians. Only works for PBR textures.
     type: integer
     value: 15
+    value-type: float
   TERRAIN_PBR_SCALE_1:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV scale
@@ -6080,6 +7239,7 @@ constants:
       Only works for PBR textures.
     type: integer
     value: 8
+    value-type: vector
   TERRAIN_PBR_SCALE_2:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV scale
@@ -6087,6 +7247,7 @@ constants:
       Only works for PBR textures.
     type: integer
     value: 9
+    value-type: vector
   TERRAIN_PBR_SCALE_3:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV scale
@@ -6094,6 +7255,7 @@ constants:
       Only works for PBR textures.
     type: integer
     value: 10
+    value-type: vector
   TERRAIN_PBR_SCALE_4:
     member-of: [GroundTextureParam]
     tooltip: Terrain parameter used with llSetGroundTexture to set the UV scale
@@ -6101,6 +7263,7 @@ constants:
       Only works for PBR textures.
     type: integer
     value: 11
+    value-type: vector
   TEXTURE_BLANK:
     tooltip: Asset UUID representing the default 'Blank' texture.
     type: string
@@ -6178,12 +7341,14 @@ constants:
       inventory into.
     type: integer
     value: 0
+    value-type: string
   TRANSFER_FLAGS:
     member-of: [GiveAgentInventoryParam]
     tooltip: Inventory parameter specifying flags to control the behavior of
       inventory transfers.
     type: integer
     value: 1
+    value-type: integer
   TRANSFER_FLAG_COPY:
     member-of: [TransferOwnershipFlag]
     tooltip: Inventory transfer flag that copies the transferred object and places
@@ -6243,6 +7408,9 @@ constants:
       type. Expects TRAVERSAL_TYPE_SLOW (default), _FAST, or _NONE.
     type: integer
     value: 7
+    value-type: integer
+    enum: CharacterTraversalType
+    default: TRAVERSAL_TYPE_SLOW
   TRAVERSAL_TYPE_FAST:
     member-of: [CharacterTraversalType]
     tooltip: ''
@@ -6333,6 +7501,8 @@ constants:
       preferred axis toward its true velocity.
     type: integer
     value: 32
+    value-type: float
+    range: [0, 1]
   VEHICLE_ANGULAR_DEFLECTION_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale for the
@@ -6340,6 +7510,7 @@ constants:
       of motion to match its true velocity.
     type: integer
     value: 33
+    value-type: float
   VEHICLE_ANGULAR_FRICTION_TIMESCALE:
     member-of: [VehicleVectorParam]
     tooltip: Vehicle vector parameter specifying the timescales (range [0.07,
@@ -6347,6 +7518,8 @@ constants:
       about the vehicle's preferred axes (at, left, up).
     type: integer
     value: 17
+    value-type: vector
+    range: ["<0.07,0.07,0.07>", "<inf,inf,inf>"]
   VEHICLE_ANGULAR_MOTOR_DECAY_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale (in
@@ -6354,6 +7527,8 @@ constants:
       toward zero.
     type: integer
     value: 35
+    value-type: float
+    range: [0, 120]
   VEHICLE_ANGULAR_MOTOR_DIRECTION:
     member-of: [VehicleVectorParam]
     tooltip: Vehicle vector parameter specifying the direction and magnitude of the
@@ -6361,12 +7536,15 @@ constants:
       attempts to achieve.
     type: integer
     value: 19
+    value-type: vector
+    range: ["<0,0,0>", "<12.56637,12.56637,12.56637>"]
   VEHICLE_ANGULAR_MOTOR_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale for the
       vehicle's angular motor to achieve full power and velocity.
     type: integer
     value: 34
+    value-type: float
   VEHICLE_BANKING_EFFICIENCY:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter (range -1.0 to 1.0) controlling banking
@@ -6375,6 +7553,8 @@ constants:
       motors to bank. 0.0 means no banking.
     type: integer
     value: 38
+    value-type: float
+    range: [-1, 1]
   VEHICLE_BANKING_MIX:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter (range 0.0 (static) to 1.0) (dynamic) controlling the mix between
@@ -6382,6 +7562,8 @@ constants:
       (additionally scales with linear speed).
     type: integer
     value: 39
+    value-type: float
+    range: [0, 1]
   VEHICLE_BANKING_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale for the
@@ -6391,12 +7573,15 @@ constants:
       behavior is trying to do, and what the vehicle is actually doing.
     type: integer
     value: 40
+    value-type: float
   VEHICLE_BUOYANCY:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter (range -1.0 to 1.0) defining buoyancy, where
       -1.0 represents double gravity and 1.0 represents full anti-gravity.
     type: integer
     value: 27
+    value-type: float
+    range: [-1, 1]
   VEHICLE_FLAG_BLOCK_INTERFERENCE:
     member-of: [VehicleFlag]
     tooltip: Vehicle flag that prevents attachments worn by passengers from pushing
@@ -6480,18 +7665,22 @@ constants:
       where 0.0 is bouncy and 1.0 is critically damped.
     type: integer
     value: 25
+    value-type: float
+    range: [0, 1]
   VEHICLE_HOVER_HEIGHT:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the height at which the vehicle
       attempts to hover. Set to 0.0 to disable hover.
     type: integer
     value: 24
+    value-type: float
   VEHICLE_HOVER_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the timescale (period of time in
       seconds) for the vehicle to achieve its hover height.
     type: integer
     value: 26
+    value-type: float
   VEHICLE_LINEAR_DEFLECTION_EFFICIENCY:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter (range 0.0 to 1.0) modulating the efficiency
@@ -6499,6 +7688,8 @@ constants:
       the strength of linear deflection.
     type: integer
     value: 28
+    value-type: float
+    range: [0, 1]
   VEHICLE_LINEAR_DEFLECTION_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale for the
@@ -6507,6 +7698,7 @@ constants:
       velocity to be redirected to its preferred axis of motion.
     type: integer
     value: 29
+    value-type: float
   VEHICLE_LINEAR_FRICTION_TIMESCALE:
     member-of: [VehicleVectorParam]
     tooltip: Vehicle vector parameter specifying the timescales (range [0.07,
@@ -6514,6 +7706,8 @@ constants:
       along the vehicle's preferred axes (at, left, up).
     type: integer
     value: 16
+    value-type: vector
+    range: ["<0.07,0.07,0.07>", "<inf,inf,inf>"]
   VEHICLE_LINEAR_MOTOR_DECAY_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale (in
@@ -6521,6 +7715,8 @@ constants:
       toward zero.
     type: integer
     value: 31
+    value-type: float
+    range: [0, 120]
   VEHICLE_LINEAR_MOTOR_DIRECTION:
     member-of: [VehicleVectorParam]
     tooltip: Vehicle vector parameter specifying the direction and magnitude of the
@@ -6528,18 +7724,22 @@ constants:
       attempts to achieve.
     type: integer
     value: 18
+    value-type: vector
+    range: ["<0,0,0>", "<30,30,30>"]
   VEHICLE_LINEAR_MOTOR_OFFSET:
     member-of: [VehicleVectorParam]
     tooltip: Vehicle vector parameter specifying the offset from the vehicle's
       center of mass where the linear motor force is applied.
     type: integer
     value: 20
+    value-type: vector
   VEHICLE_LINEAR_MOTOR_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale for the
       vehicle to reach its full linear motor velocity.
     type: integer
     value: 30
+    value-type: float
   VEHICLE_REFERENCE_FRAME:
     member-of: [VehicleRotationParam]
     tooltip: Vehicle rotation parameter setting the orientation of the vehicle's
@@ -6547,6 +7747,7 @@ constants:
       frame (x, y, z).
     type: integer
     value: 44
+    value-type: rotation
   VEHICLE_TYPE_AIRPLANE:
     member-of: [VehicleType]
     tooltip: Vehicle type constant for aircraft that use linear deflection for lift,
@@ -6590,6 +7791,8 @@ constants:
       to keep the vehicle upright.
     type: integer
     value: 36
+    value-type: float
+    range: [0, 1]
   VEHICLE_VERTICAL_ATTRACTION_TIMESCALE:
     member-of: [VehicleFloatParam]
     tooltip: Vehicle float parameter specifying the exponential timescale (in
@@ -6597,6 +7800,7 @@ constants:
       the world Z-axis (vertical).
     type: integer
     value: 37
+    value-type: float
   VERTICAL:
     member-of: [CharacterOrientation]
     tooltip: Constant indicating that the collision capsule orientation for a
@@ -6609,54 +7813,102 @@ constants:
       should pause briefly after reaching each wander waypoint.
     type: integer
     value: 0
+    value-type: boolean
+    default: false
   WATER_BLUR_MULTIPLIER:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting specifying the multiplier applied to blur the
       scene when underwater.
     type: integer
     value: 100
+    value-type: float
+    range: [-0.5, 0.5]
   WATER_FOG:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental underwater fog parameters: color, density exponent, and
       modulation."
     type: integer
     value: 101
+    values:
+      - name: color
+        value-type: vector
+        details: The color of the underwater fog.
+      - name: density
+        value-type: float
+        range: [-10, 10]
+        details: Density exponent applied to the fog.
+      - name: modulation
+        value-type: float
+        range: [0, 20]
   WATER_FRESNEL:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental water surface Fresnel scattering parameters: offset and
       scale."
     type: integer
     value: 102
+    values:
+      - name: offset
+        value-type: float
+        range: [0, 1]
+      - name: scale
+        value-type: float
+        range: [0, 1]
   WATER_NORMAL_SCALE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting specifying the scaling vector applied to the
       water normal map.
     type: integer
     value: 104
+    value-type: vector
+    range: ["<0,0,0>", "<10,10,10>"]
   WATER_NORMAL_TEXTURE:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental setting containing the inventory name or UUID of the
       normal map texture used for water waves.
     type: integer
     value: 107
+    value-type: asset
+    access: write
   WATER_REFRACTION:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: "Environmental water surface refraction scale factors: scale_above and
       scale_below."
     type: integer
     value: 105
+    values:
+      - name: scale_above
+        value-type: float
+        range: [0, 3]
+      - name: scale_below
+        value-type: float
+        range: [0, 3]
   WATER_TEXTURE_DEFAULTS:
     member-of: [EnvironmentParamReadOnly]
     tooltip: Environmental check returning 1 if default water wave maps are used, or
       0 if a custom texture is set.
     type: integer
     value: 103
+    values:
+      - name: normal_is_default
+        value-type: boolean
+      - name: transparent_is_default
+        value-type: boolean
+    access: read
   WATER_WAVE_DIRECTION:
     member-of: [EnvironmentParamReadOnly, EnvironmentParam]
     tooltip: Environmental wave direction vectors (X is east/west, Y is north/south)
       specifying speeds and directions for both large and small waves.
     type: integer
     value: 106
+    values:
+      - name: large_wave
+        value-type: vector
+        range: ["<-20,-20,0>", "<20,20,0>"]
+        details: Large wave speed and direction.
+      - name: small_wave
+        value-type: vector
+        range: ["<-20,-20,0>", "<20,20,0>"]
+        details: Small wave speed and direction.
   XP_ERROR_EXPERIENCES_DISABLED:
     member-of: [ExperienceError]
     tooltip: Region currently has experiences disabled.


### PR DESCRIPTION
This PR replaces draft #167.

After commenting in #160, I'm adding these fields to the constants that have associated values:
- in constants with one associated value:
  - value-type: same as #143.
  - range: array [ start, end ].
  - default: default value.
  - enum: category of constants, or group of categories.
  - details: anything else in the Wiki table.
  - access:
    - "arg": the value is always an argument.
    - "read": it's only used when reading.
    - "write": it's only used when writing.
    - "read/write": default, not used in the file.
  - values: an array when there is more than one associated value (or only one, but with an informative name):
    - name
    - value-type
    - range
    - default
    - enum
    - details
    - access

JSON file with the added fields: https://suzanna-linn.github.io/slua/wiki-constants-values.html

LSL definitions browser with the updated YAML file: https://suzanna-linn.github.io/slua/reference-lsl-definitions