### PR TITLE
Adding info to functions

### DIFF
--- a/lsl_definitions.schema.json
+++ b/lsl_definitions.schema.json
@@ -173,6 +173,18 @@
                             "slua-type": {
                                 "markdownDescription": "A more specific argument type for slua type-checking.",
                                 "type": "string"
+                            },
+                            "range": {
+                                "markdownDescription": "The minimum and maximum valid values for the argument as [min, max].",
+                                "type": "array",
+                                "minItems": 2,
+                                "maxItems": 2,
+                                "items": {
+                                    "anyOf": [
+                                        { "type": "number" },
+                                        { "type": "string" }
+                                    ]
+                                }
                             }
                         },
                         "required": [
@@ -344,6 +356,23 @@
                 "if": { "required": ["dispatch-fn"] },
                 "then": { "required": ["lua-module", "lua-fn"] }
             }
+        },
+        "usesEnum": {
+            "markdownDescription": "The name of the category of constants or the list of constants used by the event or function.",
+            "oneOf": [
+                {
+                    "type": "string",
+                    "pattern": "^[A-Z][A-Za-z0-9]+$"
+                },
+                {
+                    "type": "array",
+                    "items": {
+                        "type": "string",
+                        "pattern": "^[A-Z][A-Z0-9_]*$"
+                    },
+                    "uniqueItems": true
+                }
+            ]
         }
     },
     "additionalProperties": false,
@@ -507,7 +536,8 @@
                             "markdownDescription": "A brief description of this event.",
                             "type": "string"
                         },
-                        "categories": { "$ref": "#/$defs/functionCategories" }
+                        "categories": { "$ref": "#/$defs/functionCategories" },
+                        "uses-enum": { "$ref": "#/$defs/usesEnum" }
                     },
                     "required": [
                         "tooltip",
@@ -667,7 +697,12 @@
                             "markdownDescription": "A brief description of this function.",
                             "type": "string"
                         },
-                        "categories": { "$ref": "#/$defs/functionCategories" }
+                        "categories": { "$ref": "#/$defs/functionCategories" },
+                        "uses-enum": { "$ref": "#/$defs/usesEnum" },
+                        "other-values": {
+                            "markdownDescription": "Overwrites the other-values field in the category of constants.",
+                            "type": "boolean"
+                        }
                     },
                     "required": [
                         "tooltip",

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -6991,6 +6991,7 @@ events:
     categories:
       - avatar
       - input
+    uses-enum: GameControlAxis
   http_request:
     arguments:
     - request_id:

--- a/lsl_definitions.yaml
+++ b/lsl_definitions.yaml
@@ -7397,6 +7397,7 @@ functions:
     - val:
         tooltip: A floating-point value falling in the range [-1.0, 1.0].
         type: float
+        range: [-1, 1]
     slua-deprecated:
       use: math.acos
       reason: Double precision; fastcall.
@@ -7439,6 +7440,7 @@ functions:
         tooltip: Duration, in hours, to allow the avatar for (range [0.0, 144.0], 0
           for indefinite).
         type: float
+        range: [0, 144]
     energy: 10.0
     func-id: 240
     return: void
@@ -7581,6 +7583,7 @@ functions:
     - val:
         tooltip: A floating-point value falling in the range [-1.0, 1.0].
         type: float
+        range: [-1, 1]
     slua-deprecated:
       use: math.asin
       reason: Double precision; fastcall.
@@ -7834,6 +7837,7 @@ functions:
     categories:
       - physics
       - sensor
+    uses-enum: RayCastError
   llCeil:
     arguments:
     - val:
@@ -8316,6 +8320,7 @@ functions:
     categories:
       - combat
       - detected
+    uses-enum: DamageType
   llDetectedGrab:
     arguments:
     - number:
@@ -8600,6 +8605,7 @@ functions:
       number. Returns 0 if number is not a valid index.
     categories:
       - detected
+    other-values: true
   llDetectedVel:
     arguments:
     - number:
@@ -9128,6 +9134,7 @@ functions:
       object is attached to, or 0 if it is unattached or pending detachment.
     categories:
       - attachments
+    other-values: true
   llGetAttachedList:
     arguments:
     - avatar:
@@ -9827,7 +9834,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       use: typeof
-      selene-replace: ["typeof(%1[%2])" ]
+      selene-replace: ["typeof(%1[%2])"]
     energy: 10.0
     func-id: 194
     native: true
@@ -10383,6 +10390,7 @@ functions:
     categories:
       - physics
       - prim
+    uses-enum: PhysicsMaterialPreset
   llGetPos:
     arguments: []
     energy: 10.0
@@ -10758,6 +10766,7 @@ functions:
     - radius:
         tooltip: Radius of the character path, between 0.125m and 5.0m.
         type: float
+        range: [0.125, 5]
     - params:
         tooltip: A list specifying the CHARACTER_TYPE parameter (defaults to
           CHARACTER_TYPE_NONE).
@@ -10774,6 +10783,7 @@ functions:
       regardless of dynamic pathfinding status.
     categories:
       - pathfinding
+    uses-enum: CharacterPathUpdateType
   llGetStatus:
     arguments:
     - status:
@@ -11499,6 +11509,18 @@ functions:
     categories:
       - data_conversion
       - json
+    uses-enum:
+      [
+        JSON_INVALID,
+        JSON_OBJECT,
+        JSON_ARRAY,
+        JSON_NUMBER,
+        JSON_STRING,
+        JSON_NULL,
+        JSON_TRUE,
+        JSON_FALSE,
+        JSON_DELETE
+      ]
   llKey2Name:
     arguments:
     - id:
@@ -11618,6 +11640,7 @@ functions:
     - volume:
         tooltip: Volume level to set, between 0.0 (silent) and 1.0 (loud).
         type: float
+        range: [0, 1]
     - flags:
         tooltip: Bitwise flags (combination of SOUND_*) controlling the sound playback.
         type: integer
@@ -11676,6 +11699,7 @@ functions:
     - offset:
         tooltip: Offset position vector in local prim coordinates.
         type: vector
+        range: ["<-300,-300,-300>", "<300,300,300>"]
     - rot:
         tooltip: Rotation relative to the prim's rotation.
         type: rotation
@@ -11965,7 +11989,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       reason: Use '[]' and 'tonumber' instead.
-      selene-replace: ["tonumber(%1[%2]) or 0" ]
+      selene-replace: ["tonumber(%1[%2]) or 0"]
     energy: 10.0
     func-id: 187
     native: true
@@ -11988,7 +12012,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       reason: Use '[]', 'tonumber', and 'math.modf' instead.
-      selene-replace: ["math.modf(tonumber(%1[%2]) or 0)" ]
+      selene-replace: ["math.modf(tonumber(%1[%2]) or 0)"]
     energy: 10.0
     func-id: 186
     native: true
@@ -12023,6 +12047,7 @@ functions:
       - data_conversion
       - json
       - list
+    uses-enum: [JSON_INVALID, JSON_OBJECT, JSON_ARRAY]
   llList2Key:
     arguments:
     - src:
@@ -12034,7 +12059,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       reason: Use '[]' and 'touuid' instead.
-      selene-replace: ["touuid(%1[%2]) or NULL_KEY" ]
+      selene-replace: ["touuid(%1[%2]) or NULL_KEY"]
     energy: 10.0
     func-id: 189
     native: true
@@ -12155,7 +12180,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       use: '[]'
-      selene-replace: ["%1[%2]" ]
+      selene-replace: ["%1[%2]"]
     energy: 10.0
     func-id: 191
     native: true
@@ -12179,7 +12204,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       reason: Use '[]' and 'tostring' instead.
-      selene-replace: ["tostring(%1[%2])" ]
+      selene-replace: ["tostring(%1[%2])"]
     energy: 10.0
     func-id: 188
     native: true
@@ -12202,7 +12227,7 @@ functions:
         index-semantics: true
     slua-deprecated:
       use: '[]'
-      selene-replace: ["%1[%2]" ]
+      selene-replace: ["%1[%2]"]
     energy: 10.0
     func-id: 190
     native: true
@@ -12225,7 +12250,7 @@ functions:
     slua-deprecated:
       use: table.find
       reason: Prefer dictionaries or single-item searches.
-      selene-replace: ["table.find(%1, %2[1])" ]
+      selene-replace: ["table.find(%1, %2[1])"]
     energy: 10.0
     func-id: 201
     must-use: true
@@ -12251,7 +12276,7 @@ functions:
     slua-deprecated:
       use: table.find
       reason: Prefer dictionaries or single-item searches.
-      selene-replace: ["table.find(%1, %2[1])" ]
+      selene-replace: ["table.find(%1, %2[1])"]
     energy: 10.0
     func-id: 803
     must-use: true
@@ -12369,7 +12394,7 @@ functions:
     slua-deprecated:
       use: 't[n] = x'
       reason: Unnecessary table copying.
-      selene-replace: ["%1[%3] = %2[1]" ]
+      selene-replace: ["%1[%3] = %2[1]"]
     energy: 10.0
     func-id: 296
     native: true
@@ -13023,9 +13048,11 @@ functions:
     - u:
         tooltip: Horizontal (U) offset, typically in the interval [-1.0, 1.0].
         type: float
+        range: [-1, 1]
     - v:
         tooltip: Vertical (V) offset, typically in the interval [-1.0, 1.0].
         type: float
+        range: [-1, 1]
     - face:
         tooltip: Face number or ALL_SIDES.
         type: integer
@@ -13284,6 +13311,7 @@ functions:
     - volume:
         tooltip: Volume level to set, between 0.0 (silent) and 1.0 (loud).
         type: float
+        range: [0, 1]
     energy: 10.0
     func-id: 86
     return: void
@@ -14421,10 +14449,12 @@ functions:
         tooltip: Horizontal (U) texture repeats scale value, in the interval
           [-100.0, 100.0].
         type: float
+        range: [-100, 100]
     - v:
         tooltip: Vertical (V) texture repeats scale value, in the interval [-100.0,
           100.0].
         type: float
+        range: [-100, 100]
     - face:
         tooltip: Face number or ALL_SIDES.
         type: integer
@@ -14514,10 +14544,12 @@ functions:
     - radius:
         tooltip: Maximum distance in meters to scan (range [0.0, 96.0]).
         type: float
+        range: [0, 96]
     - arc:
         tooltip: Maximum angle in radians relative to the local X-axis to scan
           (range [0.0, PI]).
         type: float
+        range: [0, 3.141592]
     energy: 10.0
     func-id: 28
     return: void
@@ -14528,6 +14560,7 @@ functions:
       id) disables that filter.
     categories:
       - sensor
+    uses-enum: [PI_BY_TWO, PI]
   llSensorRemove:
     arguments: []
     energy: 10.0
@@ -14555,10 +14588,12 @@ functions:
     - radius:
         tooltip: Maximum distance in meters to scan (range [0.0, 96.0]).
         type: float
+        range: [0, 96]
     - arc:
         tooltip: Maximum angle in radians relative to the local X-axis to scan
           (range [0.0, PI]).
         type: float
+        range: [0, 3.141592]
     - rate:
         tooltip: Interval in seconds between repeated scans.
         type: float
@@ -14571,6 +14606,7 @@ functions:
       trigger sensor or no_sensor events.
     categories:
       - sensor
+    uses-enum: [PI_BY_TWO, PI]
   llSetAgentEnvironment:
     arguments:
     - agent_id:
@@ -14798,6 +14834,7 @@ functions:
         tooltip: Float damage value to set (range -100.0 for full heal to 100.0 for
           instant kill).
         type: float
+        range: [-100, 100]
     energy: 10.0
     func-id: 157
     return: void
@@ -15210,9 +15247,11 @@ functions:
     - sizex:
         tooltip: Number of horizontal frames (ignored for ROTATE and SCALE).
         type: integer
+        range: [0, 255]
     - sizey:
         tooltip: Number of vertical frames (ignored for ROTATE and SCALE).
         type: integer
+        range: [0, 255]
     - start:
         tooltip: Start frame number (or radians for ROTATE).
         type: float
@@ -15385,15 +15424,19 @@ functions:
         tooltip: Gravity multiplier float value (range [-1.0, +28.0], default is
           1.0).
         type: float
+        range: [-1, 28]
     - restitution:
         tooltip: Elasticity restitution float value (range [0.0, 1.0]).
         type: float
+        range: [0, 1]
     - friction:
         tooltip: Friction coefficient float value (range [0.0, 255.0]).
         type: float
+        range: [0, 255]
     - density:
         tooltip: Density float value in kg/m³ (range [1.0, 22587.0]).
         type: float
+        range: [1, 22587]
     energy: 10.0
     func-id: 380
     return: void
@@ -15405,6 +15448,7 @@ functions:
       - physics
       - prim
       - prim_properties
+    uses-enum: PhysicsMaterialPreset
   llSetPos:
     arguments:
     - pos:
@@ -15488,6 +15532,7 @@ functions:
         tooltip: Target position vector in region coordinates (can cross up to 10m
           over a region border).
         type: vector
+        range: ["<-10,-10,0>", "<266,266,4096>"]
     energy: 10.0
     func-id: 397
     return: integer
@@ -15553,6 +15598,7 @@ functions:
     - size:
         tooltip: Target size vector.
         type: vector
+        range: ["<0.01,0.01,0.01>", "<64,64,64>"]
     energy: 10.0
     func-id: 47
     return: void
@@ -15695,9 +15741,11 @@ functions:
     - sizex:
         tooltip: Number of horizontal frames (ignored for ROTATE and SCALE).
         type: integer
+        range: [0, 255]
     - sizey:
         tooltip: Number of vertical frames (ignored for ROTATE and SCALE).
         type: integer
+        range: [0, 255]
     - start:
         tooltip: Start frame number (or radians for ROTATE).
         type: float
@@ -15953,6 +16001,7 @@ functions:
     - offset:
         tooltip: Target position vector in local prim coordinates.
         type: vector
+        range: ["<-300,-300,-300>", "<300,300,300>"]
     - rot:
         tooltip: Target rotation relative to the prim's rotation.
         type: rotation


### PR DESCRIPTION
After commenting in #160, I'm adding these fields to the functions:

- uses-enum: string, a table related to the function but not directly to its parameters or return value, it can be a category of constants or an array of constants.
- other-values: boolean, overwrite "other-values" in the category of constants.

in the arguments:
  - range: array [ start, end ].