### PR TITLE
Export `JsonOptions` types

### DIFF
--- a/generated/lua_keywords_pretty.xml
+++ b/generated/lua_keywords_pretty.xml
@@ -223,6 +223,23 @@ export type DateTypeResult = {
             <key>tooltip</key>
             <string>HTTP request parameter table. Pass to ll.HTTPRequest() to configure an HTTP request.</string>
          </map>
+         <key>LLJsonDecodeOptions</key>
+         <map>
+            <key>tooltip</key>
+            <string>Configuration options for lljson decoding
+export type LLJsonDecodeOptions = LLJsonDecodeOptionsWithoutPath | LLJsonDecodeOptionsWithPath</string>
+         </map>
+         <key>LLJsonEncodeOptions</key>
+         <map>
+            <key>tooltip</key>
+            <string>Configuration options for lljson encoding
+export type LLJsonEncodeOptions = {
+  tight: boolean?,
+  skip_tojson: boolean?,
+  allow_sparse: boolean?,
+  replacer: ((key: any, value: any, parent: {}?) -&gt; any)?,
+}</string>
+         </map>
          <key>MediaParams</key>
          <map>
             <key>tooltip</key>

--- a/generated/secondlife.d.luau
+++ b/generated/secondlife.d.luau
@@ -69,7 +69,7 @@ export type DateTypeResult = {
   yday: number?,
   isdst: boolean?,
 }
-type LLJsonEncodeOptions = {
+export type LLJsonEncodeOptions = {
   tight: boolean?,
   skip_tojson: boolean?,
   allow_sparse: boolean?,
@@ -84,7 +84,7 @@ type LLJsonDecodeOptionsWithPath = {
   track_path: true,
   reviver: (key: string | number, value: any, parent: {}?, ctx: {path: {string | number}}) -> any
 }
-type LLJsonDecodeOptions = LLJsonDecodeOptionsWithoutPath | LLJsonDecodeOptionsWithPath
+export type LLJsonDecodeOptions = LLJsonDecodeOptionsWithoutPath | LLJsonDecodeOptionsWithPath
 export type ParticleParams = {
   flags: number?,
   color_begin: vector?,

--- a/generated/syntax/slua.tmLanguage
+++ b/generated/syntax/slua.tmLanguage
@@ -1282,7 +1282,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>\b(nil|any|boolean|buffer|integer|never|number|string|thread|unknown|quaternion|uuid|vector|DetectedEvent|rotation|list|DateTypeArg|DateTypeResult|ParticleParams|MediaParams|HttpRequestParams)\b</string>
+            <string>\b(nil|any|boolean|buffer|integer|never|number|string|thread|unknown|quaternion|uuid|vector|DetectedEvent|rotation|list|DateTypeArg|DateTypeResult|LLJsonEncodeOptions|LLJsonDecodeOptions|ParticleParams|MediaParams|HttpRequestParams)\b</string>
             <key>name</key>
             <string>support.type.primitive.luau</string>
           </dict>

--- a/generated/syntax/slua.tmLanguage.json
+++ b/generated/syntax/slua.tmLanguage.json
@@ -831,7 +831,7 @@
           "name": "constant.language.boolean.true.luau"
         },
         {
-          "match": "\\b(nil|any|boolean|buffer|integer|never|number|string|thread|unknown|quaternion|uuid|vector|DetectedEvent|rotation|list|DateTypeArg|DateTypeResult|ParticleParams|MediaParams|HttpRequestParams)\\b",
+          "match": "\\b(nil|any|boolean|buffer|integer|never|number|string|thread|unknown|quaternion|uuid|vector|DetectedEvent|rotation|list|DateTypeArg|DateTypeResult|LLJsonEncodeOptions|LLJsonDecodeOptions|ParticleParams|MediaParams|HttpRequestParams)\\b",
           "name": "support.type.primitive.luau"
         },
         {

--- a/slua_definitions.yaml
+++ b/slua_definitions.yaml
@@ -218,6 +218,7 @@ type-aliases:
   selene-type: {display: "DateTypeResult"}
 - name: LLJsonEncodeOptions
   comment: Configuration options for lljson encoding
+  export: true
   definition: |-
     {
       tight: boolean?,
@@ -245,6 +246,7 @@ type-aliases:
   selene-type: table
 - name: LLJsonDecodeOptions
   comment: Configuration options for lljson decoding
+  export: true
   definition: "LLJsonDecodeOptionsWithoutPath | LLJsonDecodeOptionsWithPath"
   selene-type: any
 - name: ParticleParams


### PR DESCRIPTION
The typechecker likes it better when I explicitly type these, but I can't as they aren't exported